### PR TITLE
Removes Ambience Preference

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -255,7 +255,6 @@ var/list/mob/living/forced_ambiance_list = new
 
 /area/proc/play_ambience(var/mob/living/L)
 	// Ambience goes down here -- make sure to list each area seperately for ease of adding things in later, thanks! Note: areas adjacent to each other should have the same sounds to prevent cutoff when possible.- LastyScratch
-	if(!(L && L.get_preference_value(/datum/client_preference/play_ambiance) == GLOB.PREF_YES)) return
 
 	if(L in forced_ambiance_list)
 		sound_to(L, sound(null, channel = 2))

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -140,7 +140,7 @@ var/list/artillery_in = list( 'sound/weapons/new_artillery_incoming01.ogg', 'sou
 		if(get_dist(M, turf_source) <= maxdistance)
 			var/turf/T = get_turf(M)
 
-			if(T && (T.z == turf_source.z || (zrange && AreConnectedZLevels(T.z, turf_source.z) && abs(T.z - turf_source.z) <= zrange)) && (!is_ambiance || M.get_preference_value(/datum/client_preference/play_ambiance) == GLOB.PREF_YES))
+			if(T && (T.z == turf_source.z || (zrange && AreConnectedZLevels(T.z, turf_source.z) && abs(T.z - turf_source.z) <= zrange)))
 				M.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, is_global, extrarange, override_env, envdry, envwet)
 
 var/const/FALLOFF_SOUNDS = 0.5

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -94,15 +94,6 @@ var/list/_client_preferences_by_type
 	else
 		sound_to(preference_mob, sound(null, repeat = 0, wait = 0, volume = 85, channel = 1))
 
-/datum/client_preference/play_ambiance
-	description ="Play ambience"
-	key = "SOUND_AMBIENCE"
-
-/datum/client_preference/play_ambiance/changed(var/mob/preference_mob, var/new_value)
-	if(new_value == GLOB.PREF_NO)
-		sound_to(preference_mob, sound(null, repeat = 0, wait = 0, volume = 0, channel = 1))
-		sound_to(preference_mob, sound(null, repeat = 0, wait = 0, volume = 0, channel = 2))
-
 /datum/client_preference/ghost_ears
 	description ="Ghost ears"
 	key = "CHAT_GHOSTEARS"


### PR DESCRIPTION
The 'play ambience' preference doesn't work, only cutting off the current and playing it like usual when you enter a different area.

'Toggle music' in OOC has the exact same function but actually works.

This has already confused one player, farewell play ambience preference.

![compilesound](https://user-images.githubusercontent.com/115356058/210185296-a61acf99-734b-4ad8-abff-cf5a8352abea.png)
