### PR TITLE
Removes Ganger Cultist Chance

### DIFF
--- a/code/game/jobs/job/pilgrims.dm
+++ b/code/game/jobs/job/pilgrims.dm
@@ -558,7 +558,7 @@ Pilgrim Fate System
 	outfit_type = /decl/hierarchy/outfit/job/ganger
 	latejoin_at_spawnpoints = TRUE
 	announced = FALSE
-	cultist_chance = 75
+	cultist_chance = 0
 
 	equip(var/mob/living/carbon/human/H)
 		H.warfare_faction = IMPERIUM


### PR DESCRIPTION
Gangers can no longer be cultists, after all what is a Cult but another Gang on your turf?

This update would also pave the way for me to get a Ganger leader role back in, who would be a Cultist and they'd have the option to turn the Gang into a Gang-Cult, but for now I think that Gangs should be united and generally less Feature Bloated