### PR TITLE
Guardsmen Slot Increases

### DIFF
--- a/code/game/jobs/job/astra_militarum.dm
+++ b/code/game/jobs/job/astra_militarum.dm
@@ -54,8 +54,8 @@
 
 /datum/job/ig/guardsman
 	title = "Imperial Guardsman"
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 6
+	spawn_positions = 6
 	social_class = SOCIAL_CLASS_MED //Guards are at least pretty respected in imperial society
 	auto_rifle_skill = 8
 	semi_rifle_skill = 8
@@ -139,8 +139,8 @@
 
 /datum/job/ig/guardsman/sharpshooter // can i be fucked renaming every /sharpshooter into /spec? no. remember to just call /sharpshooter/[regiment] instead
 	title = "Imperial Guard Specialist"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 2
+	spawn_positions = 2
 	open_when_dead = FALSE
 	outfit_type = /decl/hierarchy/outfit/job/sharpshooter
 	auto_rifle_skill = 10
@@ -220,8 +220,8 @@ datum/job/ig/bullgryn
 
 /datum/job/ig/guardsman/sniper
 	title = "Imperial Guard Sniper"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 2
+	spawn_positions = 2
 	open_when_dead = FALSE
 	outfit_type = /decl/hierarchy/outfit/job/sniper
 	auto_rifle_skill = 7
@@ -341,8 +341,8 @@ datum/job/ig/bullgryn
 	department_flag = SEC
 	social_class = SOCIAL_CLASS_MED
 	can_be_in_squad = TRUE
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 2
+	spawn_positions = 2
 	open_when_dead = FALSE
 	selection_color = "#33813A"
 	economic_modifier = 4


### PR DESCRIPTION
Increases base guardsmen spots by 2 and other special guardsmen slots by 1, making the total guard count be from 8 to 13. Expands the Guard so it can be better used in rounds with more pop.

![screenshot](https://github.com/WoodenTucker/40K-Eipharius/assets/42359139/7accae28-80c5-4cc9-af2d-7a9060529bbe)
