### PR TITLE
Cherubael 0.157

### DIFF
--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -83,7 +83,7 @@ proc/random_kroot_name(gender)
 
 proc/random_ogryn_name()
 //try and keep it to 4 letters
-	var/ogryn_names = list("Stev", "Orvy", "Lugg", "Bert", "Bran", "Gert", "Oggy", "Mono", "Nork", "Rogg", "Brog", "Prol", "Brok" )
+	var/ogryn_names = list("Stev", "Orvy", "Lugg", "Bert", "Bran", "Gert", "Oggy", "Mono", "Nork", "Rogg", "Brog", "Prol", "Brok", "Kaz", "Hurk", "Barg", "Tag", "Purg", "Worg", "Gerb", "Prel" )
 	return capitalize(pick(ogryn_names))
 
 proc/random_skitarii_name(gender)
@@ -95,7 +95,7 @@ proc/random_skitarii_name(gender)
 		return capitalize(pick(skitariinames)) + " "  + "[skitarrinum]"
 
 proc/random_ork_name(gender)
-	var/orknames = list("Bruzgrod", "Drugzag", "Klawgasha", "Warshredda", "Domechoppah", "Gravesmashah", "Krookacka", "Ugtazak", "Wildgasha", "Killgashah", "Bigrippa", "Domesplittah", "Orkamongus", "Barbcooka", "Krookkrushah", "Madwakkah", "Gatgroz" )
+	var/orknames = list("Bruzgrod", "Drugzag", "Klawgasha", "Warshredda", "Domechoppah", "Gravesmashah", "Krookacka", "Ugtazak", "Wildgasha", "Killgashah", "Bigrippa", "Domesplittah", "Orkamongus", "Barbcooka", "Krookkrushah", "Madwakkah", "Gatgroz", "Grimtoof", "Buzzgob", "Manchewa", "Wurldwrecka", "Wugzark", "Urgak", "Mawsnatcha", "Zogcrusha", "Gollik", "Bloodbrakka", "Crookcooka", "Umieslashah", "Eadhacka", "Zutmuk", "Gloomgoz", "Squigchompa", "Snurkkruk", "Doomkrakkah", "Bigackah", "Wirgox", "Zhagux", "Ghoskrugas", "Wriktug", "Skullstumpah", "Rageskorcha", "Zrakkud", "Trukzorgga", "Kharkux", "Kurgax", "UgeDakka", "Klawaface", "Zogzurk", "Zigkurg" ) // yeah i used a name generator. Gonna zogging krump me?
 	if(gender==FEMALE)
 		return capitalize(pick(orknames)) + " " + "The Lost"
 	else

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -6,7 +6,7 @@
 	icon_state = "telebaton_1"
 	item_state = "baton"
 	slot_flags = SLOT_BELT
-	force = 5	
+	force = 5
 	sharp = 0
 	edge = 0
 	throwforce = 7
@@ -278,3 +278,7 @@
 	atom_flags = ATOM_FLAG_NO_BLOOD
 	origin_tech = list(TECH_MAGNET = 7, TECH_COMBAT = 7)
 	attack_verb = list("violated", "penetrated", "infested")
+
+/obj/item/melee/baton/nidstun/dropped() //since nodrop is fucked this will deal with it for now.
+	..()
+	spawn(1) if(src) qdel(src)

--- a/code/modules/mob/living/carbon/human/species/races/nids.dm
+++ b/code/modules/mob/living/carbon/human/species/races/nids.dm
@@ -18,6 +18,7 @@
 	var/pain_power = 80
 	inherent_verbs = list(
 	/mob/living/carbon/human/genestealer/verb/convert,
+	/mob/living/carbon/human/genestealer/proc/talon,
 	/mob/living/carbon/human/genestealer/proc/makepool,
 	/mob/living/carbon/human/genestealer/proc/corrosive_acid,
 	/mob/living/carbon/human/genestealer/proc/gsheal,
@@ -302,6 +303,14 @@
 		src.inject_blood(src, 50)
 		src.biomass -=10
 
+/mob/living/carbon/human/genestealer/proc/talon()
+	set name = "Unsheathe Venomous Talon (0)"
+	set category = "Tyranid"
+	set desc = "Gives their stun talon"
+
+	put_in_hands(new /obj/item/melee/baton/nidstun)
+	src.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	return
 
 //Begin nid items
 
@@ -334,3 +343,4 @@
 		playsound(src, 'sound/weapons/pierce.ogg', 100, FALSE)
 		if(do_after(user, 110, src))
 			qdel(src)
+

--- a/code/modules/mob/living/carbon/human/species/races/orks/abilities.dm
+++ b/code/modules/mob/living/carbon/human/species/races/orks/abilities.dm
@@ -37,7 +37,7 @@
 
 /mob/living/carbon/human/ork/proc/warscream()
 	set category = "Ork"
-	set name = "WAAAAGH! (100)"
+	set name = "WAAAAGH! (1)"
 	set desc = "WE AIN'T DONE FIGHTIN' YET!"
 	var/cooldown = FALSE
 	if(src.stat == DEAD)


### PR DESCRIPTION
Gives nids a verb to unsheathe their venom talon. When dropped the talon is auto deleted. So thats the only real way of re-sheathing it. Tried fucking around with the mechanicus stuff to copy it but didnt work and this works spaghettiy enough

Renames ork waagh ability to properly cost only 1 in the verb tab. Reminder all it does rn is fix eyes for 1 second, so if orks are under giga hurt its actually worth it to wagh every few seconds to see where you are

adds 40 new ork names and a few ogryn names