### PR TITLE
Aura Edit - Post Test

### DIFF
--- a/code/game/objects/auras/aura.dm
+++ b/code/game/objects/auras/aura.dm
@@ -161,24 +161,24 @@ They should also be used for when you want to effect the ENTIRE mob, like having
 	//var/regen_message = "<span class='warning'>Your body throbs as you feel your body regenerates.</span>"
 	//var/innate_heal = TRUE // Whether the aura is on, basically.
 	can_regenerate_organs = TRUE
-	brute_mult = 27 // Value of 10 = 1 per second. Bleeding slows this down a lot, so a minimum of 15-20 is needed to stop bleeding.
+	brute_mult = 33 // Value of 10 = 1 per second. Bleeding slows this down a lot, so a minimum of 15-20 is needed to stop bleeding.
 	fire_mult = 27
-	tox_mult = 17 // We don't want toxin to heal as quickly as we want death to still be possible -- only slowed down. Not stopped.
-	organheal = 0.4 // Leave this as is. Any higher and you become god.
+	tox_mult = 5 // We don't want toxin to heal as quickly as we want death to still be possible -- only slowed down. Not stopped.
+	organheal = 0.3 // Leave this as is. Any higher and you become god.
 
 /obj/aura/regenerating/human/ork
 	can_regenerate_organs = TRUE
-	brute_mult = 35
-	fire_mult = 35
-	tox_mult = 15
-	organheal = 0.4
+	brute_mult = 39
+	fire_mult = 30
+	tox_mult = 2
+	organheal = 0.3
 
 /obj/aura/regenerating/human/nid
 	can_regenerate_organs = TRUE
 	brute_mult = 38
 	fire_mult = 38
-	tox_mult = 17
-	organheal = 0.4
+	tox_mult = 30
+	organheal = 0.6
 
 /obj/aura/regenerating/human/ultimate
 	//var/regen_message = "<span class='warning'>Your body throbs as you feel your body regenerates.</span>"
@@ -186,8 +186,8 @@ They should also be used for when you want to effect the ENTIRE mob, like having
 	can_regenerate_organs = TRUE
 	brute_mult = 45
 	fire_mult = 45
-	tox_mult = 17
-	organheal = 0.4
+	tox_mult = 8
+	organheal = 0.7
 
 
 /*/obj/aura/regenerating/human/astartes/life_tick()


### PR DESCRIPTION

Making a second PR actually, a little bit of foresight tells me we want toxin death to be quicker. Because players being stuck in crit just isn't fun at all for them.

For Nids we want them to actually heal from Crit since in Lore we know that sort of like Astartes Tyranids have redundant organs and sometimes extra brains. Sort of reminded by a Magos who remarks that even after seeing a genestealer strain blown to pieces and had been melted to the floor, it was still trying to obey the hivemind -- before they executed it with a lasbolt to the head.

Lastly we want Orks and Astartes to be more vulnerable to burns then brute, since burns biologically are harder to heal. Though Tyranids will heal their brute/burn at the same rate since they're hyper evolved predators.