### PR TITLE
Group lateparty 2.0

### DIFF
--- a/code/_global_vars/misc.dm
+++ b/code/_global_vars/misc.dm
@@ -2,6 +2,7 @@ GLOBAL_LIST_EMPTY(all_observable_events)
 
 GLOBAL_LIST_INIT(font_resources, list('fonts/Shage/Shage.ttf'))
 GLOBAL_LIST_INIT(latepartyoptions, list(""))
+GLOBAL_LIST_EMPTY(daparty) //This holds our late partiers
 
 GLOBAL_VAR_INIT(shit_left, 0)
 GLOBAL_VAR_INIT(piss_left, 0)
@@ -23,3 +24,4 @@ GLOBAL_VAR_INIT(partydelay, 18000)
 GLOBAL_VAR_INIT(thrones, 0) //used for cargo and reinforcement system, so it carries across computers
 GLOBAL_VAR_INIT(tax_rate, 0.15) //used for taxation
 GLOBAL_VAR_INIT(tithe_paid, 0) //did they pay their tithe or not yet?
+GLOBAL_VAR_INIT(partysize, 3)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -105,6 +105,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/generate_party,
 	/client/proc/choose_party,
 	/client/proc/delay_party,
+	/client/proc/partySize,
 
 )
 var/list/admin_verbs_ban = list(
@@ -1067,3 +1068,37 @@ var/list/admin_verbs_mentor = list(
 			message_admins("The lateparty has been disabled.")
 
 	feedback_add_details("admin_verb","XD") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+/client/proc/partySize() // Runs the pick proc should you need to
+	set category = "Fun"
+	set name = "Choose Party Size"
+	set desc = "Set the size of the party."
+
+	var/options = list("2", "Default(3)", "4", "5", "6", "8", "10") //lists all possible fates
+
+	var/chooseaparty = input("Choose the size of the late party", "Options") as null|anything in options
+
+	switch(chooseaparty)
+		if("2")
+			GLOB.partysize = 2
+			message_admins("The late party will have 2 attendees.")
+		if("Default(3)")
+			GLOB.partysize = 3
+			message_admins("The late party will have 3 attendees.")
+		if("4")
+			GLOB.partysize = 4
+			message_admins("The late party will have 4 attendees.")
+		if("5")
+			GLOB.partysize = 5
+			message_admins("The late party will have 5 attendees.")
+		if("6")
+			GLOB.partysize = 6
+			message_admins("The late party will have 6 attendees.")
+		if("8")
+			GLOB.partysize = 8
+			message_admins("The late party will have 8 attendees.")
+		if("10")
+			GLOB.partysize = 10
+			message_admins("The late party will have 10 attendees.")
+
+	feedback_add_details("admin_verb","YG") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/mob/observer/lateparty.dm
+++ b/code/modules/mob/observer/lateparty.dm
@@ -5,6 +5,7 @@
 	set name = "Late Party"
 	set desc= "Join a randomized late party picked from a list!"
 
+
 	if(world.time < GLOB.partydelay) //all this does is cause a delay so people can't suicide or observer and rush the base
 		switch(GLOB.partydelay)
 			if(18000)
@@ -23,95 +24,59 @@
 				to_chat(src, "Sorry guy, parties cancelled!")
 				return
 
-	if(GLOB.deployed == 1) //checks if a party has already been sent, can make this value higher if you wish to send more than one!
+	if(GLOB.deployed == 3) //checks if a party has already been sent, can make this value higher if you wish to send more than one!
 		to_chat(src, "The late party has already deployed!")
 		return
 
-	if(src.isreadied == 1) //not really used rn but could be useful if you ever wanna make people spawn in batches so they can opt out
-		to_chat(src,"<span class='warning'><b><font size=3>You leave the queue for the late party!</b></font size=3>")
-		src.isreadied = 0 //unreadies player
-		GLOB.partygang-- //subtracts from amount readied up
-		return
-	else
-		to_chat(src,"<span class='warning'><b><font size=3>You join the late party!</b></font size=3>")
+	if(src.isreadied == 0)
 		src.isreadied = 1 //readies player up
-		GLOB.partygang++ //adds to amount readied up
+		to_chat(src,"<span class='warning'><b><font size=3>You join the queue for the late party! [GLOB.daparty.len]/[GLOB.partysize] are ready!</b></font size=3>")
+		GLOB.daparty[usr.key] = usr.key
 
+		if(GLOB.daparty.len >= GLOB.partysize)
+			GLOB.deployed++
+			var/attendee
+			for(attendee in GLOB.daparty)
+				var/partyteam = input("Spawn as late party", "Randomly selected party!") as anything in GLOB.latepartyoptions //automagically puts them into whatever the pick proc chooses
 
-	switch(GLOB.partygang)
-		if(1)
-			src.say("I'm joining the late party 1/10 deployed!") //just speaks to deadchat quickly so 1. people know its open and 2. lets them know the amount of slots left.
-		if(2)
-			src.say("I'm joining the late party 2/10 deployed!")
-		if(3)
-			src.say("I'm joining the late party 3/10 deployed!")
-		if(4)
-			src.say("I'm joining the late party 4/10 deployed!")
-		if(5)
-			src.say("I'm joining the late party 5/10 deployed!")
-		if(6)
-			src.say("I'm joining the late party 6/10 deployed!")
-		if(7)
-			src.say("I'm joining the late party 7/10 deployed!")
-		if(8)
-			src.say("I'm joining the late party 8/10 deployed!")
-		if(9)
-			src.say("I'm joining the late party 9/10 deployed!")
-		if(10)
-			src.say("I'm joining the late party 10/10 deployed!")
-			GLOB.deployed++ //ensures that only 1 party can be sent
-		if(11)
-			src.say("I'm joining the late party 11/20 deployed! Admemes have opened another party!")
-		if(12)
-			src.say("I'm joining the late party 12/20 deployed!")
-		if(13)
-			src.say("I'm joining the late party 13/20 deployed!")
-		if(14)
-			src.say("I'm joining the late party 14/20 deployed!")
-		if(15)
-			src.say("I'm joining the late party 15/20 deployed!")
-		if(16)
-			src.say("I'm joining the late party 16/20 deployed!")
-		if(17)
-			src.say("I'm joining the late party 17/20 deployed!")
-		if(18)
-			src.say("I'm joining the late party 18/20 deployed!")
-		if(19)
-			src.say("I'm joining the late party 19/20 deployed!")
-		if(20)
-			src.say("I'm joining the late party 20/20 deployed! All slots are now filled!")
-			GLOB.deployed++ //ensures that only 1 party can be sent
+				switch(partyteam)
+					if("Kroot")
+						message_admins("[attendee] has joined the late party: Kroot.", 0) //msgs jannies
+						to_chat(usr, "<span class='warning'><b><font size=3>It's been a long flight, go to your Kroot tab and be sure to stretch!</b></font size=3>") //tells mob to do thing
+						usr.loc = get_turf(locate("landmark*krootstart")) //where they spawning
+						var/mob/living/carbon/human/kroot/new_character = new(usr.loc) // da mob
+						new_character.key = attendee //puts ghost in body with new key
+					if("Orkz")
+						message_admins("[attendee] has joined the late party: Orkz.", 0) //msgs jannies
+						to_chat(usr, "<span class='warning'><b><font size=3>It's been a long flight, go to your Ork tab and be sure to stretch!</b></font size=3>") //tells mob to do thing
+						usr.loc = get_turf(locate("landmark*orkstart")) //where they spawning
+						var/mob/living/carbon/human/ork/new_character = new(usr.loc) // da mob
+						new_character.key = attendee //puts ghost in body with new key
+					if("Tau")
+						message_admins("[attendee] has joined the late party: Tau.", 0) //msgs jannies
+						to_chat(usr, "<span class='warning'><b><font size=3>It has been a long flight but we have landed in Imperial space. Follow the Aun's orders. Assimilate this planet for the greater good! Check the Tau tab and remember your caste!</b></font size=3>") //tells mob to do thing
+						usr.loc = get_turf(locate("landmark*taustart")) //where they spawning
+						var/mob/living/carbon/human/tau/new_character = new(usr.loc)// da mob
+						new_character.key = attendee //puts ghost in body with new key
+					if("Genestealers")
+						message_admins("[attendee] has joined the late party: Genestealer.", 0) //msgs jannies
+						to_chat(usr, "<span class='warning'><b><font size=3>You are the point of the spear of the Great Devourer. Grow your following and undermine this planets defenses.</b></font size=3>") //tells mob to do thing
+						usr.loc = get_turf(locate("landmark*genestart")) //where they spawning
+						var/mob/living/carbon/human/genestealer/new_character = new(usr.loc)// da mob
+						new_character.key = attendee //puts ghost in body with new key
+		else
+			src.say("I'm joining the late party [GLOB.daparty.len]/[GLOB.partysize] are ready!")
+			return
+
+	else
+		src.isreadied = 0
+		to_chat(src,"<span class='warning'><b><font size=3>You leave the queue for the late party!</b></font size=3>")
+		GLOB.daparty -= usr.key
+		src.say("I'm leaving the party [GLOB.daparty.len]/[GLOB.partysize] are ready!")
+		return
 
 
 
-	var/partyteam = input("Spawn as late party", "Randomly selected party!") as anything in GLOB.latepartyoptions //automagically puts them into whatever the pick proc chooses
-
-	switch(partyteam)
-
-		//if("Kroot")
-			//message_admins("[usr.key] has joined the late party: Kroot.", 0) //msgs jannies
-			//to_chat(usr, "<span class='warning'><b><font size=3>It's been a long flight, go to your Kroot tab and be sure to stretch!</b></font size=3>") //tells mob to do thing
-			//usr.loc = get_turf(locate("landmark*krootstart")) //where they spawning
-			//var/mob/living/carbon/human/kroot/new_character = new(usr.loc) // da mob
-			//new_character.key = usr.key //puts ghost in body with new key
-		if("Orkz")
-			message_admins("[usr.key] has joined the late party: Orkz.", 0) //msgs jannies
-			to_chat(usr, "<span class='warning'><b><font size=3>It's been a long flight, go to your Ork tab and be sure to stretch!</b></font size=3>") //tells mob to do thing
-			usr.loc = get_turf(locate("landmark*orkstart")) //where they spawning
-			var/mob/living/carbon/human/ork/new_character = new(usr.loc) // da mob
-			new_character.key = usr.key //puts ghost in body with new key
-		if("Tau")
-			message_admins("[usr.key] has joined the late party: Tau.", 0) //msgs jannies
-			to_chat(usr, "<span class='warning'><b><font size=3>It has been a long flight but we have landed in Imperial space. Follow the Aun's orders. Assimilate this planet for the greater good! Check the Tau tab and remember your caste!</b></font size=3>") //tells mob to do thing
-			usr.loc = get_turf(locate("landmark*taustart")) //where they spawning
-			var/mob/living/carbon/human/tau/new_character = new(usr.loc)// da mob
-			new_character.key = usr.key //puts ghost in body with new key
-		if("Genestealers")
-			message_admins("[usr.key] has joined the late party: Genestealer.", 0) //msgs jannies
-			to_chat(usr, "<span class='warning'><b><font size=3>You are the point of the spear of the Great Devourer. Grow your following and undermine this planets defenses.</b></font size=3>") //tells mob to do thing
-			usr.loc = get_turf(locate("landmark*genestart")) //where they spawning
-			var/mob/living/carbon/human/genestealer/new_character = new(usr.loc)// da mob
-			new_character.key = usr.key //puts ghost in body with new key
 
 
 /hook/startup/proc/chooseparty() //chooses one party on startup


### PR DESCRIPTION
This adds a bit more warning and text to the steps of queuing as a group for the late party. 

It contains a new admin verb to control the party size, default is 3. 3 separate groups will be sent before an admin needs to intervene and allow more.