### PR TITLE
CULT FIX

### DIFF
--- a/code/modules/cultist/deities.dm
+++ b/code/modules/cultist/deities.dm
@@ -3,7 +3,7 @@
 	join_message = "Blood for the Blood God!"
 	status_icon_state = "khorne"
 	rune_type = /obj/effect/cleanable/heretic_rune/khorne
-	faction = "Chaos"
+	faction = "Khorne"
 	rune_recipes = list(
 						/datum/rune_recipe/khorne/offer_bioprinted,
 						/datum/rune_recipe/khorne/offer_skull,
@@ -37,7 +37,7 @@
 	name = "nurgle"
 	status_icon_state = "nurgle"
 	rune_type = /obj/effect/cleanable/heretic_rune/nurgle
-	faction = "Chaos"
+	faction = "Nurgle"
 	possible_blessings = list(
 						/datum/heretic_effect/heal,
 						/datum/heretic_effect/painless,
@@ -66,7 +66,7 @@
 	name = "slaanesh"
 	status_icon_state = "slaanesh"
 	rune_type = /obj/effect/cleanable/heretic_rune/slaanesh
-	faction = "Chaos"
+	faction = "Slaanesh"
 	rune_recipes = list(/datum/rune_recipe/slaanesh/conversion,
 						/datum/rune_recipe/slaanesh/arm,
 						/datum/rune_recipe/slaanesh/escape,
@@ -83,7 +83,7 @@
 	name = "tzeentch"
 	status_icon_state = "tzeentch"
 	rune_type = /obj/effect/cleanable/heretic_rune/tzeentch
-	faction = "Chaos"
+	faction = "Tzeentch"
 	rune_recipes = list(/datum/rune_recipe/tzeentch/conversion,
 						/datum/rune_recipe/tzeentch/fool,
 						/datum/rune_recipe/tzeentch/illusion,

--- a/code/modules/cultist/deity.dm
+++ b/code/modules/cultist/deity.dm
@@ -101,7 +101,7 @@ Most blessings and curses should be permanent.
 	to_chat(NewMember, join_message)
 	NewMember.verbs += inherent_verbs
 	NewMember.AddInfectionImages()
-	NewMember.faction = "Chaos"
+	NewMember.faction = "Nurgle"
 	NewMember.mind.special_role = "[name]"
 	SSgods.cultist_count += 1
 	post_add(NewMember)

--- a/code/modules/cultist/runes/nurgle.dm
+++ b/code/modules/cultist/runes/nurgle.dm
@@ -47,16 +47,16 @@
 
 /datum/rune_recipe/nurgle/blight
 	name = "Blightnade Rite"
-	ingredients = list(/obj/item/organ/external/head, /mob/living/simple_animal/hostile/retaliate/rat, /obj/item/grenade/frag/high_yield/homemade)
+	ingredients = list(/obj/item/grenade/frag/high_yield/krak, /obj/item/newore/gems/ruby)
 	product_path = /obj/item/grenade/chem_grenade/blightnade
 
 /datum/rune_recipe/nurgle/nurgling
 	name = "Nurgling Rite"
-	ingredients = list(/mob/living/carbon/human)
+	ingredients = list(/obj/item/newore/gems/sapphire)
 	product_path = /mob/living/simple_animal/hostile/nurgling
 
 /datum/rune_recipe/nurgle/offering
 	name = "Offering Rite"
-	ingredients = list(/mob/living/carbon/human)
+	ingredients = list(/obj/item/newore/gems/emerald)
 	delete_items = FALSE
 	special 	 = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/smalldemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/smalldemon.dm
@@ -184,7 +184,7 @@
 		return
 	custom_emote(1, pick( list("bites at [target_mob]", "crushes [target_mob]") ) ) // attack emotes
 
-	var/damage = rand(70,100) // Damage Value
+	var/damage = rand(75,90) // Damage Value
 
 	if(ishuman(target_mob))
 		var/mob/living/carbon/human/H = target_mob
@@ -222,7 +222,7 @@
 		return
 	custom_emote(1, pick( list("slices at [target_mob]", "tears [target_mob]") ) ) // attack emotes
 
-	var/damage = rand(65,135) // Damage Value
+	var/damage = rand(65,125) // Damage Value
 
 	if(ishuman(target_mob))
 		var/mob/living/carbon/human/H = target_mob
@@ -332,7 +332,7 @@
 	attacktext = "slashed"
 	attack_sound = 'sound/weapons/bite.ogg'
 
-	faction = "Chaos"
+	faction = "Nurgle"
 
 /mob/living/simple_animal/hostile/retaliate/nurgling/FindTarget()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -26,7 +26,7 @@
 	// var/weapon2
 	unsuitable_atoms_damage = 15
 	environment_smash = 1
-	faction = "chaos"
+	faction = "Chaos"
 	status_flags = CANPUSH
 
 	ranged = 1


### PR DESCRIPTION
Cultists are no longer immune to daemons. Whoever changed this - WHY? WHY...?

Rites Fixed up. Requiring various flawed gemstones to create as they were quite strong. Creating Blight Grenades is more or less the win condition for cults if they use multiple.

Slightly reduced upper values of Daemon Damage, since the mobs often absolutely destroyed people in Power Armor.