### PR TITLE
Cargo Fixes

### DIFF
--- a/code/modules/cargo/armor.dm
+++ b/code/modules/cargo/armor.dm
@@ -1,0 +1,107 @@
+/datum/cargo_entry/armor
+	category = "Armours"
+
+/datum/cargo_entry/armor/gasmask
+	name = "Gas Mask"
+	cost = 5
+	item_path = /obj/item/clothing/mask/gas/security
+
+/datum/cargo_entry/armor/webbing
+	name = "Webbing"
+	cost = 5
+	item_path = /obj/item/clothing/accessory/storage/webbing
+
+/datum/cargo_entry/armor/holster
+	name = "Holster"
+	cost = 15
+	item_path = /obj/item/clothing/accessory/holster/waist
+
+/datum/cargo_entry/armor/armorcoat
+	name = "Armored Coat"
+	cost = 34
+	item_path = /obj/item/clothing/suit/armor/militia
+
+/datum/cargo_entry/armor/armorcloak
+	name = "Armored Cloak"
+	cost = 37
+	item_path = /obj/item/clothing/suit/cloak
+
+/datum/cargo_entry/armor/explorator
+	name = "Explorator Armor"
+	cost = 41
+	item_path = /obj/item/clothing/suit/armor/explorer
+
+/datum/cargo_entry/armor/voidsuit
+	name = "Void Suit"
+	cost = 45
+	item_path = /obj/item/clothing/suit/space/void/engineering/salvage
+
+/datum/cargo_entry/armor/voidsuithelm
+	name = "Void Suit Helmet"
+	cost = 15
+	item_path = /obj/item/clothing/head/helmet/space/void/engineering/salvage
+
+/datum/cargo_entry/armor/voidsuitarmor
+	name = "Armored Void Suit"
+	cost = 95
+	item_path = /obj/item/clothing/suit/space/void/engineering
+
+/datum/cargo_entry/armor/voidsuitarmorhelm
+	name = "Armored Void Suit Helmet"
+	cost = 65
+	item_path = /obj/item/clothing/head/helmet/space/void/engineering/alt
+
+/datum/cargo_entry/armor/helmet
+	name = "Guard Flak Helmet"
+	cost = 15
+	item_path = /obj/item/clothing/head/helmet/guardhelmet
+
+/datum/cargo_entry/armor/garmor
+	name = "Guard Flak Armor"
+	cost = 50
+	item_path = /obj/item/clothing/suit/armor/guardsman
+
+/datum/cargo_entry/armor/mercflak
+	name = "Mercenary Flak Armor"
+	cost = 45
+	item_path = /obj/item/clothing/suit/armor/guardsman/mercenary
+
+/datum/cargo_entry/armor/cara
+	name = "Guard Carapace Armor"
+	cost = 110
+	item_path = /obj/item/clothing/suit/armor/guardsman/carapace
+
+/datum/cargo_entry/armor/mercspace
+	name = "Mercenary Carapace Armor"
+	cost = 100
+	item_path = /obj/item/clothing/suit/armor/guardsman/mercenary/carapace
+
+/datum/cargo_entry/armor/heavycombatarmor
+	name = "Heavy Combat Armor"
+	cost = 115
+	item_path = /obj/item/clothing/suit/storage/vest/merc
+
+/datum/cargo_entry/armor/belt
+	name = "Ammo Belt"
+	cost = 5
+	item_path = /obj/item/storage/belt/warfare
+
+/datum/cargo_entry/armor/nvg
+	name = "Night Vision Visor"
+	cost = 50
+	item_path = /obj/item/clothing/glasses/night
+
+/datum/cargo_entry/armor/val
+	name = "Valhallan Equipment Crate"
+	cost = 100
+	item_path = /obj/structure/closet/crate/valhallan
+
+/datum/cargo_entry/armor/krieg
+	name = "Krieg Equipment Crate"
+	cost = 100
+	item_path = /obj/structure/closet/crate/krieg
+
+/datum/cargo_entry/armor/excr
+	name = "Extended Operations Crate"
+	cost = 70
+	item_path = /obj/structure/closet/crate/operations

--- a/code/modules/cargo/categories/armor.dm
+++ b/code/modules/cargo/categories/armor.dm
@@ -21,12 +21,12 @@
 	cost = 34
 	item_path = /obj/item/clothing/suit/armor/militia
 
-/datum/cargo_entry/armor/armorcoat
+/datum/cargo_entry/armor/armorcloak
 	name = "Armored Cloak"
 	cost = 37
 	item_path = /obj/item/clothing/suit/cloak
 
-/datum/cargo_entry/armor/armorcoat
+/datum/cargo_entry/armor/explorator
 	name = "Explorator Armor"
 	cost = 41
 	item_path = /obj/item/clothing/suit/armor/explorer
@@ -36,17 +36,17 @@
 	cost = 45
 	item_path = /obj/item/clothing/suit/space/void/engineering/salvage
 
-/datum/cargo_entry/armor/voidsuit
+/datum/cargo_entry/armor/voidsuithelm
 	name = "Void Suit Helmet"
 	cost = 15
 	item_path = /obj/item/clothing/head/helmet/space/void/engineering/salvage
 
-/datum/cargo_entry/armor/voidsuit
+/datum/cargo_entry/armor/voidsuitarmor
 	name = "Armored Void Suit"
 	cost = 95
 	item_path = /obj/item/clothing/suit/space/void/engineering/salvage
 
-/datum/cargo_entry/armor/voidsuit
+/datum/cargo_entry/armor/voidsuitarmorhelm
 	name = "Armored Void Suit Helmet"
 	cost = 65
 	item_path = /obj/item/clothing/head/helmet/space/void/engineering/alt

--- a/code/modules/cargo/categories/blackmarket.dm
+++ b/code/modules/cargo/categories/blackmarket.dm
@@ -31,11 +31,6 @@
 	cost = 55
 	item_path = /obj/item/material/sword/chaosknife
 
-/datum/cargo_entry/bmarket/slaaneshknife
-	name = "Sla**sh Knife"
-	cost = 56
-	item_path = /obj/item/material/sword/chaosknife
-
 /datum/cargo_entry/bmarket/slaaneshsword
 	name = "Sla**sh Blade"
 	cost = 140
@@ -61,7 +56,7 @@
 	cost = 31
 	item_path = /obj/item/grenade/chem_grenade/metalfoam
 
-/datum/cargo_entry/bmarket/batterer
+/datum/cargo_entry/bmarket/taser
 	name = "Xenos Taser"
 	cost = 79
 	item_path = /obj/item/gun/energy/taser
@@ -71,12 +66,12 @@
 	cost = 100
 	item_path = /obj/item/storage/box/syndie_kit/imp_freedom
 
-/datum/cargo_entry/bmarket/freedomimplant
+/datum/cargo_entry/bmarket/compressionimplant
 	name = "Compression Implant Box"
 	cost = 100
 	item_path = /obj/item/storage/box/syndie_kit/imp_compress
 
-/datum/cargo_entry/bmarket/freedomimplant
+/datum/cargo_entry/bmarket/explosiveimplant
 	name = "Explosive Implant Box"
 	cost = 200
 	item_path = /obj/item/storage/box/syndie_kit/imp_explosive

--- a/code/modules/cargo/categories/melee.dm
+++ b/code/modules/cargo/categories/melee.dm
@@ -1,7 +1,7 @@
 /datum/cargo_entry/melee
 	category = "Melee"
 
-/datum/cargo_entry/melee/baton
+/datum/cargo_entry/melee/shieldriot
 	name = "Riot Shield"
 	cost = 25
 	item_path = /obj/item/shield/riot

--- a/code/modules/cargo/categories/melee.dm
+++ b/code/modules/cargo/categories/melee.dm
@@ -21,20 +21,10 @@
 	cost = 110
 	item_path = /obj/item/material/sword/combat_knife/catachan
 
-/datum/cargo_entry/melee/machete
-	name = "Machete"
-	cost = 15
-	item_path = /obj/item/material/sword/machete
-
 /datum/cargo_entry/melee/ironsword
 	name = "Iron Sword"
 	cost = 49
 	item_path = /obj/item/toy/katana
-
-/datum/cargo_entry/melee/saber
-	name = "Masterwork Saber"
-	cost = 50
-	item_path = /obj/item/material/sword/sabre
 
 /datum/cargo_entry/melee/saber2
 	name = "Officer's Saber"

--- a/code/modules/cargo/categories/weapons.dm
+++ b/code/modules/cargo/categories/weapons.dm
@@ -71,7 +71,7 @@
 	cost = 73
 	item_path = /obj/item/gun/projectile/shotgun/pump/boltaction/shitty/lp338
 
-/datum/cargo_entry/weapon/sniperrifle
+/datum/cargo_entry/weapon/sniperrifleheavy
 	name = "Heavy Sniper Rifle"
 	cost = 99
 	item_path = /obj/item/gun/projectile/heavysniper
@@ -211,7 +211,7 @@
 	cost = 8
 	item_path = /obj/item/ammo_magazine/box/shotgun/slug
 
-/datum/cargo_entry/weapon/riflemag
+/datum/cargo_entry/weapon/riflehandful
 	name = "Rifle Handful"
 	cost = 3
 	item_path = /obj/item/ammo_magazine/handful/brifle_handful


### PR DESCRIPTION
Fixes bad references and missing item sprites by removing the items added that did not have sprites such as Machete and Sabre.

![image](https://user-images.githubusercontent.com/58716873/185235516-25718624-a3e2-4d0a-a0a1-43d62924b748.png)
