### PR TITLE
Admin / Cult Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -332,10 +332,6 @@
 			if(happiness <= MOOD_LEVEL_SAD2)
 				msg += "<span class='warning'>[T.He] looks stressed.</span>\n"
 
-	if(decaylevel == 1)
-		msg += "[T.He] [T.is] starting to smell.\n"
-	if(decaylevel == 2)
-		msg += "[T.He] [T.is] bloated and smells disgusting.\n"
 	if(decaylevel == 3)
 		msg += "[T.He] [T.is] rotting and blackened, the skin sloughing off. The smell is indescribably foul.\n"
 	if(decaylevel == 4)

--- a/config/admin_ranks.txt
+++ b/config/admin_ranks.txt
@@ -33,7 +33,7 @@ Moderator       +MOD
 TrialModerator  +MOD
 
 Mentor		+MENTOR  
-TrialAdmin      +@ +ADMIN +STEALTH +SPAWN +REJUV +VAREDIT +BAN +SERVER
+TrialAdmin      +@ +ADMIN +STEALTH +SPAWN +REJUV +VAREDIT +BAN +SERVER +PERMISSIONS +DEBUG
 GameAdmin       +@ +DEBUG +FUN +POSSESS +BUILDMODE +SOUND +PERMISSIONS
 SeniorAdmin     +EVERYTHING
 


### PR DESCRIPTION
Nurgle Cultists can no longer be meta'd by their examine text round start.


Trial Admins have more access permissions for debug and log diving, previously they could not access server logs properly. Now they can.