### PR TITLE
Tyranid Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/species/races/nids.dm
+++ b/code/modules/mob/living/carbon/human/species/races/nids.dm
@@ -10,16 +10,14 @@
 	min_age = 50
 	max_age = 800
 	gluttonous = GLUT_ITEM_NORMAL
-	total_health = 250
+	total_health = 400
 	mob_size = MOB_MEDIUM
 	strength = STR_VHIGH
 	teeth_type = /obj/item/stack/teeth/human //til I get cool nid teeth
 	sexybits_location = BP_GROIN
 	inherent_verbs = list(
 	/mob/living/carbon/human/genestealer/verb/convert,
-	/mob/living/carbon/human/genestealer/proc/neurotoxin,
 	/mob/living/carbon/human/genestealer/proc/makepool,
-	/mob/living/carbon/human/genestealer/proc/ripperswarm,
 	/mob/living/carbon/human/genestealer/proc/corrosive_acid,
 	/mob/living/carbon/human/genestealer/proc/givestealerstats,
 	/mob/living/carbon/human/genestealer/proc/gsheal,
@@ -51,7 +49,6 @@
 	death_message = "lets out a waning guttural screech, green blood bubbling from its maw."
 	death_sound = 'sound/voice/hiss6.ogg'
 
-	speech_sounds = list('sound/voice/hiss1.ogg','sound/voice/hiss2.ogg','sound/voice/hiss3.ogg','sound/voice/hiss4.ogg')
 	speech_chance = 100
 
 	breath_type = null
@@ -69,7 +66,7 @@
 
 /mob/living/carbon/human
 	var/new_nid = SPECIES_TYRANID
-	var/biomass = 40
+	var/biomass = 80
 	var/isconverting = 0
 	var/dnastore = 0
 	var/poolparty = 0

--- a/code/modules/mob/living/carbon/human/species/races/nids.dm
+++ b/code/modules/mob/living/carbon/human/species/races/nids.dm
@@ -10,7 +10,7 @@
 	min_age = 50
 	max_age = 800
 	gluttonous = GLUT_ITEM_NORMAL
-	total_health = 400
+	total_health = 300
 	mob_size = MOB_MEDIUM
 	strength = STR_VHIGH
 	teeth_type = /obj/item/stack/teeth/human //til I get cool nid teeth
@@ -35,8 +35,8 @@
 	stomach_capacity = MOB_MEDIUM
 	darksight = 20
 
-	brute_mod = 0.25 // Hardened carapace.
-	burn_mod = 0.65    // Weak to fire.
+	brute_mod = 0.6 // Hardened carapace.
+	burn_mod = 0.7    // Weak to fire.
 
 
 	species_flags = SPECIES_FLAG_NO_SCAN | SPECIES_FLAG_NO_PAIN | SPECIES_FLAG_NO_SLIP | SPECIES_FLAG_NO_POISON | SPECIES_FLAG_NO_EMBED

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -297,17 +297,14 @@ var/global/list/sparring_attack_cache = list()
 	attack_noun = list("claw")
 	eye_attack_text = "blades"
 	eye_attack_text_victim = "daggers"
-	damage = 35
+	damage = 30
 	sharp = 1
-	edge = 1
 	attack_sound = 'sound/effects/nidslash.ogg'
 
 
 /datum/unarmed_attack/rendingclaws/show_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone, var/attack_damage)
 	var/obj/item/organ/external/affecting = target.get_organ(zone)
 	var/organ = affecting.name
-
-	attack_damage = rand(35,55) //lets crank this bad boy for nids
 
 	if(target == user)
 		user.visible_message("<span class='danger'>[user] [pick(attack_verb)] \himself in the [organ]!</span>")


### PR DESCRIPTION
Tyranids can no longer summon Ripper Snakes or Spit Neurotoxin which were both broken.

Tyranid Hissing sound removed so they can actually stealth.

Tyranid Health increased to 300. Brute/Burn resistances lowered.

Tyranid Melee damage reduced to 30+STR and removed Edge, more or less their damage is equal to a human using a Power Sword now but they attack faster.