### PR TITLE
Power Maul Balancing Update (super small)

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -266,9 +266,9 @@
 	color = "#292929"
 	slot_flags = SLOT_BELT|SLOT_BACK|SLOT_S_STORE
 	str_requirement = 1
-	force = 2
+	force = 25
 	stunforce = 0
-	agonyforce = 165
+	agonyforce = 25
 	status = 1
 	block_chance = 60
 	sales_price = 20

--- a/maps/warhammer/jobs/xenos.dm
+++ b/maps/warhammer/jobs/xenos.dm
@@ -79,7 +79,7 @@
 	belt = /obj/item/gun/projectile/eldar/spistol
 	l_pocket = /obj/item/storage/box/ifak
 	r_pocket =/obj/item/device/flashlight/lantern
-	backpack_contents = list(/obj/item/ammo_magazine/catapult_magazine = 1,/obj/item/ammo_magazine/spistol_magazine = 1)
+	backpack_contents = list(/obj/item/ammo_magazine/catapult_magazine = 1,/obj/item/ammo_magazine/spistol_magazine = 1, /obj/item/device/soulstone = 1)
 	id = null
 	id_slot = null
 	pda_slot = null


### PR DESCRIPTION
This fixes the power maul by lowering the agony and raising the force. This makes it a two hit knockdown most of the time, but RNG changes this, obviously.