### PR TITLE
Pilgrim Fix  (100% cult chance)

### DIFF
--- a/code/game/jobs/job/pilgrims.dm
+++ b/code/game/jobs/job/pilgrims.dm
@@ -9,7 +9,7 @@
 	outfit_type = /decl/hierarchy/outfit/job/penitent
 	latejoin_at_spawnpoints = TRUE
 	announced = FALSE
-	cultist_chance = 60
+	cultist_chance = 100
 
 
 	equip(var/mob/living/carbon/human/H)


### PR DESCRIPTION
This PR changes the Pilgrim role to have an 100% cult chance. I have not seen a single person who enjoys the new system, and many express frustrations and not being able to play the role (which is supposed to have freedom) how they wish. Rounds have also be consistently less enjoyable due to less heretical activity occurring, which is the main point of the game. Truth be told, non-heretic pilgrim is simply not fun for the people who want to roll cultist. 