### PR TITLE
Nurgle abilities

### DIFF
--- a/code/modules/cultist/deities.dm
+++ b/code/modules/cultist/deities.dm
@@ -36,6 +36,9 @@
 	name = "nurgle"
 	status_icon_state = "nurgle"
 	rune_type = /obj/effect/cleanable/heretic_rune/nurgle
+	possible_blessings = list(
+						/datum/heretic_effect/heal,
+						/datum/heretic_effect/zombie)
 	rune_recipes = list(/datum/rune_recipe/nurgle/deathtolerance,
 						/datum/rune_recipe/nurgle/conversion,
 						/datum/rune_recipe/nurgle/toughen,

--- a/code/modules/cultist/effects/nurgle.dm
+++ b/code/modules/cultist/effects/nurgle.dm
@@ -28,6 +28,7 @@
 	add_message = "<span class='notice'>You feel your body begin to rot before your eyes.</span>"
 
 /datum/heretic_effect/zombie/add_effect(var/mob/living/carbon/human/user)
+	. = ..()
 	for(var/obj/item/organ/org in user.internal_organs)
 		org.vital = FALSE
 		org.robotic = ORGAN_ROBOT
@@ -41,6 +42,7 @@
 	unique = TRUE
 
 /datum/heretic_effect/heal/add_effect(var/mob/living/carbon/human/user)
+	. = ..()
 	user.verbs |= /mob/living/carbon/human/proc/nurgle_heal
 
 /datum/heretic_effect/heal/remove_effect(var/mob/living/carbon/human/user)

--- a/code/modules/cultist/effects/nurgle.dm
+++ b/code/modules/cultist/effects/nurgle.dm
@@ -14,8 +14,55 @@
 
 /datum/heretic_effect/tough/add_effect(var/mob/living/carbon/human/user)
 	. = ..()
-	user.STAT_LEVEL(dex) += 4
+	user.STAT_LEVEL(end) += 4
 
 /datum/heretic_effect/tough/remove_effect(var/mob/living/carbon/human/user)
 	. = ..()
-	user.STAT_LEVEL(dex) -= 4
+	user.STAT_LEVEL(end) -= 4
+
+
+// Makes nurgle cultists more durable. Visible change so rather powerful. Maybe?
+/datum/heretic_effect/zombie
+	name = "Resurrection"
+	unique = TRUE
+
+/datum/heretic_effect/zombie/add_effect(var/mob/living/carbon/human/user)
+	for(var/obj/item/organ/org in user.internal_organs)
+		org.vital = FALSE
+		org.robotic = ORGAN_ROBOT
+	var/obj/item/organ/internal/heart/hrt = locate() in user.internal_organs
+	hrt.pulse = PULSE_NONE
+	hrt.max_damage = -1
+	user.decaylevel = 2
+
+/datum/heretic_effect/heal
+	name = "Heal"
+	unique = TRUE
+
+/datum/heretic_effect/heal/add_effect(var/mob/living/carbon/human/user)
+	user.verbs |= /mob/living/carbon/human/proc/nurgle_heal
+
+/datum/heretic_effect/heal/remove_effect(var/mob/living/carbon/human/user)
+	user.verbs -= /mob/living/carbon/human/proc/nurgle_heal
+
+/mob/living/carbon/human/proc/nurgle_heal()
+	set category = "Ruinous Powers"
+	set name = "Heal (20)"
+	set desc = "Heal injuries in exchange for taking toxin damage, and tiring yourself."
+	if(staminaloss >= staminaexhaust / 2)
+		return FALSE
+	visible_message("[src]'s body covers its wounds with large puss-filled growths.")
+	adjustOxyLoss(-10)
+	adjustBruteLoss(-10)
+	adjustToxLoss(30)
+	adjustBrainLoss(-10)
+	eye_blurry = 0
+	ear_deaf = 0
+	ear_damage = 0
+	inject_blood(src, 50)
+	adjustStaminaLoss(staminaexhaust / 2)
+	for(var/obj/item/organ/external/temp in organs)
+		temp.wounds.Cut()
+
+
+

--- a/code/modules/cultist/effects/nurgle.dm
+++ b/code/modules/cultist/effects/nurgle.dm
@@ -25,6 +25,7 @@
 /datum/heretic_effect/zombie
 	name = "Resurrection"
 	unique = TRUE
+	add_message = "<span class='notice'>You feel your body begin to rot before your eyes.</span>"
 
 /datum/heretic_effect/zombie/add_effect(var/mob/living/carbon/human/user)
 	for(var/obj/item/organ/org in user.internal_organs)


### PR DESCRIPTION
1. Zombie: Makes the cultist more durable. No pulse, visibly decayed(Flavortext)
2. Heal: Lets nurgle cultists heal wounds, but they take toxin damage.
