### PR TITLE
Description Changes for Two things that needed it

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -776,7 +776,7 @@ obj/item/clothing/suit/armor
 
 /obj/item/clothing/suit/sisterofbattle/training
 	name = "Scholam Power Armor"
-	desc = "The Ancient and Deconsecrated Power Armour adorned by Scholam Progena during their training in Eipharius' Monastarium. Stripped of almost all iconography and with damaged plating, this suit mainly serves to acclimatize the Progena for Heavy Armour but is still formidable."
+	desc = "The Ancient and Deconsecrated Power Armour adorned by Scholam Progena during their training in Eipharius' Monastarium. Stripped of almost all iconography and with damaged plating, this suit mainly serves to acclimatize the Progena for Heavy Armour but is still formidable and has legible scriptures across it's surface speaking of The Beatie and her crusade across the Sabbat worlds."
 	icon_state = "ooml"
 	item_state = "ooml"
 	armor = list(melee = 55, bullet = 60, laser = 55, energy = 50, bomb = 60, bio = 100, rad = 50)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -776,10 +776,10 @@ obj/item/clothing/suit/armor
 
 /obj/item/clothing/suit/sisterofbattle/training
 	name = "Scholam Power Armor"
-	desc = "The Sacred and holy Power Armour adorned by Battle Sister of the Order Of The Ember Thorn, this particular pattern has been maintained for many terran centuries, with scriptures across all speaking to The Beatie and her crusade across the Sabbat worlds."
+	desc = "The Ancient and Deconsecrated Power Armour adorned by Scholam Progena during their training in Eipharius' Monastarium. Stripped of almost all iconography and with damaged plating, this suit mainly serves to acclimatize the Progena for Heavy Armour but is still formidable."
 	icon_state = "ooml"
 	item_state = "ooml"
-	armor = list(melee = 55, bullet = 60, laser = 55, energy = 50, bomb = 60, bio = 100, rad = 50) // This is power armor forged centuries ago and is for use by the Schola Progena who wish to become sisters of battle.
+	armor = list(melee = 55, bullet = 60, laser = 55, energy = 50, bomb = 60, bio = 100, rad = 50)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET
 	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -204,7 +204,7 @@
 
 /obj/item/clothing/under/guard/uniform/sisterofbattle
 	name = "Adepta Sororitas Bodysuit"
-	desc = "If you can inspect this, you're a coomer, do not ERP."
+	desc = "The bodysuit worn by Adepta Sororitas underneath their Power Armour."
 	armor = list(melee = 5, bullet = 5, laser = 5,energy = 5, bomb = 0, bio = 0, rad = 0)
 	siemens_coefficient = 0.9
 	species_restricted = list(SPECIES_HUMAN)


### PR DESCRIPTION
I changed the description for the Progena's Power Armor, and the Sister of Battle Body suit

For the Student Power Armour, it made more sense to distance it from power armor that WOULD be active in a combat zone, as this is old armor that has been restored to just functionality to train students in wearing heavy armor and caring for it


And for the Sister of Battle Bodysuit... As funny as it is calling people coomers, if we ever add the ability to inspect the equipment on people it wouldn't make much sense, and it does feel a little out of tone

![image](https://user-images.githubusercontent.com/48303989/183563876-9c74ede0-dc0b-4c09-99c0-833c22bbd56a.png)


Anyway here is the compile, even though it was a few text changes