### PR TITLE
Fast PR

### DIFF
--- a/code/datums/outfits/civilian.dm
+++ b/code/datums/outfits/civilian.dm
@@ -1,0 +1,133 @@
+/decl/hierarchy/outfit/job/assistant
+	name = OUTFIT_JOB_NAME("Assistant")
+	l_ear = /obj/item/device/radio/headset
+
+/decl/hierarchy/outfit/job/service
+	l_ear = /obj/item/device/radio/headset/headset_service
+	hierarchy_type = /decl/hierarchy/outfit/job/service
+
+/decl/hierarchy/outfit/job/service/bartender
+	name = OUTFIT_JOB_NAME("Bar Servitor")
+	uniform = /obj/item/clothing/under/rank/bartender
+	id_type = /obj/item/card/id/civilian/bartender
+	pda_type = null
+	pda_slot = null
+	head = /obj/item/clothing/head/servitorhead
+	l_ear = /obj/item/device/radio/headset/red_team
+	r_ear = null
+	suit = /obj/item/clothing/suit/servitor
+	back = /obj/item/storage/backpack/satchel/servitor
+
+/decl/hierarchy/outfit/job/service/chef
+	name = OUTFIT_JOB_NAME("Chef")
+	uniform = /obj/item/clothing/under/color/brown
+	suit = /obj/item/clothing/suit/guardchef
+	head = /obj/item/clothing/head/chefhat
+	id_type = /obj/item/card/id/civilian/chef
+	pda_type = null
+	pda_slot = null
+	back = /obj/item/storage/backpack/satchel/warfare
+	shoes = /obj/item/clothing/shoes/jackboots
+	neck = /obj/item/reagent_containers/food/drinks/canteen
+	l_ear = /obj/item/device/radio/headset/red_team
+	r_ear = null
+	backpack_contents = list(
+	/obj/item/reagent_containers/food/snacks/warfare/rat = 1,
+	/obj/item/stack/thrones = 1,
+	/obj/item/stack/thrones2 = 1,
+	/obj/item/stack/thrones3/five = 1,
+		)
+
+/decl/hierarchy/outfit/job/service/gardener
+	name = OUTFIT_JOB_NAME("Farmer")
+	uniform = /obj/item/clothing/under/rank/hydroponics
+	suit = /obj/item/clothing/suit/farmer
+	gloves = /obj/item/clothing/gloves/thick/botany
+	r_pocket = /obj/item/device/analyzer/plant_analyzer
+	id_type = /obj/item/card/id/civilian/botanist
+	pda_type = null
+	pda_slot = null
+	l_ear = /obj/item/device/radio/headset/red_team
+	r_ear = null
+	back = /obj/item/storage/backpack/satchel/warfare
+	shoes = /obj/item/clothing/shoes/jackboots
+	neck = /obj/item/reagent_containers/food/drinks/canteen
+	l_hand = /obj/item/farmshovel
+	belt = /obj/item/storage/plants
+	backpack_contents = list(/obj/item/seeds/potatoseed = 1,
+	/obj/item/seeds/wheatseed = 1,
+	/obj/item/seeds/cornseed = 1,
+	/obj/item/seeds/random = 1,
+	/obj/item/seeds/tobaccoseed = 2,
+	/obj/item/reagent_containers/food/snacks/warfare/rat = 1,
+	/obj/item/stack/thrones = 1,
+	/obj/item/stack/thrones2 = 1,
+	/obj/item/stack/thrones3/five = 1,
+
+	)
+
+/decl/hierarchy/outfit/job/service/gardener/New()
+	..()
+	backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/storage/backpack/hydroponics
+	backpack_overrides[/decl/backpack_outfit/satchel]       = /obj/item/storage/backpack/satchel/satchel_hyd
+	backpack_overrides[/decl/backpack_outfit/messenger_bag] = /obj/item/storage/backpack/messenger/hyd
+
+/decl/hierarchy/outfit/job/service/janitor
+	name = OUTFIT_JOB_NAME("Janitor Servitor")
+	uniform = /obj/item/clothing/under/rank/janitor
+	id_type = /obj/item/card/id/civilian/janitor
+	pda_type = null
+	pda_slot = null
+	head = /obj/item/clothing/head/servitorhead/janitor
+	l_ear = /obj/item/device/radio/headset/red_team
+	r_ear = null
+	suit = /obj/item/clothing/suit/servitor/janitor
+	back = /obj/item/storage/backpack/satchel/servitor
+
+/decl/hierarchy/outfit/job/librarian
+	name = OUTFIT_JOB_NAME("Record Keeper")
+	uniform = /obj/item/clothing/under/suit_jacket/red
+	id_type = /obj/item/card/id/civilian/librarian
+	pda_type = null
+	pda_slot = null
+
+/decl/hierarchy/outfit/job/chaplain
+	name = OUTFIT_JOB_NAME("Ministorum Confessor")
+	uniform = /obj/item/clothing/under/rank/chaplain
+	neck = /obj/item/reagent_containers/food/drinks/canteen
+	id_type = /obj/item/card/id/civilian/chaplain
+	pda_type = null
+	pda_slot = null
+	l_ear = /obj/item/device/radio/headset/red_team
+	r_ear = null
+	l_pocket = /obj/item/storage/box/ifak
+	belt = /obj/item/device/flashlight/lantern
+	back = /obj/item/storage/backpack/satchel/warfare
+	shoes = /obj/item/clothing/shoes/jackboots
+	suit = /obj/item/clothing/suit/ministorumrobes
+	l_hand = /obj/item/staff/ministorumstaff
+	r_hand = /obj/item/melee/whip/censer
+	backpack_contents = list(
+	/obj/item/reagent_containers/food/snacks/warfare/rat = 1,
+	/obj/item/stack/thrones = 1,
+	/obj/item/stack/thrones2/five = 1,
+	/obj/item/stack/thrones3/ten = 1
+		)
+
+/decl/hierarchy/outfit/job/service/undertaker
+	name = OUTFIT_JOB_NAME("Undertaker")
+	uniform = /obj/item/clothing/under/child_jumpsuit
+	id_type = /obj/item/card/id/civilian/bartender
+	neck = /obj/item/reagent_containers/food/drinks/canteen
+	l_ear = /obj/item/device/radio/headset/red_team
+	r_ear = null
+	suit = /obj/item/clothing/suit/child_coat/red
+	back = /obj/item/storage/backpack/satchel/warfare
+	l_hand = /obj/item/shovel
+	shoes = /obj/item/clothing/shoes/child_shoes
+	pda_type = null
+	pda_slot = null
+	backpack_contents = list(
+	/obj/item/reagent_containers/food/snacks/warfare/rat = 1,
+	/obj/item/stack/thrones = 1,
+	/obj/item/stack/thrones2 = 1,)

--- a/code/datums/outfits/medical.dm
+++ b/code/datums/outfits/medical.dm
@@ -1,0 +1,116 @@
+/decl/hierarchy/outfit/job/medical
+	hierarchy_type = /decl/hierarchy/outfit/job/medical
+	shoes = /obj/item/clothing/shoes/white
+	pda_type = /obj/item/device/pda/medical
+	//pda_slot = slot_l_store
+
+/decl/hierarchy/outfit/job/medical/New()
+	..()
+	BACKPACK_OVERRIDE_MEDICAL
+
+/decl/hierarchy/outfit/job/medical/cmo
+	name = OUTFIT_JOB_NAME("Sister Superior")
+	l_ear  = /obj/item/device/radio/headset/red_team/medicae
+	uniform = /obj/item/clothing/under/rank/medical
+	neck = /obj/item/reagent_containers/food/drinks/canteen
+	suit = /obj/item/clothing/suit/storage/sistersuperiorsuit
+	back = /obj/item/storage/backpack/satchel/warfare
+	shoes = /obj/item/clothing/shoes/white
+	l_hand = /obj/item/storage/firstaid/adv
+	glasses = /obj/item/clothing/glasses/hud/health
+	belt = /obj/item/storage/belt/medical/apothecary
+	r_pocket = /obj/item/device/flashlight/pen
+	id_type = /obj/item/card/id/medical/head
+	head = /obj/item/clothing/head/hospitallerhelm
+	backpack_contents = list(
+		/obj/item/reagent_containers/food/snacks/warfare/rat = 1,
+		/obj/item/stack/thrones/five = 1,
+		/obj/item/stack/thrones2/five = 1,
+		/obj/item/stack/thrones3/five = 1,)
+
+/decl/hierarchy/outfit/job/medical/doctor
+	name = OUTFIT_JOB_NAME("Sister Hospitellar")
+	uniform = /obj/item/clothing/under/rank/medical
+	l_ear  = /obj/item/device/radio/headset/red_team
+	neck = /obj/item/reagent_containers/food/drinks/canteen
+	suit = /obj/item/clothing/suit/storage/sistersuit
+	back = /obj/item/storage/backpack/satchel/warfare
+	glasses = /obj/item/clothing/glasses/hud/health
+	l_hand = /obj/item/storage/firstaid/adv
+	belt = /obj/item/storage/belt/medical/full
+	r_pocket = /obj/item/device/flashlight/pen
+	id_type = /obj/item/card/id/medical
+	head = /obj/item/clothing/head/hospitallerhelm
+	backpack_contents = list(
+		/obj/item/reagent_containers/food/snacks/warfare/rat = 1,
+		/obj/item/stack/thrones = 1,
+		/obj/item/stack/thrones2 = 1,
+		/obj/item/stack/thrones3/five = 1,)
+
+/decl/hierarchy/outfit/job/medical/chemist
+	name = OUTFIT_JOB_NAME("Alchemist")
+	uniform = /obj/item/clothing/under/rank/medical/scrubs/black
+	suit = /obj/item/clothing/suit/storage/toggle/labcoat/alchemist
+	id_type = /obj/item/card/id/medical/chemist
+	pda_type = /obj/item/device/pda/chemist
+	belt = /obj/item/storage/belt/medical/alchemist
+	neck = /obj/item/reagent_containers/food/drinks/canteen
+	glasses = /obj/item/clothing/glasses/hud/health
+	back = /obj/item/storage/backpack/satchel/warfare
+	l_ear = /obj/item/device/radio/headset/red_team
+	r_ear = null
+	backpack_contents = list(
+		/obj/item/reagent_containers/food/snacks/warfare/rat = 1,
+		/obj/item/stack/thrones = 1,
+		/obj/item/stack/thrones2 = 1,
+		/obj/item/stack/thrones3/five = 1,)
+
+/decl/hierarchy/outfit/job/medical/geneticist
+	name = OUTFIT_JOB_NAME("Genetor")
+	uniform = /obj/item/clothing/under/rank/geneticist
+	suit = /obj/item/clothing/suit/storage/hooded/genetor
+	mask = /obj/item/clothing/mask/gas/techpriest
+	r_pocket = /obj/item/device/flashlight/pen
+	id_type = /obj/item/card/id/medical/geneticist
+	pda_type = /obj/item/device/pda/geneticist
+	belt = /obj/item/storage/belt/medical/apothecary
+	neck = /obj/item/reagent_containers/food/drinks/canteen
+	gloves = /obj/item/clothing/gloves/thick/techpriest
+	glasses = /obj/item/clothing/glasses/hud/health
+	shoes = /obj/item/clothing/shoes/workboots
+	l_ear = /obj/item/device/radio/headset/red_team
+	r_ear = null
+	back = /obj/item/storage/backpack/satchel/warfare/techpriest/biologis
+	backpack_contents = list(
+		/obj/item/stack/thrones = 1,
+		/obj/item/stack/thrones2 = 1,
+		/obj/item/stack/thrones3/five = 1,
+		/obj/item/reagent_containers/food/snacks/warfare/rat = 1,)
+
+/decl/hierarchy/outfit/job/medical/paramedic
+	name = OUTFIT_JOB_NAME("combat medicae")
+	uniform = /obj/item/clothing/under/cadian_uniform
+	suit = /obj/item/clothing/suit/armor/medicae
+	shoes = /obj/item/clothing/shoes/jackboots
+	gloves = /obj/item/clothing/gloves/thick/swat/combat/warfare
+	back = /obj/item/storage/backpack/satchel/warfare
+	neck = /obj/item/reagent_containers/food/drinks/canteen
+	glasses = /obj/item/clothing/glasses/hud/health
+	belt = /obj/item/storage/belt/medical/full
+	head = /obj/item/clothing/head/helmet/medicae
+	r_pocket = /obj/item/storage/box/ifak
+	l_pocket = /obj/item/cell/lasgun
+	id_type = /obj/item/card/id/medical/paramedic
+	l_ear = /obj/item/device/radio/headset/red_team
+	r_ear = null
+	backpack_contents = list(
+	/obj/item/cell/lasgun = 1,
+	/obj/item/reagent_containers/food/snacks/warfare/rat = 1,
+	/obj/item/stack/thrones = 1,
+	/obj/item/stack/thrones2 = 1,
+	/obj/item/stack/thrones3/five = 1,
+	/obj/item/clothing/mask/gas/half/cadianrespirator = 1,
+	/obj/item/clothing/glasses/cadiangoggles = 1,
+	)
+	suit_store = /obj/item/gun/energy/las/lasgun
+	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL

--- a/code/game/gamemodes/warfare/turfs.dm
+++ b/code/game/gamemodes/warfare/turfs.dm
@@ -142,7 +142,7 @@
 					return
 			playsound(src, 'sound/effects/dig_shovel.ogg', 50, 0)
 			visible_message("[user] begins to dig some dirt cover!")
-			if(do_after(user, (backwards_skill_scale(user.SKILL_LEVEL(engineering)) * 5)))
+			if(do_after(user, (backwards_skill_scale(user.SKILL_LEVEL(engineering)) * 1)))
 				new /obj/structure/dirt_wall(src)
 				visible_message("[user] finishes digging the dirt cover.")
 				playsound(src, 'sound/effects/empty_shovel.ogg', 50, 0)
@@ -172,7 +172,7 @@
 				return
 		playsound(src, 'sound/effects/dig_shovel.ogg', 50, 0)
 		visible_message("[user] begins to dig a trench!")
-		if(do_after(user, backwards_skill_scale(user.SKILL_LEVEL(engineering)) * 5))
+		if(do_after(user, backwards_skill_scale(user.SKILL_LEVEL(engineering)) * 1))
 			ChangeTurf(/turf/simulated/floor/trench)
 			visible_message("[user] finishes digging the trench.")
 			playsound(src, 'sound/effects/empty_shovel.ogg', 50, 0)
@@ -204,7 +204,7 @@
 				return
 		playsound(src, 'sound/effects/dig_shovel.ogg', 50, 0)
 		visible_message("[user] begins to dig a trench!")
-		if(do_after(user, backwards_skill_scale(user.SKILL_LEVEL(engineering)) * 5))
+		if(do_after(user, backwards_skill_scale(user.SKILL_LEVEL(engineering)) * 1))
 			ChangeTurf(/turf/simulated/floor/trench)
 			visible_message("[user] finishes digging the trench.")
 			playsound(src, 'sound/effects/empty_shovel.ogg', 50, 0)
@@ -230,7 +230,7 @@
 					return
 			playsound(src, 'sound/effects/dig_shovel.ogg', 50, 0)
 			visible_message("[user] begins to dig a grave!")
-			if(do_after(user, (backwards_skill_scale(user.SKILL_LEVEL(engineering)) * 5)))
+			if(do_after(user, (backwards_skill_scale(user.SKILL_LEVEL(engineering)) * 1)))
 				new /obj/structure/closet/pit(src)
 				visible_message("[user] finishes digging the grave!")
 				playsound(src, 'sound/effects/empty_shovel.ogg', 50, 0)

--- a/code/game/jobs/astra_militarum.dm
+++ b/code/game/jobs/astra_militarum.dm
@@ -15,7 +15,7 @@
 	shotgun_skill = 7
 	lmg_skill = 6
 	smg_skill = 7
-	open_when_dead = TRUE
+	open_when_dead = FALSE
 	announced = FALSE
 	can_be_in_squad = TRUE
 	latejoin_at_spawnpoints = TRUE
@@ -48,8 +48,8 @@
 
 /datum/job/ig/guardsman
 	title = "Imperial Guardsman"
-	total_positions = 20
-	spawn_positions = 20
+	total_positions = 10
+	spawn_positions = 10
 	social_class = SOCIAL_CLASS_MED //Guards are at least pretty respected in imperial society
 	auto_rifle_skill = 7
 	semi_rifle_skill = 7
@@ -68,7 +68,7 @@
 	equip(var/mob/living/carbon/human/H)
 		H.warfare_faction = IMPERIUM
 		..()
-		H.add_stats(rand(12,16), rand(12,16), rand(12,16), rand (8,14))
+		H.add_stats(rand(14,16), rand(14,16), rand(12,16), rand (8,14))
 		H.add_skills(rand(7,10),rand(6,10),rand(3,6),rand(1,4),rand(1,3)) //melee, ranged, med, eng, surgery
 		H.warfare_language_shit(LANGUAGE_LOW_GOTHIC)
 		SSwarfare.red.team += H
@@ -81,10 +81,10 @@
 		H.assign_random_quirk()
 		H.witchblood()
 
-		to_chat(H, "<span class='notice'><b><font size=3>You are a soldier of the Imperium. Obey your Sergeant and Commissar. The Emperor Protects. </font></b></span>")
-
 		H.get_idcard()?.access = list(access_security, access_sec_doors, access_brig, access_forensics_lockers, access_all_personal_lockers, access_maint_tunnels)
-		to_chat(H, "<span class='notice'><b><font size=3>You are a soldier of the Imperium. Obey your Sergeant and Commissar. You can see controls in top right -> OOC tab -> View Controls.  The Emperor Protects. </font></b></span>")
+		to_chat(H, "<span class='notice'><b><font size=3>   You are an Imperial Guardsmen selected personally by the Lord Trader to serve as the primary source of manpower and security within their retinue, your services go beyond the wielding of your lasgun and may involve tasks varying from hard labour, exploration and peacekeeping -- up until the point in which it is decided you must lay down your life to protect the citizens of The Imperium. </font></b></span>")
+		to_chat(H, "<span class='notice'><b><font size=3>   The Astra Militarum, also known as the Imperial Guard in colloquial Low Gothic, is the largest coherent fighting force in the galaxy. They serve as the Imperium of Man's primary combat force and first line of defence from the myriad threats which endanger the existence of the Human race in the 41st Millennium. </font></b></span>")
+		to_chat(H, "<span class='notice'><b><font size=3>   There is no universal uniform or regimental command hierarchy in the Astra Militarum, although it is compulsory for every regiment to have at least one commissar to maintain the discipline and morale of the troops while watching for any signs of corruption or heretical taint in the ranks. </font></b></span>")
 
 		if(title == "Krieg Guardsman")
 			H.add_skills(rand(7,10),rand(6,10),rand(3,6),rand(3,6),rand(1,3))
@@ -102,9 +102,9 @@
 //Whiteshield
 
 /datum/job/ig/guardsman/whiteshield
-	title = "Imperial Guard Whiteshield"
-	total_positions = 20
-	spawn_positions = 20
+	title = "Imperial Guard Conscript"
+	total_positions = 4
+	spawn_positions = 4
 	social_class = SOCIAL_CLASS_MED //Guards are at least pretty respected in imperial society
 	outfit_type = /decl/hierarchy/outfit/job/whiteshield
 	can_be_in_squad = FALSE
@@ -126,7 +126,7 @@
 		H.assign_random_quirk()
 		H.witchblood()
 		H.get_idcard()?.access = list(access_security, access_sec_doors, access_brig, access_forensics_lockers, access_all_personal_lockers, access_maint_tunnels)
-		to_chat(H, "<span class='notice'><b><font size=3>You are nothing but a young recruit, future soldier of the Imperium. Obey your Sergeant and Commissar and assist the fellow guardsmen while trying to survive. You can see controls in top right -> OOC tab -> View Controls.  The Emperor Protects. </font></b></span>")
+		to_chat(H, "<span class='notice'><b><font size=3>Conscripts are units within the Imperial Guard that consist of normal Imperial citizens with little or no military training, new Guard recruits who have not yet entered training, children of an already extant regiment's troops or standing Guardsmen who have not yet completed their training. Sometimes, in military emergencies, the Imperium's need for manpower is so great that normal Imperial citizens will simply find themselves conscripted by their local Imperial Guard regiment. </font></b></span>")
 
 //Sharpshooters
 
@@ -237,8 +237,8 @@
 	department_flag = SEC|MED
 	social_class = SOCIAL_CLASS_MED
 	can_be_in_squad = TRUE
-	total_positions = 6
-	spawn_positions = 6
+	total_positions = 1
+	spawn_positions = 1
 	supervisors = "the Sister Hospitaller and the Commissar"
 	selection_color = "#967096"
 	economic_modifier = 4
@@ -264,7 +264,7 @@
 		H.set_trait(new/datum/trait/death_tolerant())
 		if(can_be_in_squad)
 			H.assign_random_squad(IMPERIUM, "medic")
-		H.add_stats(rand(10,16), rand(12,17), rand(12,15), rand(12,16)) //dodgy as fuck, would probably dodge a bullet even if it meant killing the comrade behind them
+		H.add_stats(rand(12,16), rand(12,17), rand(12,15), rand(12,16)) //dodgy as fuck, would probably dodge a bullet even if it meant killing the comrade behind them
 		H.add_skills(rand(7,10),rand(8,10),rand(7,10),rand(3,5),rand(6,10)) //melee, ranged, med, eng, surgery
 		H.get_equipped_item(slot_s_store)
 		H.assign_random_quirk()
@@ -313,7 +313,7 @@
 		H.warfare_language_shit(LANGUAGE_HIGH_GOTHIC)
 		H.get_idcard()?.access = get_all_accesses()
 		H.warfare_faction = IMPERIUM
-		to_chat(H, "<span class='notice'><b><font size=3>You are an Imperial Commissar. You are the acting head of the Astra Militarum on this outpost. Maintain morale and maintain discipline. Do not be afraid to execute an unruly guardsmen. </font></b></span>")
+		to_chat(H, "<span class='notice'><b><font size=3>The commissar is empowered to use any means necessary to ensure the loyalty and moral purity of his or her charges, including overriding or even executing a regiment's commanding officer if necessary, and so is regarded with a mixture of fear and admiration by rank-and-file Guardsmen -- and not a few of their officers. Commissars provide the link between regimental officers and the Departmento Munitorum. They are tough, ruthless individuals whose primary responsibilities are to preserve the courage, discipline and loyalty of the regiment. Only a handful of commissars have ever obtained leadership over large Imperial forces as a lord commander, or even a governor militant, such as Yarrick at Armageddon, and only a handful are known to have even retained full command of an entire regiment, such as Colonel-Commissar Ibram Gaunt. All commissars are trained as excellent orators, and often deliver stirring speeches to their regiment or company prior to battle. During battle, the commissar is almost always amongst the front lines, and roars a litany of battle cries and prayers to the Emperor to inspire his troops to battle. </font></b></span>")
 /*
 		H.verbs -= list(
 		/mob/living/carbon/human/proc/khorne,

--- a/code/game/jobs/job/astra_militarum.dm
+++ b/code/game/jobs/job/astra_militarum.dm
@@ -15,7 +15,7 @@
 	shotgun_skill = 7
 	lmg_skill = 6
 	smg_skill = 7
-	open_when_dead = TRUE
+	open_when_dead = FALSE
 	announced = FALSE
 	can_be_in_squad = TRUE
 	latejoin_at_spawnpoints = TRUE
@@ -48,8 +48,8 @@
 
 /datum/job/ig/guardsman
 	title = "Imperial Guardsman"
-	total_positions = 20
-	spawn_positions = 20
+	total_positions = 10
+	spawn_positions = 10
 	social_class = SOCIAL_CLASS_MED //Guards are at least pretty respected in imperial society
 	auto_rifle_skill = 7
 	semi_rifle_skill = 7
@@ -68,7 +68,7 @@
 	equip(var/mob/living/carbon/human/H)
 		H.warfare_faction = IMPERIUM
 		..()
-		H.add_stats(rand(12,16), rand(12,16), rand(12,16), rand (8,14))
+		H.add_stats(rand(14,16), rand(14,16), rand(12,16), rand (8,14))
 		H.add_skills(rand(7,10),rand(6,10),rand(3,6),rand(1,4),rand(1,3)) //melee, ranged, med, eng, surgery
 		H.warfare_language_shit(LANGUAGE_LOW_GOTHIC)
 		SSwarfare.red.team += H
@@ -81,10 +81,10 @@
 		H.assign_random_quirk()
 		H.witchblood()
 
-		to_chat(H, "<span class='notice'><b><font size=3>You are a soldier of the Imperium. Obey your Sergeant and Commissar. The Emperor Protects. </font></b></span>")
-
 		H.get_idcard()?.access = list(access_security, access_sec_doors, access_brig, access_forensics_lockers, access_all_personal_lockers, access_maint_tunnels)
-		to_chat(H, "<span class='notice'><b><font size=3>You are a soldier of the Imperium. Obey your Sergeant and Commissar. You can see controls in top right -> OOC tab -> View Controls.  The Emperor Protects. </font></b></span>")
+		to_chat(H, "<span class='notice'><b><font size=3>   You are an Imperial Guardsmen selected personally by the Lord Trader to serve as the primary source of manpower and security within their retinue, your services go beyond the wielding of your lasgun and may involve tasks varying from hard labour, exploration and peacekeeping -- up until the point in which it is decided you must lay down your life to protect the citizens of The Imperium. </font></b></span>")
+		to_chat(H, "<span class='notice'><b><font size=3>   The Astra Militarum, also known as the Imperial Guard in colloquial Low Gothic, is the largest coherent fighting force in the galaxy. They serve as the Imperium of Man's primary combat force and first line of defence from the myriad threats which endanger the existence of the Human race in the 41st Millennium. </font></b></span>")
+		to_chat(H, "<span class='notice'><b><font size=3>   There is no universal uniform or regimental command hierarchy in the Astra Militarum, although it is compulsory for every regiment to have at least one commissar to maintain the discipline and morale of the troops while watching for any signs of corruption or heretical taint in the ranks. </font></b></span>")
 
 		if(title == "Krieg Guardsman")
 			H.add_skills(rand(7,10),rand(6,10),rand(3,6),rand(3,6),rand(1,3))
@@ -102,9 +102,9 @@
 //Whiteshield
 
 /datum/job/ig/guardsman/whiteshield
-	title = "Imperial Guard Whiteshield"
-	total_positions = 20
-	spawn_positions = 20
+	title = "Imperial Guard Conscript"
+	total_positions = 4
+	spawn_positions = 4
 	social_class = SOCIAL_CLASS_MED //Guards are at least pretty respected in imperial society
 	outfit_type = /decl/hierarchy/outfit/job/whiteshield
 	can_be_in_squad = FALSE
@@ -126,7 +126,7 @@
 		H.assign_random_quirk()
 		H.witchblood()
 		H.get_idcard()?.access = list(access_security, access_sec_doors, access_brig, access_forensics_lockers, access_all_personal_lockers, access_maint_tunnels)
-		to_chat(H, "<span class='notice'><b><font size=3>You are nothing but a young recruit, future soldier of the Imperium. Obey your Sergeant and Commissar and assist the fellow guardsmen while trying to survive. You can see controls in top right -> OOC tab -> View Controls.  The Emperor Protects. </font></b></span>")
+		to_chat(H, "<span class='notice'><b><font size=3>Conscripts are units within the Imperial Guard that consist of normal Imperial citizens with little or no military training, new Guard recruits who have not yet entered training, children of an already extant regiment's troops or standing Guardsmen who have not yet completed their training. Sometimes, in military emergencies, the Imperium's need for manpower is so great that normal Imperial citizens will simply find themselves conscripted by their local Imperial Guard regiment. </font></b></span>")
 
 //Sharpshooters
 
@@ -143,7 +143,7 @@
 	smg_skill = 7
 	alt_titles = list(
 		"Cadian Sharpshooter" = /decl/hierarchy/outfit/job/sharpshooter,
-		"Valhallan Ice Warriors" = /decl/hierarchy/outfit/job/sharpshooter/valhalla
+		"Valhallan Ice Warriors" = /decl/hierarchy/outfit/job/guardsman/valhallan
 		)
 
 	equip(var/mob/living/carbon/human/H)
@@ -237,8 +237,8 @@
 	department_flag = SEC|MED
 	social_class = SOCIAL_CLASS_MED
 	can_be_in_squad = TRUE
-	total_positions = 6
-	spawn_positions = 6
+	total_positions = 1
+	spawn_positions = 1
 	supervisors = "the Sister Hospitaller and the Commissar"
 	selection_color = "#967096"
 	economic_modifier = 4
@@ -264,7 +264,7 @@
 		H.set_trait(new/datum/trait/death_tolerant())
 		if(can_be_in_squad)
 			H.assign_random_squad(IMPERIUM, "medic")
-		H.add_stats(rand(10,16), rand(12,17), rand(12,15), rand(12,16)) //dodgy as fuck, would probably dodge a bullet even if it meant killing the comrade behind them
+		H.add_stats(rand(12,16), rand(12,17), rand(12,15), rand(12,16)) //dodgy as fuck, would probably dodge a bullet even if it meant killing the comrade behind them
 		H.add_skills(rand(7,10),rand(8,10),rand(7,10),rand(3,5),rand(6,10)) //melee, ranged, med, eng, surgery
 		H.get_equipped_item(slot_s_store)
 		H.assign_random_quirk()
@@ -313,7 +313,7 @@
 		H.warfare_language_shit(LANGUAGE_HIGH_GOTHIC)
 		H.get_idcard()?.access = get_all_accesses()
 		H.warfare_faction = IMPERIUM
-		to_chat(H, "<span class='notice'><b><font size=3>You are an Imperial Commissar. You are the acting head of the Astra Militarum on this outpost. Maintain morale and maintain discipline. Do not be afraid to execute an unruly guardsmen. </font></b></span>")
+		to_chat(H, "<span class='notice'><b><font size=3>The commissar is empowered to use any means necessary to ensure the loyalty and moral purity of his or her charges, including overriding or even executing a regiment's commanding officer if necessary, and so is regarded with a mixture of fear and admiration by rank-and-file Guardsmen -- and not a few of their officers. Commissars provide the link between regimental officers and the Departmento Munitorum. They are tough, ruthless individuals whose primary responsibilities are to preserve the courage, discipline and loyalty of the regiment. Only a handful of commissars have ever obtained leadership over large Imperial forces as a lord commander, or even a governor militant, such as Yarrick at Armageddon, and only a handful are known to have even retained full command of an entire regiment, such as Colonel-Commissar Ibram Gaunt. All commissars are trained as excellent orators, and often deliver stirring speeches to their regiment or company prior to battle. During battle, the commissar is almost always amongst the front lines, and roars a litany of battle cries and prayers to the Emperor to inspire his troops to battle. </font></b></span>")
 /*
 		H.verbs -= list(
 		/mob/living/carbon/human/proc/khorne,

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -47,8 +47,8 @@
 	title = "Cook"
 	department = "Service"
 	department_flag = CIV
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 2
+	spawn_positions = 2
 	open_when_dead = 1
 	latejoin_at_spawnpoints = TRUE
 	supervisors = "the Seneschal, the Commissar"
@@ -87,7 +87,7 @@
 	department = "Service"
 	department_flag = CIV
 	total_positions = 2
-	spawn_positions = 1
+	spawn_positions = 2
 	supervisors = "the Seneschal"
 	selection_color = "#848484"
 	latejoin_at_spawnpoints = TRUE

--- a/code/game/jobs/job/departmento_munitorum.dm
+++ b/code/game/jobs/job/departmento_munitorum.dm
@@ -1,7 +1,7 @@
 //  Munitorum Tribunus
 
 /datum/job/qm
-	title = "Munitorum Tribunus"
+	title = "Munitorum Prefectus"
 	department = "Supply"
 	department_flag = CIV
 	total_positions = 1
@@ -47,8 +47,8 @@
 	title = "Munitorum Menial"
 	department = "Supply"
 	department_flag = CIV
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	latejoin_at_spawnpoints = 1
 	social_class = SOCIAL_CLASS_MED
 	announced = 0

--- a/code/game/objects/effects/lateparty.dm
+++ b/code/game/objects/effects/lateparty.dm
@@ -1,0 +1,96 @@
+// Wel Ard's whacky late party system, look to admin verbs for tools that play around with this namely generate party and another party
+//This is the current slightly improved version of the observer file variant, much mo flexible. It is a clown world system but it just works.
+/mob/observer/ghost/verb/latepartynew()
+	set category = "Ghost"
+	set name = "Late Party"
+	set desc= "Join a randomized late party picked from a list!"
+
+	var/partydelay = 25000 //in deciseconds (40 min rn or 18000 deciseconds)
+
+	if(world.time < partydelay) //all this does is cause a delay so people can't suicide or observer and rush the base
+		to_chat(src, "It is too early for a late party! This will open when round duration reaches 0:40!")
+		return
+
+	if(GLOB.deployed == 1) //checks if a party has already been sent, can make this value higher if you wish to send more than one!
+		to_chat(src, "The late party has already deployed!")
+		return
+
+	if(src.isreadied == 1) //not really used rn but could be useful if you ever wanna make people spawn in batches so they can opt out
+		to_chat(src,"<span class='warning'><b><font size=3>You leave the queue for the late party!</b></font size=3>")
+		src.isreadied = 0 //unreadies player
+		GLOB.partygang-- //subtracts from amount readied up
+		return
+	else
+		to_chat(src,"<span class='warning'><b><font size=3>You join the late party!</b></font size=3>")
+		src.isreadied = 1 //readies player up
+		GLOB.partygang++ //adds to amount readied up
+
+
+	switch(GLOB.partygang)
+		if(1)
+			src.say("I'm joining the late party 1/6 deployed!") //just speaks to deadchat quickly so 1. people know its open and 2. lets them know the amount of slots left.
+		if(2)
+			src.say("I'm joining the late party 2/6 deployed!")
+		if(3)
+			src.say("I'm joining the late party 3/6 deployed!")
+		if(4)
+			src.say("I'm joining the late party 4/6 deployed!")
+		if(5)
+			src.say("I'm joining the late party 5/6 deployed!")
+		if(6)
+			src.say("I'm joining the late party 6/6 deployed! All slots are now filled!")
+			GLOB.deployed++ //ensures that only 1 party can be sent
+		if(7)
+			src.say("I'm joining the late party 7/12 deployed! Admemes have opened another party!")
+		if(8)
+			src.say("I'm joining the late party 8/12 deployed!")
+		if(9)
+			src.say("I'm joining the late party 9/12 deployed!")
+		if(10)
+			src.say("I'm joining the late party 10/12 deployed!")
+		if(11)
+			src.say("I'm joining the late party 11/12 deployed!")
+		if(12)
+			src.say("I'm joining the late party 12/12 deployed! All slots are now filled!")
+			GLOB.deployed++ //ensures that only 1 party can be sent
+
+
+	var/partyteam = input("Spawn as late party", "Randomly selected party!") as anything in GLOB.latepartyoptions //automagically puts them into whatever the pick proc chooses
+
+	switch(partyteam)
+
+		//if("Kroot")
+			//message_admins("[usr.key] has joined the late party: Kroot.", 0) //msgs jannies
+			//to_chat(usr, "<span class='warning'><b><font size=3>It's been a long flight, go to your Kroot tab and be sure to stretch!</b></font size=3>") //tells mob to do thing
+			//usr.loc = get_turf(locate("landmark*krootstart")) //where they spawning
+			//var/mob/living/carbon/human/kroot/new_character = new(usr.loc) // da mob
+			//new_character.key = usr.key //puts ghost in body with new key
+		if("Orkz")
+			message_admins("[usr.key] has joined the late party: Orkz.", 0) //msgs jannies
+			to_chat(usr, "<span class='warning'><b><font size=3>It's been a long flight, go to your Ork tab and be sure to stretch!</b></font size=3>") //tells mob to do thing
+			usr.loc = get_turf(locate("landmark*orkstart")) //where they spawning
+			var/mob/living/carbon/human/ork/new_character = new(usr.loc) // da mob
+			new_character.key = usr.key //puts ghost in body with new key
+		if("Tau")
+			message_admins("[usr.key] has joined the late party: Tau.", 0) //msgs jannies
+			to_chat(usr, "<span class='warning'><b><font size=3>It has been a long flight but we have landed in Imperial space. Follow the Aun's orders. Assimilate this planet for the greater good! Check the Tau tab and remember your caste!</b></font size=3>") //tells mob to do thing
+			usr.loc = get_turf(locate("landmark*taustart")) //where they spawning
+			var/mob/living/carbon/human/tau/new_character = new(usr.loc)// da mob
+			new_character.key = usr.key //puts ghost in body with new key
+		if("Genestealers")
+			message_admins("[usr.key] has joined the late party: Genestealer.", 0) //msgs jannies
+			to_chat(usr, "<span class='warning'><b><font size=3>You are the point of the spear of the Great Devourer. Grow your following and undermine this planets defenses.</b></font size=3>") //tells mob to do thing
+			usr.loc = get_turf(locate("landmark*genestart")) //where they spawning
+			var/mob/living/carbon/human/genestealer/new_character = new(usr.loc)// da mob
+			new_character.key = usr.key //puts ghost in body with new key
+
+
+/hook/startup/proc/chooseparty() //chooses one party on startup
+	Get_Party()
+	return
+
+/proc/Get_Party() //dis is the proc that actually selects the party
+	GLOB.latepartyoptions += pick("Orkz", "Tau",)
+
+	//note for myself, make procs to spawn as group if you ever wanna switch to that.
+	//Something like the new_character key that uses an if isreadied to pull them all at once. You could make like beKroot() that contains everything under if("kroot")

--- a/code/modules/mob/observer/lateparty.dm
+++ b/code/modules/mob/observer/lateparty.dm
@@ -5,10 +5,10 @@
 	set name = "Late Party"
 	set desc= "Join a randomized late party picked from a list!"
 
-	var/partydelay = 18000 //in deciseconds (30 min rn or 18000 deciseconds)
+	var/partydelay = 25000 //in deciseconds (40 min rn or 18000 deciseconds)
 
 	if(world.time < partydelay) //all this does is cause a delay so people can't suicide or observer and rush the base
-		to_chat(src, "It is too early for a late party! This will open when round duration reaches 0:30!")
+		to_chat(src, "It is too early for a late party! This will open when round duration reaches 0:40!")
 		return
 
 	if(GLOB.deployed == 1) //checks if a party has already been sent, can make this value higher if you wish to send more than one!

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -243,7 +243,7 @@ obj/item/gun/energy/retro
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/las/lasgun
-	charge_cost = 100
+	charge_cost = 80
 	cell_type = /obj/item/cell/lasgun
 	ammoType = /obj/item/cell/lasgun
 	wielded_item_state = "lasgun-wielded"
@@ -260,7 +260,7 @@ obj/item/gun/energy/retro
 	armor_penetration = 10
 	force = 15
 	one_hand_penalty = 1.9
-	charge_cost = 60
+	charge_cost = 65
 
 	firemodes = list(
 		list(mode_name="semi-automatic",       burst=1, fire_delay=3, move_delay=1.5, one_hand_penalty=1.7, burst_accuracy=null, dispersion=null, automatic = 0),
@@ -282,7 +282,7 @@ obj/item/gun/energy/retro
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/las/lasgun/lucius
-	charge_cost = 200
+	charge_cost = 120
 	cell_type = /obj/item/cell/lasgun
 	ammoType = /obj/item/cell/lasgun
 	wielded_item_state = "luscius-wielded"
@@ -305,7 +305,7 @@ obj/item/gun/energy/retro
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/las/lasgun
-	charge_cost = 50
+	charge_cost = 60
 	cell_type = /obj/item/cell/lasgun
 	ammoType = /obj/item/cell/lasgun
 	wielded_item_state = "lasgun-wielded"
@@ -331,7 +331,7 @@ obj/item/gun/energy/retro
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/las/lasgun
-	charge_cost = 50
+	charge_cost = 70
 	cell_type = /obj/item/cell/lasgun
 	ammoType = /obj/item/cell/lasgun
 	wielded_item_state = "lasgun-wielded"
@@ -349,7 +349,7 @@ obj/item/gun/energy/retro
 	force = 12
 	one_hand_penalty = 1.8
 	fire_delay = 3.5
-	charge_cost = 150
+	charge_cost = 90
 
 	firemodes = list(
 		list(mode_name="semi-automatic", burst=1, fire_delay=2.5,    move_delay = 1.5, one_hand_penalty=2, burst_accuracy=null, dispersion=null, automatic = 0),
@@ -371,7 +371,7 @@ obj/item/gun/energy/retro
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/las/lasgun
-	charge_cost = 30
+	charge_cost = 55
 	cell_type = /obj/item/cell/lasgun
 	ammoType = /obj/item/cell/lasgun
 	wielded_item_state = "lascar-wielded"
@@ -397,7 +397,7 @@ obj/item/gun/energy/retro
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/las/lasgun/hotshot
-	charge_cost = 300
+	charge_cost = 200
 	cell_type = /obj/item/cell/lasgun
 	ammoType = /obj/item/cell/lasgun
 	wielded_item_state = "lascar-wielded"
@@ -420,7 +420,7 @@ obj/item/gun/energy/retro
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/las/lasgun
-	charge_cost = 100
+	charge_cost = 90
 	armor_penetration = 5
 	cell_type = /obj/item/cell/lasgun
 	ammoType = /obj/item/cell/lasgun
@@ -441,6 +441,7 @@ obj/item/gun/energy/retro
 	desc = "Kantrael MG is a Cadian laspistol, frequently seen as a cheap and reliable sidearm. This variant bears the Astra Militarum markings, issued to the enlisted personnel and non-commissioned officers"
 	icon_state = "laspistol"
 	item_state = "laspistol"
+	charge_cost = 80
 
 /obj/item/gun/energy/las/laspistol/militarum/lucius
 	name = "Astra Militarum Lucius-pattern Laspistol"
@@ -450,9 +451,9 @@ obj/item/gun/energy/retro
 	force = 10
 	one_hand_penalty = 2.55
 	accuracy = -0.6
-	fire_delay = 2.7
+	fire_delay = 2.5
 	armor_penetration = 8.75
-	charge_cost = 200
+	charge_cost = 100
 
 	firemodes = list(
 		list(mode_name="semi-automatic",       burst=1, fire_delay=2.5,    move_delay=null, burst_accuracy=null, dispersion=null, automatic = 0),
@@ -543,7 +544,7 @@ obj/item/gun/energy/retro
 	wielded_item_state = "ionriflet-wielded"
 
 	firemodes = list(
-		list(mode_name="semi-automatic",       burst=1, fire_delay=40,    move_delay=null, one_hand_penalty=2, burst_accuracy=null, dispersion=null, automatic = 0),
+		list(mode_name="semi-automatic",       burst=1, fire_delay=10,    move_delay=null, one_hand_penalty=2, burst_accuracy=null, dispersion=null, automatic = 0),
 		)
 
 /obj/item/gun/energy/pulse/pulsepistol

--- a/code/modules/projectiles/guns/projectile/mattguns.dm
+++ b/code/modules/projectiles/guns/projectile/mattguns.dm
@@ -599,7 +599,7 @@
 	move_delay= 1.5
 	one_hand_penalty = 4
 	accuracy = -0.3
-	fire_delay = 2.9
+	fire_delay = 1.7
 	automatic = 1
 
 	fire_sound = 'sound/weapons/guns/fire/smg_fire.ogg'
@@ -624,7 +624,7 @@
 	move_delay= 1.4
 	one_hand_penalty = 3
 	accuracy = -0.2
-	fire_delay = 2.8
+	fire_delay = 1.5
 	armor_penetration = 8
 
 	wielded_item_state = "autorifle-wielded"
@@ -651,7 +651,7 @@
 	move_delay= 2
 	one_hand_penalty = 4
 	accuracy = -0.2
-	fire_delay = 3
+	fire_delay = 1.6
 	automatic = 1
 
 	magazine_type = /obj/item/ammo_magazine/autogrim
@@ -695,7 +695,7 @@
 	firemodes = list()
 	accuracy = 0
 	automatic = 1
-	fire_delay = 1
+	fire_delay = 4
 	burst=1
 	magazine_type = /obj/item/ammo_magazine/flamer
 	allowed_magazines = /obj/item/ammo_magazine/flamer
@@ -766,7 +766,7 @@
 	move_delay= 1
 	one_hand_penalty = 1
 	accuracy = 0
-	fire_delay = 2.8
+	fire_delay = 1.7
 	force = 8
 
 /obj/item/gun/projectile/warfare/update_icon()//We gotta snowflake this a bit.
@@ -787,7 +787,7 @@
 	move_delay = 1
 	one_hand_penalty = 0.7
 	accuracy = -0.1
-	fire_delay = 2.5
+	fire_delay = 1.5
 	armor_penetration = 10
 
 /obj/item/ammo_magazine/c45m/warfare
@@ -829,22 +829,22 @@
 	unwielded_unloaded_icon = "hmg-e"
 	wielded_unloaded_icon = "hmg-wielded-e"
 	burst = 1
-	automatic = 1
+	automatic = 0.8
 	firemodes = list()
 	gun_type = GUN_LMG
 	move_delay= 5
 	one_hand_penalty = 8 //it is a HMG, but its also not a bolter, this is probably enough penalty
 	accuracy = -0.5
-	fire_delay = 2.9
+	fire_delay = 1.6
 
 /obj/item/gun/projectile/automatic/stubber/villiers
 	name = "Villiers Heavy Stubber"
 	desc = "A rugged belt-fed stubber that is long out of service. This one seems to have been diligently maintained over the years."
 	move_delay= 4.5
 	one_hand_penalty = 7
-	accuracy = -0.5
-	fire_delay = 3.2
-	automatic = 1
+	accuracy = 1
+	fire_delay = 1.8
+	automatic = 0.8
 	armor_penetration = 5 //this is melee
 
 // Boltgun
@@ -869,7 +869,7 @@
 	cock_sound 		= 'sound/weapons/guns/interact/ltrifle_cock.ogg'
 	loaded_icon = "ultrabolter-30"
 	unloaded_icon = "ultrabolter-e"
-	fire_delay = 3
+	fire_delay = 2
 	burst = 1
 	move_delay = 5
 	one_hand_penalty = 10
@@ -949,7 +949,7 @@
 	cock_sound 		= 'sound/weapons/guns/interact/ltrifle_cock.ogg'
 	loaded_icon = "lockebolter-30"
 	unloaded_icon = "lockebolter-e"
-	fire_delay = 3
+	fire_delay = 2
 	burst = 1
 	move_delay = 3
 	automatic = 1
@@ -989,7 +989,7 @@
 	cock_sound 		= 'sound/weapons/guns/interact/ltrifle_cock.ogg'
 	loaded_icon = "sisterbolter-30"
 	unloaded_icon = "sisterbolter-30-e"
-	fire_delay = 3.5
+	fire_delay = 1.8
 	burst = 1
 	move_delay = 3
 	automatic = 1
@@ -1018,7 +1018,7 @@
 	one_hand_penalty = 7
 	empty_icon = "krootrifle"
 	far_fire_sound = "sniper_fire"
-	fire_delay = 8
+	fire_delay = 6
 	move_delay= 2
 	one_hand_penalty = 6
 	accuracy = -0.1
@@ -1046,7 +1046,7 @@
 	empty_icon = "krootrifle"
 	far_fire_sound = "sniper_fire"
 	ammo_type = /obj/item/ammo_casing/krootbullet
-	fire_delay = 6
+	fire_delay = 5
 	move_delay= 2
 	one_hand_penalty = 7
 	accuracy = -0.2

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -368,7 +368,7 @@
 	force = 10
 	caliber = ".75"
 	accuracy = -0.3 
-	fire_delay = 2.1
+	fire_delay = 1.8
 	move_delay = 1
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/bolt_pistol_magazine

--- a/maps/battle/jobs/guardsmen.dm
+++ b/maps/battle/jobs/guardsmen.dm
@@ -12,7 +12,7 @@
 		)
 	selection_color = "#33813A"
 	department_flag = SEC
-	open_when_dead = TRUE
+	open_when_dead = FALSE
 	announced = FALSE
 	can_be_in_squad = TRUE
 	latejoin_at_spawnpoints = TRUE
@@ -145,7 +145,7 @@
 	H.warfare_language_shit(LANGUAGE_LOW_GOTHIC)
 	H.get_idcard()?.access = get_all_accesses()
 	H.warfare_faction = IMPERIUM
-	to_chat(H, "<span class='notice'><b><font size=3>You are an Imperial Commissar. You are the acting head of the Guard force on this planet. The mission is all, maintain morale and maintain discipline. Do not be afraid to execute an unruly guardsmen. </font></b></span>")
+	to_chat(H, "<span class='notice'><b><font size=3>The commissar is empowered to use any means necessary to ensure the loyalty and moral purity of his or her charges, including overriding or even executing a regiment's commanding officer if necessary, and so is regarded with a mixture of fear and admiration by rank-and-file Guardsmen -- and not a few of their officers. Commissars provide the link between regimental officers and the Departmento Munitorum. They are tough, ruthless individuals whose primary responsibilities are to preserve the courage, discipline and loyalty of the regiment. Only a handful of commissars have ever obtained leadership over large Imperial forces as a lord commander, or even a governor militant, such as Yarrick at Armageddon, and only a handful are known to have even retained full command of an entire regiment, such as Colonel-Commissar Ibram Gaunt. All commissars are trained as excellent orators, and often deliver stirring speeches to their regiment or company prior to battle. During battle, the commissar is almost always amongst the front lines, and roars a litany of battle cries and prayers to the Emperor to inspire his troops to battle. </font></b></span>")
 	var/obj/O = H.get_equipped_item(slot_s_store)
 	if(O)
 		qdel(O)
@@ -172,7 +172,7 @@
 	engineering_skill = 1
 	surgery_skill = 1
 	can_be_in_squad = FALSE
-	open_when_dead = TRUE
+	open_when_dead = FALSE
 	department_flag = SEC
 	latejoin_at_spawnpoints = TRUE
 	access = list(access_security, access_sec_doors, access_brig, access_forensics_lockers,

--- a/maps/battle/jobs/pilgrims.dm
+++ b/maps/battle/jobs/pilgrims.dm
@@ -262,7 +262,7 @@ Pilgrim Fate System
 	back = /obj/item/storage/backpack/satchel/warfare
 	neck = /obj/item/reagent_containers/food/drinks/canteen
 	head = /obj/item/clothing/head/bardhat
-	l_ear = null
+	l_ear = /obj/item/device/radio/headset/red_team
 	r_ear = null
 	pda_slot = null
 	shoes = /obj/item/clothing/shoes/vigilante

--- a/maps/delta/jobs/guardsmen.dm
+++ b/maps/delta/jobs/guardsmen.dm
@@ -13,7 +13,7 @@
 		)
 	selection_color = "#33813A"
 	department_flag = SEC
-	open_when_dead = TRUE
+	open_when_dead = FALSE
 	announced = FALSE
 	can_be_in_squad = TRUE
 	latejoin_at_spawnpoints = TRUE
@@ -70,7 +70,7 @@
 		)
 	can_be_in_squad = FALSE //They have snowflake shit for squads.
 	department_flag = SEC
-	open_when_dead = TRUE
+	open_when_dead = FALSE
 	latejoin_at_spawnpoints = TRUE
 	access = list(access_security, access_sec_doors, access_brig, access_forensics_lockers,
 			access_all_personal_lockers, access_maint_tunnels, access_guard_armory, access_armory)
@@ -144,7 +144,7 @@
 	H.warfare_language_shit(LANGUAGE_LOW_GOTHIC)
 	H.get_idcard()?.access = get_all_accesses()
 	H.warfare_faction = IMPERIUM
-	to_chat(H, "<span class='notice'><b><font size=3>You are an Imperial Commissar. You are the acting head of the Guard force on this planet. The mission is all, maintain morale and maintain discipline. Do not be afraid to execute an unruly guardsmen. </font></b></span>")
+	to_chat(H, "<span class='notice'><b><font size=3>The commissar is empowered to use any means necessary to ensure the loyalty and moral purity of his or her charges, including overriding or even executing a regiment's commanding officer if necessary, and so is regarded with a mixture of fear and admiration by rank-and-file Guardsmen -- and not a few of their officers. Commissars provide the link between regimental officers and the Departmento Munitorum. They are tough, ruthless individuals whose primary responsibilities are to preserve the courage, discipline and loyalty of the regiment. Only a handful of commissars have ever obtained leadership over large Imperial forces as a lord commander, or even a governor militant, such as Yarrick at Armageddon, and only a handful are known to have even retained full command of an entire regiment, such as Colonel-Commissar Ibram Gaunt. All commissars are trained as excellent orators, and often deliver stirring speeches to their regiment or company prior to battle. During battle, the commissar is almost always amongst the front lines, and roars a litany of battle cries and prayers to the Emperor to inspire his troops to battle. </font></b></span>")
 	var/obj/O = H.get_equipped_item(slot_s_store)
 	if(O)
 		qdel(O)

--- a/maps/delta/jobs/pilgrims.dm
+++ b/maps/delta/jobs/pilgrims.dm
@@ -262,7 +262,7 @@ Pilgrim Fate System
 	back = /obj/item/storage/backpack/satchel/warfare
 	neck = /obj/item/reagent_containers/food/drinks/canteen
 	head = /obj/item/clothing/head/bardhat
-	l_ear = null
+	l_ear = /obj/item/device/radio/headset/red_team
 	r_ear = null
 	pda_slot = null
 	shoes = /obj/item/clothing/shoes/vigilante

--- a/maps/delta/warhammer-1.dmm
+++ b/maps/delta/warhammer-1.dmm
@@ -73,7 +73,6 @@
 /obj/effect/floor_decal/turf/checkers/two,
 /obj/structure/table/rack/dark,
 /obj/item/mortar_launcher,
-/obj/random/loot/goodweapon,
 /turf/simulated/floor/tiled/dark,
 /area/cadiaoutpost/oa/security)
 "ao" = (
@@ -807,10 +806,9 @@
 /area/cadiaoutpost/oa/caves/dark)
 "eH" = (
 /obj/structure/table/rack/dark,
-/obj/item/defensive_barrier,
-/obj/item/defensive_barrier,
-/obj/item/defensive_barrier,
 /obj/effect/floor_decal/turf/checkers/two,
+/obj/item/ammo_magazine/melta,
+/obj/item/ammo_magazine/melta,
 /turf/simulated/floor/tiled/dark,
 /area/cadiaoutpost/oa/security)
 "eK" = (
@@ -1757,6 +1755,19 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/caves/dark)
+"kR" = (
+/obj/structure/table/rack/dark,
+/obj/item/defensive_barrier,
+/obj/item/defensive_barrier,
+/obj/item/defensive_barrier,
+/obj/effect/floor_decal/turf/checkers/two,
+/obj/item/defensive_barrier,
+/obj/item/defensive_barrier,
+/obj/item/defensive_barrier,
+/obj/item/defensive_barrier,
+/obj/item/defensive_barrier,
+/turf/simulated/floor/tiled/dark,
+/area/cadiaoutpost/oa/security)
 "kS" = (
 /obj/effect/floor_decal/turf/plating,
 /obj/item/archaeological_find/remains/xeno{
@@ -1863,6 +1874,15 @@
 "lm" = (
 /turf/simulated/floor/dirty,
 /area/cadiaoutpost/oa/caves)
+"lp" = (
+/obj/structure/table/rack/dark,
+/obj/effect/floor_decal/turf/checkers/two,
+/obj/item/gun/energy/las/lasgun/tinkered/catachan,
+/obj/item/gun/projectile/automatic/flamer,
+/obj/random/loot/goodweapon,
+/obj/random/loot/goodweapon,
+/turf/simulated/floor/tiled/dark,
+/area/cadiaoutpost/oa/security)
 "lq" = (
 /obj/structure/sewers/pipeflow,
 /turf/simulated/wall/ancient{
@@ -2536,6 +2556,15 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/caves/undercity)
+"pq" = (
+/obj/effect/floor_decal/turf/checkers/two,
+/obj/machinery/door/airlock/highsecurity/imperiumdoor{
+	maxhealth = 3000;
+	name = "Imperialis Doorway - Armory";
+	req_access = list(330)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/cadiaoutpost/oa/security)
 "ps" = (
 /obj/effect/wingrille_spawn/reinforced{
 	color = "grey"
@@ -2643,11 +2672,20 @@
 	icon_state = "spline_plain"
 	},
 /obj/structure/table/steel,
-/obj/item/clothing/suit/armor/militia,
-/obj/item/clothing/suit/armor/militia,
-/obj/item/clothing/suit/cloak,
+/obj/item/clothing/suit/armor/militia{
+	name = "Frateris Armor"
+	},
 /obj/item/clothing/head/helmet/salvage,
 /obj/item/clothing/head/helmet/salvage,
+/obj/item/clothing/suit/armor/militia{
+	name = "Frateris Armor"
+	},
+/obj/item/clothing/suit/armor/militia{
+	name = "Frateris Armor"
+	},
+/obj/item/clothing/suit/armor/militia{
+	name = "Frateris Armor"
+	},
 /turf/simulated/floor/stone/chapel,
 /area/cadiaoutpost/oa/service/chapel)
 "pP" = (
@@ -2786,6 +2824,15 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/caves/dark)
+"qr" = (
+/obj/effect/floor_decal/turf/checkers/two,
+/obj/machinery/door/airlock/highsecurity/imperiumdoor{
+	maxhealth = 3000;
+	name = "Imperialis Doorway - Armory";
+	req_access = list(63)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/cadiaoutpost/oa/security)
 "qs" = (
 /obj/effect/floor_decal/turf/splate,
 /obj/effect/floor_decal/industrial/warning{
@@ -2890,6 +2937,11 @@
 /obj/item/mortar_shell/flare,
 /obj/item/mortar_shell/flare,
 /obj/structure/table/rack/dark,
+/obj/item/card/id/innkey3{
+	name = "Armory Key";
+	req_access = list(330);
+	access = list(330)
+	},
 /turf/simulated/floor/tiled/dark,
 /area/cadiaoutpost/oa/security)
 "qZ" = (
@@ -3038,7 +3090,6 @@
 /obj/effect/floor_decal/spline/plain,
 /obj/random/loot/badweapon,
 /obj/random/loot/badweapon,
-/obj/random/loot/badweapon,
 /turf/simulated/floor/stone/chapel,
 /area/cadiaoutpost/oa/service/chapel)
 "sc" = (
@@ -3143,8 +3194,6 @@
 /obj/effect/floor_decal/turf/checkers/two,
 /obj/item/grenade/fire,
 /obj/item/grenade/frag/warfare,
-/obj/item/ammo_magazine/melta,
-/obj/item/ammo_magazine/melta,
 /turf/simulated/floor/tiled/dark,
 /area/cadiaoutpost/oa/security)
 "sH" = (
@@ -3824,6 +3873,11 @@
 /obj/structure/table/steel_reinforced,
 /obj/item/flame/candle/dinner,
 /obj/item/material/sword/commissword,
+/obj/item/card/id/innkey3{
+	name = "Master Key";
+	req_access = list(331);
+	access = list(331,330,225)
+	},
 /turf/simulated/floor/tiled/dark,
 /area/cadiaoutpost/oa/security)
 "wf" = (
@@ -4046,9 +4100,8 @@
 /turf/simulated/floor/tiled,
 /area/cadiaoutpost/oa/caves/dark)
 "yd" = (
-/obj/structure/table/rack/dark,
-/obj/effect/floor_decal/turf/checkers/two,
-/obj/item/gun/projectile/automatic/flamer,
+/obj/effect/floor_decal/turf/splate,
+/obj/item/clothing/accessory/holster/armpit,
 /turf/simulated/floor/tiled/dark,
 /area/cadiaoutpost/oa/security)
 "ye" = (
@@ -4083,6 +4136,13 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/caves/dark)
+"yo" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/turf/checkers/two,
+/obj/random/loot/heavystubber,
+/obj/random/loot/heavystubber,
+/turf/simulated/floor/tiled/dark,
+/area/cadiaoutpost/oa/security)
 "yw" = (
 /obj/effect/floor_decal/turf/plating,
 /obj/structure/sign/warning/detailed{
@@ -5485,6 +5545,12 @@
 	color = "grey"
 	},
 /obj/effect/floor_decal/turf/checkers/two,
+/obj/item/card/id/innkey3{
+	name = "Armory Key";
+	req_access = list(330);
+	access = list(330)
+	},
+/obj/item/clothing/accessory/holster/armpit,
 /turf/simulated/floor/tiled/dark,
 /area/cadiaoutpost/oa/security)
 "Gi" = (
@@ -5596,6 +5662,7 @@
 	color = "grey"
 	},
 /obj/item/clothing/head/helmet,
+/obj/item/clothing/accessory/holster/armpit,
 /turf/simulated/floor/tiled/dark,
 /area/cadiaoutpost/oa/security)
 "GR" = (
@@ -6388,6 +6455,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/cadiaoutpost/oa/caves/dark)
+"KR" = (
+/obj/structure/table/rack/dark,
+/obj/effect/floor_decal/turf/checkers/two,
+/obj/random/loot/guardhelmet,
+/obj/random/loot/guardhelmet,
+/obj/random/loot/guardhelmet,
+/obj/random/loot/guardhelmet,
+/obj/random/loot/guardhelmet,
+/turf/simulated/floor/tiled/dark,
+/area/cadiaoutpost/oa/security)
 "KU" = (
 /obj/structure/torchwall/service{
 	dir = 1;
@@ -6458,7 +6535,6 @@
 /obj/structure/table/rack/dark,
 /obj/item/wrench,
 /obj/effect/floor_decal/turf/checkers/two,
-/obj/item/gun/energy/las/lasgun/tinkered/catachan,
 /obj/item/crowbar,
 /obj/item/crowbar,
 /obj/item/wrench,
@@ -7037,8 +7113,7 @@
 /obj/structure/table/steel_reinforced,
 /obj/effect/floor_decal/turf/checkers/two,
 /obj/random/loot/guardarmor,
-/obj/random/loot/guardhelmet,
-/obj/random/loot/guardhelmet,
+/obj/random/loot/guardarmor,
 /turf/simulated/floor/tiled/dark,
 /area/cadiaoutpost/oa/security)
 "OX" = (
@@ -7111,6 +7186,7 @@
 	},
 /obj/item/melee/baton,
 /obj/item/melee/baton,
+/obj/random/loot/heavymelee,
 /obj/random/loot/heavymelee,
 /turf/simulated/floor/stone/chapel,
 /area/cadiaoutpost/oa/service/chapel)
@@ -7330,7 +7406,7 @@
 /obj/machinery/door/airlock/highsecurity/imperiumdoor{
 	maxhealth = 3000;
 	name = "Imperialis Doorway - Armory";
-	req_access = list(67)
+	req_access = list(63)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/cadiaoutpost/oa/security)
@@ -8749,8 +8825,6 @@
 	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/turf/checkers/two,
-/obj/random/loot/heavystubber,
-/obj/random/loot/heavystubber,
 /obj/random/loot/heavystubberammo,
 /obj/random/loot/heavystubberammo,
 /obj/random/loot/heavystubberammo,
@@ -28440,7 +28514,7 @@ Jm
 dj
 et
 dj
-yd
+am
 dj
 tc
 dj
@@ -29213,7 +29287,7 @@ ED
 dj
 Cn
 dj
-am
+KR
 dj
 dj
 Ku
@@ -29726,7 +29800,7 @@ Ez
 Ez
 Ez
 Ez
-hg
+qr
 Ez
 Ez
 Ez
@@ -29977,10 +30051,10 @@ PI
 PI
 eD
 Ez
-eH
+kR
 dj
 dj
-hg
+pq
 uX
 EB
 dj
@@ -30234,7 +30308,7 @@ PI
 PI
 eD
 Ez
-eH
+lp
 dj
 ON
 Ez
@@ -30493,7 +30567,7 @@ eD
 Ez
 eH
 dj
-ON
+yo
 Ez
 KG
 dj
@@ -31293,7 +31367,7 @@ Ez
 ee
 lc
 rF
-Xz
+yd
 Ez
 eD
 PI

--- a/maps/delta/warhammer-2.dmm
+++ b/maps/delta/warhammer-2.dmm
@@ -726,6 +726,7 @@
 	name = "Magistratum Enforcer"
 	},
 /obj/item/stack/thrones2,
+/obj/item/clothing/accessory/storage/webbing_large,
 /turf/simulated/floor/wood{
 	color = "grey"
 	},
@@ -1059,19 +1060,6 @@
 /obj/random/shoes,
 /obj/item/device/radio/headset/red_team/voxcaster,
 /obj/effect/floor_decal/turf/carpetn00,
-/obj/item/card/id/ring/disgracedmedicae{
-	access = list(213);
-	name = "Frateris"
-	},
-/obj/item/card/id/ring/disgracedmedicae{
-	access = list(213);
-	name = "Frateris"
-	},
-/obj/item/card/id/ring/disgracedmedicae{
-	access = list(213);
-	desc = "An old ring signifying your position as a member of the Frateris Militia.";
-	name = "Frateris"
-	},
 /obj/item/stack/thrones/ten,
 /obj/item/stack/thrones/ten,
 /obj/item/card/id/innkey3{
@@ -1086,6 +1074,7 @@
 	access = list(333);
 	name = "monastary key"
 	},
+/obj/item/stamp/chameleon,
 /turf/simulated/floor/stone/chapel,
 /area/cadiaoutpost/oa/service/chapel)
 "cE" = (
@@ -2545,13 +2534,26 @@
 /turf/simulated/floor/tiled/dark,
 /area/cadiaoutpost/oa/gatehouse)
 "gp" = (
+/obj/effect/floor_decal/turf/brick,
+/obj/effect/floor_decal/turf/carpetn00,
 /obj/item/card/id/ring/disgracedmedicae{
 	access = list(213);
-	desc = "An old ring signifying your position as a member of the Frateris Militia.";
 	name = "Frateris"
 	},
-/turf/unsimulated/miningtime,
-/area/cadiaoutpost/oa/caves)
+/obj/item/card/id/ring/disgracedmedicae{
+	access = list(213);
+	name = "Frateris"
+	},
+/obj/item/card/id/ring/disgracedmedicae{
+	access = list(213);
+	name = "Frateris"
+	},
+/obj/item/card/id/ring/disgracedmedicae{
+	access = list(213);
+	name = "Frateris"
+	},
+/turf/simulated/floor/stone/chapel,
+/area/cadiaoutpost/oa/service/chapel)
 "gq" = (
 /obj/structure/table/woodentable{
 	color = "#36261B"
@@ -3151,6 +3153,7 @@
 	name = "Magistratum Enforcer"
 	},
 /obj/item/storage/box/ifak,
+/obj/item/clothing/accessory/storage/webbing_large,
 /turf/simulated/floor/wood{
 	color = "grey"
 	},
@@ -3830,6 +3833,7 @@
 /obj/structure/sign/magistrate{
 	pixel_x = -30
 	},
+/obj/item/clothing/accessory/storage/webbing_large,
 /turf/simulated/floor/wood{
 	color = "grey"
 	},
@@ -4303,7 +4307,10 @@
 /area/cadiaoutpost/oa/villageinside)
 "kL" = (
 /obj/structure/undies_wardrobe,
-/obj/item/clothing/suit/armor/guardsman/mercenary,
+/obj/item/clothing/suit/armor/guardsman/mercenary{
+	armor = list("melee" = 56, "bullet" = 40, "laser" = 54, "energy" = 20, "bomb" = 30, "bio" = 10, "rad" = 20);
+	name = "Heavy Flak Plate"
+	},
 /turf/simulated/floor/wood{
 	color = "grey"
 	},
@@ -4627,6 +4634,7 @@
 	dir = 8
 	},
 /obj/random/loot/randomammo,
+/obj/item/clothing/accessory/storage/webbing_large,
 /turf/simulated/floor/tiled/dark{
 	color = "grey"
 	},
@@ -4688,10 +4696,10 @@
 	dir = 4
 	},
 /obj/structure/closet/crate/freezer/rations,
-/obj/random/loot/lightlasgun,
 /obj/random/loot/guardarmor,
 /obj/random/loot/guardgear,
 /obj/random/loot/guardhelmet,
+/obj/random/loot/goodweapon,
 /turf/simulated/floor/tiled{
 	color = "grey"
 	},
@@ -5097,9 +5105,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/turf/barnew,
-/obj/effect/mine/stun{
-	color = "grey"
-	},
 /obj/item/reagent_containers/food/snacks/poo,
 /turf/simulated/floor/tiled/dark{
 	color = "grey"
@@ -5811,6 +5816,7 @@
 "oE" = (
 /obj/structure/table/rack,
 /obj/random/maintenance,
+/obj/random/accessory,
 /turf/simulated/floor/wood{
 	color = "grey"
 	},
@@ -6158,6 +6164,7 @@
 	color = "grey"
 	},
 /obj/item/device/radio/headset/red_team,
+/obj/random/accessory,
 /turf/simulated/floor/wood,
 /area/cadiaoutpost/oa/villageinside)
 "pD" = (
@@ -6605,6 +6612,8 @@
 /area/cadiaoutpost/oa/tradefloor)
 "sA" = (
 /obj/structure/new_ore_box,
+/obj/random/loot/randomammo,
+/obj/random/loot/randomammo,
 /turf/simulated/floor/stone,
 /area/cadiaoutpost/oa/caves)
 "sD" = (
@@ -6677,12 +6686,19 @@
 	},
 /area/cadiaoutpost/oa/service/inn)
 "tm" = (
-/obj/item/card/id/innkey2{
-	access = list(212);
-	name = "rusty key 3"
+/obj/structure/bed{
+	desc = "A mass produced sleeping mat, now with actual cloth!";
+	icon_state = "bed_padding1";
+	name = "sleeping mat"
 	},
-/turf/simulated/floor/snow,
-/area/cadiaoutpost/oa/theforest)
+/obj/effect/floor_decal/newcorner/plating/corner{
+	dir = 8
+	},
+/obj/item/clothing/accessory/storage/webbing_large,
+/turf/simulated/floor/tiled/dark{
+	color = "grey"
+	},
+/area/cadiaoutpost/oa/village)
 "tn" = (
 /obj/effect/floor_decal/turf/checkers,
 /obj/structure/table/rack,
@@ -6793,6 +6809,7 @@
 /obj/item/remains/human{
 	color = "grey"
 	},
+/obj/random/accessory,
 /turf/simulated/floor/stone,
 /area/cadiaoutpost/oa/caves)
 "ui" = (
@@ -6806,6 +6823,10 @@
 	dir = 4
 	},
 /obj/item/stack/thrones3/five,
+/obj/item/card/id/innkey2{
+	access = list(212);
+	name = "rusty key 3"
+	},
 /turf/simulated/floor/tiled{
 	color = "grey"
 	},
@@ -6853,6 +6874,11 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/villageinside)
+"uT" = (
+/obj/effect/decal/remains,
+/obj/random/loot/randomarmor,
+/turf/simulated/floor/stone,
+/area/cadiaoutpost/oa/caves)
 "uV" = (
 /obj/structure/torchwall{
 	dir = 1;
@@ -6928,6 +6954,7 @@
 /obj/item/remains/human{
 	color = "grey"
 	},
+/obj/random/loot/badweapon,
 /turf/simulated/floor/stone,
 /area/cadiaoutpost/oa/caves)
 "vx" = (
@@ -7203,6 +7230,7 @@
 "xC" = (
 /obj/effect/floor_decal/turf/barnew,
 /obj/structure/closet/crate/bin,
+/obj/random/accessory,
 /turf/simulated/floor/tiled/dark,
 /area/cadiaoutpost/oa/service/inn)
 "xE" = (
@@ -7341,7 +7369,6 @@
 /area/cadiaoutpost/oa/service/bar)
 "yr" = (
 /obj/structure/bed/chair/office,
-/obj/effect/landmark/start/cargo,
 /obj/effect/floor_decal/newcorner/shaft/diagonal,
 /obj/effect/floor_decal/turf/metal,
 /turf/simulated/floor/tiled/dark,
@@ -7386,6 +7413,7 @@
 /obj/structure/closet/coffin{
 	color = "grey"
 	},
+/obj/random/accessory,
 /turf/simulated/floor/stone,
 /area/cadiaoutpost/oa/caves)
 "yB" = (
@@ -7612,6 +7640,8 @@
 /area/cadiaoutpost/oa/caves)
 "Ae" = (
 /obj/structure/largecrate,
+/obj/random/loot/randomammo,
+/obj/random/loot/randomammo,
 /turf/simulated/floor/stone,
 /area/cadiaoutpost/oa/caves)
 "Ag" = (
@@ -8222,8 +8252,10 @@
 /turf/simulated/floor/stone,
 /area/cadiaoutpost/oa/caves)
 "EV" = (
-/turf/simulated/wall/wood,
-/area/cadiaoutpost/oa/villageinside)
+/obj/effect/decal/remains,
+/obj/effect/landmark/animal/rnghostilespawner,
+/turf/simulated/floor/stone,
+/area/cadiaoutpost/oa/caves)
 "EY" = (
 /obj/structure/table/standard{
 	color = "grey";
@@ -8506,7 +8538,8 @@
 "HL" = (
 /obj/machinery/door/unpowered/inn/room2{
 	name = "locked room";
-	req_access = list(212)
+	req_access = list(212);
+	maxhealth = 3000
 	},
 /turf/simulated/floor/wood{
 	color = "grey"
@@ -8597,6 +8630,10 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/hallway/centralhall)
+"IG" = (
+/obj/random/accessory,
+/turf/simulated/floor/stone,
+/area/cadiaoutpost/oa/caves)
 "II" = (
 /obj/structure/torchwall{
 	dir = 4;
@@ -8640,7 +8677,6 @@
 	},
 /obj/effect/floor_decal/turf/brick/two,
 /obj/item/clothing/accessory/storage/webbing_large,
-/obj/random/loot/badweapon,
 /turf/simulated/floor/tiled/dark{
 	color = "grey"
 	},
@@ -8718,13 +8754,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/cadiaoutpost/oa/supply/cargo/warehouse)
 "JV" = (
-/obj/effect/floor_decal/newcorner/red/solid,
-/obj/structure/closet/secure_closet/guncabinet,
-/obj/random/loot/goodweapon,
-/turf/simulated/floor/tiled{
-	color = "grey"
+/mob/living/simple_animal/hostile/syndicate/ranged{
+	health = 250
 	},
-/area/cadiaoutpost/oa/service/bar)
+/turf/simulated/floor/stone,
+/area/cadiaoutpost/oa/caves)
 "JW" = (
 /obj/random/junk,
 /turf/simulated/floor/stone,
@@ -9095,6 +9129,9 @@
 /obj/item/melee/trench_axe,
 /obj/item/beartrap,
 /obj/item/beartrap,
+/obj/item/beartrap,
+/obj/item/beartrap,
+/obj/item/beartrap,
 /turf/simulated/floor/wood{
 	color = "grey"
 	},
@@ -9367,6 +9404,7 @@
 /obj/structure/closet/crate,
 /obj/item/stack/barbwire,
 /obj/item/stack/material/steel/ten,
+/obj/item/stack/barbwire,
 /turf/simulated/floor/wood{
 	color = "grey"
 	},
@@ -9519,6 +9557,7 @@
 /obj/random/loot/sidearmammo,
 /obj/random/loot/sidearmammo,
 /obj/random/loot/sidearmammo,
+/obj/item/clothing/accessory/holster/armpit,
 /turf/simulated/floor/tiled{
 	color = "grey"
 	},
@@ -9784,7 +9823,6 @@
 /area/cadiaoutpost/oa/caves)
 "RB" = (
 /obj/structure/bed/chair/office,
-/obj/effect/landmark/start/cargo,
 /obj/effect/floor_decal/newcorner/shaft/diagonal,
 /obj/effect/floor_decal/turf/metal/six,
 /turf/simulated/floor/tiled/dark,
@@ -10782,7 +10820,9 @@
 /turf/simulated/floor/stone,
 /area/cadiaoutpost/oa/caves)
 "YK" = (
-/obj/effect/landmark/start/qm,
+/obj/effect/landmark/start/qm{
+	name = "Munitorum Prefectus"
+	},
 /obj/structure/bed/chair{
 	dir = 8;
 	icon_state = "chair_preview"
@@ -10960,6 +11000,7 @@
 	name = "Magistratum Enforcer"
 	},
 /obj/item/storage/box/teargas,
+/obj/item/clothing/accessory/storage/webbing_large,
 /turf/simulated/floor/wood{
 	color = "grey"
 	},
@@ -13452,7 +13493,7 @@ xE
 rO
 rO
 ae
-Uj
+uT
 rO
 xE
 xE
@@ -21355,7 +21396,7 @@ xE
 xE
 xE
 xE
-gp
+xE
 xE
 xE
 rO
@@ -23421,7 +23462,7 @@ rO
 xE
 xE
 xE
-gp
+xE
 xE
 xE
 xE
@@ -28332,7 +28373,7 @@ fM
 fM
 jt
 kb
-vQ
+QS
 yh
 kb
 vQ
@@ -30865,7 +30906,7 @@ ro
 ro
 ro
 aY
-dJ
+gp
 dJ
 eg
 dD
@@ -37316,7 +37357,7 @@ kb
 vM
 ES
 ES
-lW
+tm
 kb
 ES
 Jr
@@ -37481,8 +37522,8 @@ ae
 xE
 xE
 xE
-xE
-rO
+ae
+ae
 aC
 ae
 rO
@@ -37736,9 +37777,9 @@ xE
 ae
 ae
 ae
-xE
-xE
-xE
+ae
+ae
+ae
 rO
 rO
 rO
@@ -47013,7 +47054,7 @@ mU
 TF
 EF
 AX
-JV
+SZ
 SZ
 TF
 XL
@@ -49335,10 +49376,10 @@ xE
 xE
 xE
 xE
-xE
-xE
-xE
-xE
+ae
+ae
+ae
+ae
 rO
 rO
 rO
@@ -49591,10 +49632,10 @@ rO
 xE
 xE
 xE
-xE
-xE
-xE
-xE
+ae
+ae
+ae
+ae
 xE
 xE
 xE
@@ -52479,17 +52520,17 @@ ro
 ro
 ro
 ro
-EV
-EV
-EV
-EV
-EV
-EV
-EV
-EV
-EV
-EV
-EV
+rf
+rf
+rf
+rf
+rf
+rf
+rf
+rf
+rf
+rf
+rf
 ro
 ro
 ro
@@ -52736,17 +52777,17 @@ ro
 ro
 ro
 NS
-EV
+rf
 kL
 nX
 WM
-EV
 mx
+rf
 mx
 Xz
 mx
 mx
-EV
+rf
 ro
 ro
 ro
@@ -52993,17 +53034,17 @@ ro
 ZH
 ro
 ro
-EV
-mx
-mx
-mx
-EV
+rf
 mx
 mx
 mx
 mx
+rf
 mx
-EV
+mx
+mx
+mx
+rf
 ro
 ro
 NS
@@ -53250,18 +53291,18 @@ NS
 ro
 ro
 ro
-EV
+rf
 mx
 mx
 mx
-EV
 mx
+rf
 Zq
 mx
 mx
 mx
-EV
-tm
+rf
+ro
 ro
 ro
 ro
@@ -53507,12 +53548,12 @@ ro
 ro
 ro
 ro
-EV
+rf
 mx
 mx
 mx
-EV
 mx
+rf
 mw
 mx
 mx
@@ -53764,17 +53805,17 @@ ro
 ro
 ro
 ro
-EV
+rf
+la
 mx
 mx
 mx
-EV
+rf
 mx
 mx
 mx
 mx
-mx
-EV
+rf
 ro
 ro
 NS
@@ -54021,17 +54062,17 @@ ro
 ro
 ro
 ro
-EV
+rf
+bB
 mx
 mx
 mx
-EV
+rf
 mx
 mx
 mx
 mx
-mx
-EV
+rf
 ro
 ro
 ro
@@ -54278,17 +54319,17 @@ ro
 ro
 ro
 ro
-EV
+rf
 Mf
 On
 mx
+mx
 gr
 mx
-bB
-la
+mx
 mx
 WM
-EV
+rf
 ro
 ro
 ro
@@ -54414,7 +54455,7 @@ ae
 rO
 rO
 aC
-ae
+ab
 ae
 ae
 rO
@@ -54535,17 +54576,17 @@ ro
 ro
 ro
 ro
-EV
-EV
-EV
-EV
-EV
-EV
-EV
-EV
-EV
-EV
-EV
+rf
+rf
+rf
+rf
+rf
+rf
+rf
+rf
+rf
+rf
+rf
 ro
 ro
 ro
@@ -66236,7 +66277,7 @@ ae
 rO
 rO
 rO
-Uj
+EV
 rO
 ae
 rO
@@ -67422,7 +67463,7 @@ rO
 oP
 vx
 ne
-FP
+xr
 rf
 xE
 xE
@@ -68193,7 +68234,7 @@ ae
 rO
 rO
 rO
-ae
+JV
 rO
 rO
 rO
@@ -69473,7 +69514,7 @@ ae
 ae
 ae
 xE
-ae
+JV
 xE
 xE
 xE
@@ -72288,7 +72329,7 @@ ae
 ae
 ae
 ae
-ae
+IG
 aC
 ae
 ae
@@ -74688,7 +74729,7 @@ xE
 xE
 xE
 xE
-ae
+av
 by
 xE
 xE
@@ -75458,9 +75499,9 @@ xE
 xE
 xE
 xE
+nt
 ae
-ae
-ae
+av
 xE
 xE
 ae

--- a/maps/delta/warhammer-3.dmm
+++ b/maps/delta/warhammer-3.dmm
@@ -3534,6 +3534,11 @@
 	pixel_w = 2;
 	pixel_x = 31
 	},
+/obj/item/card/id/innkey3{
+	name = "Master Key";
+	req_access = list(331);
+	access = list(331,330,225)
+	},
 /turf/simulated/floor/tiled/dark,
 /area/cadiaoutpost/oa/bridge/offices/magoserrant)
 "jD" = (
@@ -4137,13 +4142,10 @@
 /obj/structure/closet/secure_closet/hop{
 	color = "grey"
 	},
-/obj/item/card/id/innkey2{
-	access = list(225);
-	name = "storage key"
-	},
 /obj/item/card/id/innkey3{
-	name = "Vault Key";
-	req_access = list(331)
+	name = "Master Key";
+	req_access = list(331);
+	access = list(331,330,225)
 	},
 /turf/simulated/floor/wood{
 	color = "grey"

--- a/maps/delta/warhammer-4.dmm
+++ b/maps/delta/warhammer-4.dmm
@@ -18,6 +18,7 @@
 /obj/machinery/power/apc{
 	pixel_y = -32
 	},
+/obj/item/clothing/accessory/holster/armpit,
 /turf/simulated/floor/wood{
 	color = "grey"
 	},
@@ -426,10 +427,6 @@
 /obj/item/clothing/suit/armor/rtdrip,
 /obj/item/reagent_containers/food/drinks/bottle/amasecexpensive,
 /obj/item/clothing/glasses/cadiangoggles/elite,
-/obj/item/card/id/innkey2{
-	access = list(225);
-	name = "storage key"
-	},
 /obj/item/clothing/glasses/monocle,
 /obj/item/storage/pill_bottle/dexalin_plus,
 /obj/item/storage/pill_bottle/kelotane,
@@ -1873,6 +1870,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/cadiaoutpost/oa/bridge/hallway)
+"pF" = (
+/obj/structure/closet/secure_closet/guncabinet,
+/obj/random/loot/goodweapon,
+/turf/simulated/floor/tiled/dark{
+	color = "grey"
+	},
+/area/cadiaoutpost/oa/bridge/meetingroom)
 "qi" = (
 /obj/machinery/door/airlock/glass_command/rt{
 	color = null;
@@ -1887,8 +1891,9 @@
 /area/cadiaoutpost/oa/bridge/offices/roguetrader)
 "qo" = (
 /obj/item/card/id/innkey3{
-	name = "Vault Key";
-	req_access = list(331)
+	name = "Master Key";
+	req_access = list(331);
+	access = list(331,330,225)
 	},
 /turf/simulated/floor/wood{
 	color = "grey"
@@ -30047,7 +30052,7 @@ ai
 ai
 ai
 rr
-ym
+pF
 bc
 ct
 mm

--- a/maps/delta/warhammer-5.dmm
+++ b/maps/delta/warhammer-5.dmm
@@ -3103,6 +3103,8 @@
 /obj/random/loot/randomarmor,
 /obj/random/loot/randomarmor,
 /obj/random/loot/randomarmor,
+/obj/random/loot/randomarmor,
+/obj/random/loot/randomarmor,
 /turf/simulated/floor/tiled/dark,
 /area/cadiaoutpost/gma/inquisitoracolyte)
 "ul" = (
@@ -3440,8 +3442,6 @@
 	name = "Lectitio Divinitatus"
 	},
 /obj/item/clothing/mask/chameleon,
-/obj/item/clothing/under/chameleon,
-/obj/item/clothing/head/chameleon,
 /turf/simulated/floor/tiled/dark,
 /area/cadiaoutpost/gma/inquisitoracolyte)
 "zd" = (
@@ -3922,6 +3922,13 @@
 /obj/structure/table/steel,
 /obj/item/clothing/suit/armor/guardsman,
 /obj/item/clothing/suit/armor/guardsman,
+/obj/item/clothing/under/cadian_uniform,
+/obj/item/clothing/under/cadian_uniform,
+/obj/item/clothing/under/rank/roboticist,
+/obj/item/clothing/under/syndicate,
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/clothing/under/wedding/bride_red,
+/obj/item/clothing/under/rank/seneschal,
 /turf/simulated/floor/tiled/dark,
 /area/cadiaoutpost/gma/inquisitoracolyte)
 "FF" = (
@@ -4336,8 +4343,6 @@
 	desc = "The Emperor once walked among men, but He is, and always has been, a god. The Emperor is the one true god, regardless of what past faiths any human may have worshipped. To purge the heretic, beware the psyker and mutant, and abhor the alien. Every human being has a place within the Emperor's divine order. To unquestionably obey the authority of the Imperial government and one's superiors.";
 	name = "Lectitio Divinitatus"
 	},
-/obj/item/clothing/under/chameleon,
-/obj/item/clothing/head/chameleon,
 /turf/simulated/floor/tiled/dark,
 /area/cadiaoutpost/gma/inquisitoracolyte)
 "LU" = (
@@ -4936,8 +4941,6 @@
 	desc = "The Emperor once walked among men, but He is, and always has been, a god. The Emperor is the one true god, regardless of what past faiths any human may have worshipped. To purge the heretic, beware the psyker and mutant, and abhor the alien. Every human being has a place within the Emperor's divine order. To unquestionably obey the authority of the Imperial government and one's superiors.";
 	name = "Lectitio Divinitatus"
 	},
-/obj/item/clothing/under/chameleon,
-/obj/item/clothing/head/chameleon,
 /turf/simulated/floor/tiled/dark,
 /area/cadiaoutpost/gma/inquisitoracolyte)
 "Ua" = (

--- a/maps/warhammer/jobs/pilgrims.dm
+++ b/maps/warhammer/jobs/pilgrims.dm
@@ -262,7 +262,7 @@ Pilgrim Fate System
 	back = /obj/item/storage/backpack/satchel/warfare
 	neck = /obj/item/reagent_containers/food/drinks/canteen
 	head = /obj/item/clothing/head/bardhat
-	l_ear = null
+	l_ear = /obj/item/device/radio/headset/red_team
 	r_ear = null
 	pda_slot = null
 	shoes = /obj/item/clothing/shoes/vigilante


### PR DESCRIPTION
Late Party spawns at 40 minutes instead of 30.

Lots of small map edits, such as adding the Master Key for certain roles - loot changes. Deacon gets a fancy stamp. Frateris badges displayed properly.

Shovel digs trenches much slower, but filling in time is still the same.

Munitorium Menial is removed. Nobody plays it. 

Munitorium Tribunus replaced with Prefectus.

Spawns for civilian roles changed to have more slots.

Removed GRIM Autogun until it is fixed from spawns.

Imperial Guard slots reduced and they no longer regenerate slots on death.

Whiteshield renamed to Conscript. Slots reduced to 4.

Added new spawn text for certain roles.

Fixed Medicae spawning with Tau Headsets.

Automatic Weapons fire much faster now instead of being stupid slow.

Lasguns Power Use is balanced. Old lasguns had a very weird comparison.