### PR TITLE
Remove Kroot Foot Sprite

### DIFF
--- a/code/modules/clothing/shoes/jobs.dm
+++ b/code/modules/clothing/shoes/jobs.dm
@@ -363,8 +363,8 @@
 /obj/item/clothing/shoes/krootfeet //walking sounds only play with shoes and I was losing my mind not having them
 	name = "kroot feet"
 	desc = "The spindly webbed feet of a Kroot"
-	icon_state = "krootboot"
-	item_state = "krootboot"
+	icon_state =
+	item_state =
 	canremove = 0
 	unacidable = 1
 	item_flags = ITEM_FLAG_NOSLIP
@@ -388,7 +388,7 @@
 	item_state = "ork_boots"
 	species_restricted = list(SPECIES_ORK)
 	canremove = 0
-//	item_flags = ITEM_FLAG_NOSLIP //walker here, add this if you don't like orks being goofy or funny or if you are a nerd
+	item_flags = ITEM_FLAG_NOSLIP
 
 
 //Eldar Stuff


### PR DESCRIPTION
Remove the Kroot Foot sprite since the new species sprites covers that pretty well and the old kroot foot icons are made for the old model

Also adds noslip to the ork shoes, to put them on Par with the other late parties