### PR TITLE
Implant pad added to protolate

### DIFF
--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -550,6 +550,13 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/implantcase/explosive
 	sort_string = "MFAAG"
 
+/datum/design/item/implant/pad
+	name = "implant pad"
+	id = "implant_pad"
+	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_DATA = 4, TECH_BLUESPACE = 3, TECH_ILLEGAL = 4)
+	build_path = /obj/item/implantpad
+	sort_string = "MFAAH"
+
 /datum/design/item/AssembleDesignName()
 	..()
 	name = "[item_name]"


### PR DESCRIPTION
TECH_MATERIAL = 2, TECH_BIO = 3, TECH_DATA = 4, TECH_BLUESPACE = 3, TECH_ILLEGAL = 4
Because you need to unlock all implants in order to reprogram them. Very fair.
![Capture](https://user-images.githubusercontent.com/95250696/222920738-13727a9a-6290-4843-a8ff-0fa6ea39f1f0.JPG)
