### PR TITLE
Weapon Sprite fix

### DIFF
--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -73,6 +73,7 @@
  * Fireaxe
  */
 /obj/item/material/twohanded/fireaxe  // DEM AXES MAN, marker -Agouri
+	icon = 'icons/obj/weapons/melee/misc.dmi'
 	icon_state = "fireaxe0"
 	base_icon = "fireaxe"
 	name = "fire axe"

--- a/code/modules/projectiles/guns/projectile/mattguns.dm
+++ b/code/modules/projectiles/guns/projectile/mattguns.dm
@@ -1522,12 +1522,12 @@ obj/item/gun/projectile/automatic/autogun
 	loaded_icon = "emitter_carbine"
 	unloaded_icon = "emitter_carbine_e"
 	item_state = "emitter_carbine"
-	wielded_item_state = "emitter_carbine"
+	wielded_item_state = "laer"
 	fire_sound = 'sound/weapons/gunshot/shotgun3.ogg'
 	unwielded_loaded_icon = "emitter_carbine"
-	wielded_loaded_icon = "emitter_carbine"
+	wielded_loaded_icon = "laer"
 	unwielded_unloaded_icon = "emitter_carbine_e"
-	wielded_unloaded_icon = "emitter_carbine_e"
+	wielded_unloaded_icon = "laer"
 	caliber = "rad"
 	max_shells = 30
 	str_requirement = 11


### PR DESCRIPTION
Rad Carbines now have in-hand sprites so no state of them should be invisible now, The fire axe has had its code changed to point to the right DMI file now so it is also no longer invisible.

- Rad Carbine has In hands
- Fire axe is not Invisible