### PR TITLE
Medicae Patch

### DIFF
--- a/code/game/jobs/job/astra_militarum.dm
+++ b/code/game/jobs/job/astra_militarum.dm
@@ -457,6 +457,7 @@ datum/job/ig/bullgryn
 	selection_color = "#33813A"
 	economic_modifier = 4
 	minimal_player_age = 18
+	outfit_type = /decl/hierarchy/outfit/job/medical/paramedic
 	latejoin_at_spawnpoints = TRUE
 	announced = FALSE
 	access = list(access_medical, access_village, access_guard_common, access_security


### PR DESCRIPTION
The default medicae role (WHICH YOU SHOULD NOT USE) now defaults to the Cadian gear.
![screenshot](https://user-images.githubusercontent.com/42359139/218292497-3eea2e28-f948-4471-b133-4bd13d980d55.PNG)
