### PR TITLE
Vice tweaks, better logging coverage

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -35,8 +35,8 @@ var/list/obj/item/device/uplink/world_uplinks = list()
 //Preferences stuff
 //Vices, make sure random is always last and that you update the rand length in 03_body to the length of your options. This will let us choose a random vice without getting assigned Random on spawn
 GLOBAL_LIST_INIT(vice_list, list(
-"Alcohol",
 "Lho",
+"Alcohol",
 "Obscura",
 "Piety",
 "Neat Freak",

--- a/code/game/jobs/job/adeptus_astartes.dm
+++ b/code/game/jobs/job/adeptus_astartes.dm
@@ -100,6 +100,7 @@
 		H.bladder = -INFINITY
 		H.bowels = -INFINITY //integrated shitter
 		H.adjustStaminaLoss(-INFINITY) //astartes have basically infinite fight in them
+		H.vice = null //off for now
 
 /datum/job/envoy/equip(var/mob/living/carbon/human/H)
 	. = ..()

--- a/code/game/jobs/job/adeptus_mechanicus.dm
+++ b/code/game/jobs/job/adeptus_mechanicus.dm
@@ -48,6 +48,7 @@
 		H.bowels = -INFINITY //he's too heavily modified to require things like a toilet
 		H.thirst = INFINITY
 		H.nutrition = INFINITY //he is sustained by the Omnissiah, he requires neither food nor drink
+		H.vice = null //off for now
 
 
 
@@ -89,6 +90,7 @@
 		H.bowels = -INFINITY //he's too heavily modified to require things like a toilet
 		H.thirst = INFINITY
 		H.nutrition = INFINITY //he is sustained by the Omnissiah, he requires neither food nor drink
+		H.vice = null //off for now
 		to_chat(H, "<span class='notice'><b><font size=3>You are a Enginseer, Obey your Magi and remember, your primary duty is to ensure that all machine spirits are pleased and secure technology.</font></b></span>")
 
 // Biologis
@@ -131,6 +133,7 @@
 		H.bowels = -INFINITY //he's too heavily modified to require things like a toilet
 		H.thirst = INFINITY
 		H.nutrition = INFINITY //he is sustained by the Omnissiah, he requires neither food nor drink
+		H.vice = null //off for now
 		to_chat(H, "<span class='notice'><b><font size=3>You are a Magos Biologis, you are a expert on xenos and biological research, your primary duty is to oversee the construction of Skitarii, you are not forced to listen to the Magos Dominus, but be aware, he holds much more power in the outpost than you.</font></b></span>")
 
 

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -32,7 +32,7 @@
 			if(T)
 				T.clean(src, user)
 			to_chat(user, "<span class='notice'>You have finished mopping!</span>")
-			if(user.vice == "Neat Freak" && user.faction != "Nurgle" && istype(A, /obj/effect/decal/cleanable))
+			if(user.vice == "Neat Freak" && user.faction != "nurgle" && istype(A, /obj/effect/decal/cleanable))
 				user.happiness +=1
 				if(prob(10))
 					to_chat(user, "<span class='goodmood'>+ That's much better... +</span>\n")

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -33,14 +33,14 @@
 	else if(istype(target,/obj/effect/decal/cleanable/blood))
 		to_chat(user, "<span class='notice'>You scrub \the [target.name] out.</span>")
 		target.clean_blood() //Blood is a cleanable decal, therefore needs to be accounted for before all cleanable decals.
-		if(user.vice == "Neat Freak" && user.faction != "Nurgle")
+		if(user.vice == "Neat Freak" && user.faction != "nurgle")
 			user.happiness += 1
 			if(prob(10))
 				to_chat(user, "<span class='goodmood'>+ That's much better... +</span>\n")
 	else if(istype(target,/obj/effect/decal/cleanable))
 		to_chat(user, "<span class='notice'>You scrub \the [target.name] out.</span>")
 		qdel(target)
-		if(user.vice == "Neat Freak" && user.faction != "Nurgle")
+		if(user.vice == "Neat Freak" && user.faction != "nurgle")
 			user.happiness += 1
 			if(prob(10))
 				to_chat(user, "<span class='goodmood'>+ That's much better... +</span>\n")
@@ -54,7 +54,7 @@
 	else
 		to_chat(user, "<span class='notice'>You clean \the [target.name].</span>")
 		target.clean_blood() //Clean bloodied atoms. Blood decals themselves need to be handled above.
-		if(user.vice == "Neat Freak" && user.faction != "Nurgle")
+		if(user.vice == "Neat Freak" && user.faction != "nurgle")
 			user.happiness += 0.2
 			if(prob(10))
 				to_chat(user, "<span class='goodmood'>+ That's much better... +</span>\n")

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -110,7 +110,7 @@ var/list/flooring_types
 
 /decl/flooring/tiling
 	name = "floor"
-	desc = "Scuffed from the passage of countless greyshirts."
+	desc = "Scuffed from the passage of countless menials."
 	icon = 'icons/turf/flooring/tiles.dmi'
 	icon_base = "steel"
 	color = null

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -104,3 +104,23 @@
 	else
 		src.music_on = 1
 		to_chat(src, "Ambient music enabled.")
+
+
+/mob/living/verb/playedTime()
+	set name = "View Played Time"
+	set desc = "See how long you've played!"
+	set category = "OOC"
+
+	establish_db_connection()
+	if(!dbcon.IsConnected())
+		to_chat(src, "DB connection failed! Tell an admeme!")
+		return
+
+	var/DBQuery/query = dbcon.NewQuery("SELECT time_living FROM playtime_history WHERE ckey='[src.ckey]'")
+	query.Execute()
+	while(query.NextRow())
+		var/playedTime = query.item[1]
+		playedTime = text2num(playedTime)
+		playedTime = playedTime/60
+		to_chat(src, "[playedTime] hours played")
+		break

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -233,6 +233,9 @@
 //DISCONNECT//
 //////////////
 /client/Del()
+	var/mob/living/carbon/human/player = src
+	sql_report_played_time(player)
+	player.time_alive = 0 //When a player closes the client their played time is reported, their time_alive is set to 0 to prevent duping/gaming it in the DB -wel
 	ticket_panels -= src
 	if(holder)
 		holder.owner = null

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -326,6 +326,17 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 				return TOPIC_REFRESH
 			else
 				pref.cult = chosen_religion
+				switch(pref.cult)
+					if("khorne")
+						to_chat(user, "<span class='badmood'>⠀+ BLOOD FOR THE BLOOD GOD! (Cult roles are not guaranteed) +</span>")
+					if("nurgle")
+						to_chat(user, "<span class='badmood'>⠀+ I'm a boil on the face of reality. And I fester! (Cult roles are not guaranteed) +</span>")
+					if("slaanesh")
+						to_chat(user, "<span class='badmood'>⠀+ Hail to the Prince of Delight! (Cult roles are not guaranteed) +</span>")
+					if("tzeentch")
+						to_chat(user, "<span class='badmood'>⠀+ All according to plan! (Cult roles are not guaranteed) +</span>")
+					if("None")
+						to_chat(user, "<span class='badmood'>⠀+ You have opted out of a cult role. +</span>")
 				return TOPIC_REFRESH
 
 	else if(href_list["show_species"])

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -103,7 +103,7 @@
 		if(do_after(user,30, progress = 0))
 			user.visible_message("\The [user] finishes wiping off the [A]!")
 			A.clean_blood()
-			if(user.vice == "Neat Freak" && user.faction != "Nurgle" && istype(A, /obj/effect/decal/cleanable))
+			if(user.vice == "Neat Freak" && user.faction != "nurgle" && istype(A, /obj/effect/decal/cleanable))
 				user.happiness +=1
 				if(prob(10))
 					to_chat(user, "<span class='goodmood'>+ That's much better... +</span>\n")

--- a/code/modules/mob/living/carbon/human/vice.dm
+++ b/code/modules/mob/living/carbon/human/vice.dm
@@ -2,8 +2,11 @@
 	if(vice)
 		if(vice == "Parental Instincts") return //They have events that handle their happiness, no timer needed
 
+		if (viceneed < 0)
+			viceneed = 0 //no banking need by afking in da chapel
+
 		if(src.vice == "Piety")
-			if(src.loc.loc.name == "Chapel") //src loc goes to the tile, need to access the tiles loc
+			if(src.loc.loc.name == "Chapel" ) //src loc goes to the tile, need to access the tiles loc
 				src.viceneed -= rand(15,25)
 				if(prob(5))
 					to_chat(src, "<span class='goodmood'>+ I feel at ease here. +</span>\n")
@@ -11,17 +14,39 @@
 		if(src.vice == "Neat Freak")
 			if(sleeping || src.faction == "nurgle") return
 
-			for(var/obj/effect/decal/cleanable/H in view(5, src))
+			if(src.happiness < -17) //stops them from acquiring infinite sad
+				src.happiness = -17
+
+			for(var/obj/effect/decal/cleanable/H in view(3, src))
 				if(src.vice == "Neat Freak" && src.faction != "nurgle")
 					if(prob(2))
 						to_chat(src, "<span class='badmood'>+ Emperor it's filthy here... +</span>\n")
 						src.happiness -= 0.2
-			for(var/obj/item/reagent_containers/food/snacks/poo/H in view(5, src))
+			for(var/obj/item/reagent_containers/food/snacks/poo/H in view(3, src))
 				if(src.vice == "Neat Freak" && src.faction != "nurgle")
 					if(prob(2))
 						to_chat(src, "<span class='badmood'>+ Emperor it's filthy here... +</span>\n")
 						src.happiness -= 0.2
 			return
+
+		if(src.vice == "Alcohol" || src.vice == "Obscura")
+			if(sleeping) return
+
+			for(var/drug in src.chem_doses)
+				if(src.vice == "Alcohol")
+					var/textSlice = copytext("[drug]",1,23) //this is incredibly fucking hacky but drug is an associated array and the key is an obj for some fucking reason
+					if(textSlice == "/datum/reagent/ethanol")
+						src.viceneed -= rand(3,6)
+						if(prob(2))
+							to_chat(src, "<span class='goodmood'>+ Now I'm buzzing... +</span>\n")
+				if(src.vice == "Obscura")
+					var/textSlice = copytext("[drug]",1,0) //this is incredibly fucking hacky but drug is an associated array and the key is an obj for some fucking reason
+					if(textSlice == "/datum/reagent/space_drugs")
+						src.viceneed -= rand(3,6)
+						if(prob(2))
+							to_chat(src, "<span class='goodmood'>+ I finally feel human again... +</span>\n")
+
+
 
 
 		if(viceneed < 1000 && vice != "Glutton")
@@ -34,7 +59,7 @@
 				viceneed += rand(1,3)
 				clear_event("vice")
 
-		else if(viceneed < 1000 && vice == "Glutton" && nutrition >= 375)
+		else if(viceneed <= 1000 && vice == "Glutton" && nutrition >= 375)
 			spawn(10)
 				viceneed -= rand(3,6)
 				clear_event("vice")
@@ -42,8 +67,6 @@
 	if(viceneed > 1000)
 		viceneed = 1000
 
-	if (viceneed < 0)
-		viceneed = 0 //no banking need by afking in da chapel
 
 	if(viceneed >= 1000)
 		switch(vice)

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -1,4 +1,7 @@
 /mob/Logout()
+	var/mob/living/carbon/human/player = src
+	sql_report_played_time(player)
+	player.time_alive = 0 //When a player closes the client their played time is reported, their time_alive is set to 0 to prevent duping/gaming it in the DB -wel
 	SSnanoui.user_logout(src) // this is used to clean up (remove) this user's Nano UIs
 	SStgui && SStgui.on_logout(src)
 	GLOB.player_list -= src

--- a/code/modules/mob/shit_piss.dm
+++ b/code/modules/mob/shit_piss.dm
@@ -248,7 +248,7 @@
 			message = "<span class='danger'><b>[src]</b> shits right on <b>[M]</b>'s face!</span>"
 			M.reagents.add_reagent(/datum/reagent/poo, 10)
 			M.unlock_achievement(new/datum/achievement/shit_on())
-			if(src.vice == "Neat Freak" && src.faction != "Nurgle")
+			if(src.vice == "Neat Freak" && src.faction != "nurgle")
 				happiness = -15
 				to_chat(src, "<span class='phobia'<big>I will never be clean again!</big></span>")
 
@@ -260,7 +260,7 @@
 				reagents.trans_to(V, rand(1,5))
 			GLOB.shit_left++//Add it to the shit on the floor counter.
 			for(var/mob/living/carbon/human/H in view(5, src))
-				if(H.vice == "Neat Freak" && H.faction != "Nurgle")
+				if(H.vice == "Neat Freak" && H.faction != "nurgle")
 					to_chat(src, "<span class='badmood'>+ [src] is a disgusting animal... +</span>\n")
 					H.happiness -= 3
 
@@ -320,7 +320,7 @@
 			message = "<B>[src]</B> pisses on the [TT.name]."
 		GLOB.piss_left++//Add it to the piss on the floor counter.
 		for(var/mob/living/carbon/human/H in view(5, src))
-			if(H.vice == "Neat Freak" && H.faction != "Nurgle")
+			if(H.vice == "Neat Freak" && H.faction != "nurgle")
 				to_chat(src, "<span class='badmood'>+ NOT ON THE FLOOR... +</span>\n")
 				H.happiness -= 3
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -133,8 +133,6 @@
 	if(effective_dose >= strength * 2) // Slurring
 		M.add_chemical_effect(CE_PAINKILLER, 150/strength)
 		M.slurring = max(M.slurring, 30)
-		if(M.vice == "Alcohol") //alcoholics need to drink a bit to feel it.
-			M.viceneed = 0
 	if(effective_dose >= strength * 3) // Confusion - walking in random directions
 		M.add_chemical_effect(CE_PAINKILLER, 150/strength)
 		M.confused = max(M.confused, 20)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -441,10 +441,6 @@
 		drug_strength = drug_strength * 0.8
 
 	M.druggy = max(M.druggy, drug_strength)
-	if(M.vice == "Obscura")
-		M.viceneed = 0
-		if(prob(5))
-			to_chat(M, "<span class='goodmood'>⠀+ Your muscles relax as obscura flows through your veins. +</span>")
 	if(prob(10) && isturf(M.loc) && !istype(M.loc, /turf/space) && M.canmove && !M.restrained())
 		step(M, pick(GLOB.cardinal))
 	if(prob(7))


### PR DESCRIPTION
This has a bit of stuff in it.

**Vices:**

1. Lho is now the default vice to avoid making new players drunk.
2. Glutton has been fixed, you can now be happy again.
3. view range has been reduced for neat freak
4. Reworked how to handle alcohol and obscura. You no longer need to be perma blackout, if the reagent is in your blood stream your need will tick down. This means a sip every few minutes should keep you covered. Obscura is still going to make you high as balls tho.
5. Asstardes and Mech boys get no vices for now.

**SQL:**

1. Added better coverage for played time logging.
2. Now logs on mob logout, empties var to prevent dupes
3. Logs on client closing, empties the var to prevent dupes
4. In the OOC tab there is now a verb called 'View Played Time' to see your tracked alive played time in hours. This information does nothing but it could potentially be used for timegates in the future as the db matures and data becomes better.

