### PR TITLE
Fixes barbed wire

### DIFF
--- a/code/game/gamemodes/warfare/structures.dm
+++ b/code/game/gamemodes/warfare/structures.dm
@@ -359,7 +359,7 @@
 			qdel(src)
 			return
 
-	else if (istype(W, /obj/item/material/sword))
+	else if (istype(W, /obj/item/melee/sword))
 		if (anchored)
 			user.visible_message("<span class = 'notice'>\The [user] starts to cut through \the [src] with [W].</span>")
 			if (!do_after(user,60))


### PR DESCRIPTION
Lets sword subtypes cut through barbed wire again.

![image](https://user-images.githubusercontent.com/58889237/212449210-28d07e75-5a44-476c-bbc9-602f80d5b21b.png)
