### PR TITLE
Minor Edits / Nurgle

### DIFF
--- a/code/game/jobs/job/magistratum.dm
+++ b/code/game/jobs/job/magistratum.dm
@@ -187,7 +187,7 @@
 	belt = /obj/item/melee/baton/loaded
 	id_type = /obj/item/card/id/dog_tag/guardsman
 	pda_slot = null
-	l_ear = /obj/item/device/radio/headset/headset_cargo
+	l_ear = /obj/item/device/radio/headset/red_team
 	suit_store = /obj/item/gun/projectile/shotgun/pump/shitty/magrave
 	l_hand = /obj/item/device/flashlight/lantern
 	backpack_contents = list(
@@ -240,7 +240,7 @@
 	belt = /obj/item/gun/energy/las/laspistol/shitty
 	id_type = /obj/item/card/id/dog_tag/guardsman
 	pda_slot = null
-	l_ear = /obj/item/device/radio/headset/headset_cargo
+	l_ear = /obj/item/device/radio/headset/red_team
 	suit_store = /obj/item/gun/projectile/shotgun/pump/voxlegis
 	backpack_contents = list(
 	/obj/item/handcuffs = 1,

--- a/code/modules/cultist/effects/nurgle.dm
+++ b/code/modules/cultist/effects/nurgle.dm
@@ -27,11 +27,11 @@
 
 /datum/heretic_effect/tough/add_effect(var/mob/living/carbon/human/user)
 	. = ..()
-	user.STAT_LEVEL(end) += 5
+	user.STAT_LEVEL(end) += 4
 
 /datum/heretic_effect/tough/remove_effect(var/mob/living/carbon/human/user)
 	. = ..()
-	user.STAT_LEVEL(end) -= 5
+	user.STAT_LEVEL(end) -= 4
 
 
 // Makes nurgle cultists more durable. Visible change so rather powerful. Maybe?
@@ -69,9 +69,9 @@
 		return FALSE
 	visible_message("[src]'s body covers their wounds with large puss-filled growths!")
 	adjustOxyLoss(-1)
-	adjustToxLoss(-1)
-	adjustBruteLoss(-4)
-	adjustFireLoss(-4)
+	adjustToxLoss(1)
+	adjustBruteLoss(-2)
+	adjustFireLoss(-1)
 	eye_blurry = 0
 	ear_deaf = 0
 	ear_damage = 0

--- a/code/modules/cultist/runes/nurgle.dm
+++ b/code/modules/cultist/runes/nurgle.dm
@@ -17,7 +17,7 @@
 
 /datum/rune_recipe/nurgle/toughen
 	name = "Toughen Rite"
-	ingredients = list(/mob/living/simple_animal/hostile/retaliate/rat)
+	ingredients = list(/mob/living/simple_animal/hostile/retaliate/rat, /obj/item/organ/external/head,)
 	effect_path = /datum/heretic_effect/tough
 
 /datum/rune_recipe/nurgle/nganga
@@ -47,12 +47,12 @@
 
 /datum/rune_recipe/nurgle/blight
 	name = "Blightnade Rite"
-	ingredients = list(/obj/item/organ/external/head, /obj/item/grenade/frag/high_yield/homemade)
+	ingredients = list(/obj/item/organ/external/head, /mob/living/simple_animal/hostile/retaliate/rat, /obj/item/grenade/frag/high_yield/homemade)
 	product_path = /obj/item/grenade/chem_grenade/blightnade
 
 /datum/rune_recipe/nurgle/nurgling
 	name = "Nurgling Rite"
-	ingredients = list(/obj/item/organ/internal/liver)
+	ingredients = list(/mob/living/carbon/human)
 	product_path = /mob/living/simple_animal/hostile/nurgling
 
 /datum/rune_recipe/nurgle/offering

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -305,7 +305,7 @@
 	verbs += /mob/living/proc/zombie_eat
 /*	verbs += /mob/living/proc/claws */
 	src.species.species_flags += SPECIES_FLAG_NO_PAIN|SPECIES_FLAG_NO_POISON|SPECIES_FLAG_NO_SLIP
-	src.species.slowdown += 1.5
+	/* src.species.slowdown += 1.5 */
 
 	if (r_hand)
 		drop_from_inventory(r_hand)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -692,7 +692,7 @@
 		var/mob/living/carbon/human/H = M
 		H.zombieze()
 	M.adjustOxyLoss(3 * removed)
-	M.Weaken(10)
+	M.Weaken(5)
 	M.silent = max(M.silent, 10)
 	remove_self(volume)
 

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -254,40 +254,9 @@
 	chance_max = 0
 	allow_multiple = 1
 
-/datum/disease2/effect/plague4
-	name = "Nurgle Plague(INSTANT DEATH)"
-	stage = 1
-	badness = VIRUS_EXOTIC
-	chance_max = 99
-	allow_multiple = 1
-	delay = 5 SECONDS
-	activate(var/mob/living/carbon/human/mob,var/multiplier)
-		if (prob(20))
-			new /mob/living/simple_animal/hostile/smalldemon/plague(mob.loc)
-			mob.gib()
-
-/datum/disease2/effect/plague3
-	name = "Nurgle Plague Part 3"
-	stage = 1
-	badness = VIRUS_EXOTIC
-	chance_max = 99
-	allow_multiple = 1
-	delay = 30 SECONDS
-	activate(var/mob/living/carbon/human/mob,var/multiplier)
-		sleep(30)
-		if (prob(50))
-			mob.apply_damage(30, BURN)
-		sleep(50)
-		if (prob(100) && !mob.wear_mask)
-			sleep(100)
-		if (prob(20))
-			new /mob/living/simple_animal/hostile/smalldemon/plague(mob.loc)
-			mob.gib()
-
-
 /datum/disease2/effect/plague2
 	name = "Nurgle Plague Part 2"
-	stage = 1
+	stage = 2
 	badness = VIRUS_EXOTIC
 	chance_max = 99
 	allow_multiple = 1
@@ -296,14 +265,17 @@
 		if (prob(70))
 			mob.emote("cry")
 			to_chat(mob, "<span class='warning'>Mucous runs down the back of your throat, it feels almost like worms crawling inside your throat.</span>")
-		sleep(30)
+		sleep(15)
 		if (prob(50))
 			mob.apply_damage(5, BURN)
-		sleep(60)
-		if (prob(100) && !mob.wear_mask)
-			sleep(80)
+		if (prob(7))
+			mob.bowels = rand(530, 940)
+			mob.bladder = rand(530, 940)
+			mob.custom_pain("Your skin hurts a bit.", 20)
+			mob.apply_damage(5, BRUTE)
+		sleep(15)
 		if (prob(10))
-			mob.apply_damage(22, BURN)
+			mob.apply_damage(5, BURN)
 
 /datum/disease2/effect/plague1
 	name = "Nurgle Plague Part 1"
@@ -313,17 +285,15 @@
 	allow_multiple = 1
 	delay = 15 SECONDS
 	activate(var/mob/living/carbon/human/mob,var/multiplier)
-		sleep(30)
-		if (prob(100) && !mob.wear_mask)
-			sleep(80)
+		sleep(15)
 		if (prob(10))
-			mob.bowels = rand(0, 900)
-			mob.bladder = rand(0, 900)
+			mob.bowels = rand(530, 940)
+			mob.bladder = rand(530, 940)
 			mob.custom_pain("Your skin hurts a bit.", 20)
-			mob.apply_damage(6, BRUTE)
-		sleep(30)
+			mob.apply_damage(5, BRUTE)
+		sleep(15)
 		if (prob(20))
-			mob.emote("yawn")
+			mob.emote("cough")
 
 // to do; bloodpox(coughing blood). long cycles. brute and tox damage. slow. laughing plague.
 

--- a/maps/delta/warhammer_areas.dm
+++ b/maps/delta/warhammer_areas.dm
@@ -627,12 +627,13 @@ Area basic template
 /area/cadiaoutpost/oa/medicae/mansion
 	name = "Mansion Medical"
 	icon_state = "medbay"
+	requires_power = FALSE
 
 /area/cadiaoutpost/oa/medicae/mansion/medicae
 	name = "Mansion Medicae"
 	icon_state = "mansionmed"
 	dynamic_lighting = 1
-	requires_power = 1
+	requires_power = FALSE
 
 /area/cadiaoutpost/oa/medicae/storage
 	name = "Medicae Storage"
@@ -923,7 +924,7 @@ Area basic template
 /area/cadiaoutpost/oa/supply/mining/miningproduction
 	name = "Mining Production"
 	icon_state = "mining_production"
-	requires_power = TRUE
+	requires_power = FALSE
 	music = 'sound/newmusic/General_Ambient2.ogg'
 
 /area/cadiaoutpost/oa/supply/mining/office
@@ -934,7 +935,7 @@ Area basic template
 /area/cadiaoutpost/oa/supply/mining/miningbreak
 	name = "Mining Breakroom"
 	icon_state = "mining_break"
-	requires_power = TRUE
+	requires_power = FALSE
 	music = 'sound/newmusic/General_Ambient2.ogg'
 
 /area/cadiaoutpost/oa/supply/mining/explored


### PR DESCRIPTION
Misc;
Fixed Magistratum Headset to be Guard Issue and Medicae Power Issues.

NURGLE;
Modified Toughen Rite to grant +4 Endurance instead of +5

Modified Heal Rite to heal less and cause Toxin Damage as it was initially balanced. The original text of the rite is that it is meant to poison you in exchange for healing which it did not currently.

Modified Blightnade to have less Knockdown and Zombie Plague to not have slowdown. Noticed significantly in testing that zombies were never a threat to anyone on account of being too slow to catch their victims, quite literally snails would be faster then them. The knockdown from the Blightnade also made it so those turned into zombies couldn't really get up and be a threat for quite a long time. 

Slight edits to the Nurgle Plague Virus - which is unrelated to the Blightnade Zombie Virus.

[Added more Recipe Requirements for certain Nurgle Rites]
Tough Requires; /mob/living/simple_animal/hostile/retaliate/rat, /obj/item/organ/external/head,
Blightnade Requires; /obj/item/organ/external/head, /mob/living/simple_animal/hostile/retaliate/rat, /obj/item/grenade/frag/high_yield/homemade
Nurgling Requires; /mob/living/carbon/human