### PR TITLE
Update matt_combat.dm

### DIFF
--- a/code/modules/mob/living/carbon/human/matt_combat.dm
+++ b/code/modules/mob/living/carbon/human/matt_combat.dm
@@ -9,7 +9,7 @@
 	var/dodge_modifier = 0
 	if(combat_mode && (defense_intent == I_DODGE) && !lying)//Todo, make use of the check_shield_arc proc to make sure you can't dodge from behind.
 		if(atk_intent == I_DEFENSE)//Better chance to dodge
-			dodge_modifier += 30
+			dodge_modifier += 10
 		if(statscheck(STAT_LEVEL(dex) / 2 + 3) >= SUCCESS)
 			do_dodge()
 			return	1


### PR DESCRIPTION
Massively nerfs the defend combat intent. Now you can actually hit people on the defend intent- it's no longer an instant melee counter. The negative of having low melee damage is offset far to much by the complete lack of any negatives if you just shoot them point blank. Needs testing, but I don't see how it could not work.