### PR TITLE
Trench Speed Buff & Meat Price Update

### DIFF
--- a/code/game/gamemodes/warfare/turfs.dm
+++ b/code/game/gamemodes/warfare/turfs.dm
@@ -141,7 +141,7 @@
 					return
 			playsound(src, 'sound/effects/dig_shovel.ogg', 50, 0)
 			visible_message("[user] begins to dig some dirt cover!")
-			if(do_after(user, (backwards_skill_scale(user.SKILL_LEVEL(engineering)) * 10)))
+			if(do_after(user, (backwards_skill_scale(user.SKILL_LEVEL(engineering)) * 5)))
 				new /obj/structure/dirt_wall(src)
 				visible_message("[user] finishes digging the dirt cover.")
 				playsound(src, 'sound/effects/empty_shovel.ogg', 50, 0)
@@ -171,7 +171,7 @@
 				return
 		playsound(src, 'sound/effects/dig_shovel.ogg', 50, 0)
 		visible_message("[user] begins to dig a trench!")
-		if(do_after(user, backwards_skill_scale(user.SKILL_LEVEL(engineering)) * 10))
+		if(do_after(user, backwards_skill_scale(user.SKILL_LEVEL(engineering)) * 5))
 			ChangeTurf(/turf/simulated/floor/trench)
 			visible_message("[user] finishes digging the trench.")
 			playsound(src, 'sound/effects/empty_shovel.ogg', 50, 0)
@@ -203,7 +203,7 @@
 				return
 		playsound(src, 'sound/effects/dig_shovel.ogg', 50, 0)
 		visible_message("[user] begins to dig a trench!")
-		if(do_after(user, backwards_skill_scale(user.SKILL_LEVEL(engineering)) * 10))
+		if(do_after(user, backwards_skill_scale(user.SKILL_LEVEL(engineering)) * 5))
 			ChangeTurf(/turf/simulated/floor/trench)
 			visible_message("[user] finishes digging the trench.")
 			playsound(src, 'sound/effects/empty_shovel.ogg', 50, 0)
@@ -229,7 +229,7 @@
 					return
 			playsound(src, 'sound/effects/dig_shovel.ogg', 50, 0)
 			visible_message("[user] begins to dig a grave!")
-			if(do_after(user, (backwards_skill_scale(user.SKILL_LEVEL(engineering)) * 10)))
+			if(do_after(user, (backwards_skill_scale(user.SKILL_LEVEL(engineering)) * 5)))
 				new /obj/structure/closet/pit(src)
 				visible_message("[user] finishes digging the grave!")
 				playsound(src, 'sound/effects/empty_shovel.ogg', 50, 0)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -677,11 +677,11 @@
 
 /obj/item/reagent_containers/food/snacks/bearmeat
 	name = "bear meat"
-	desc = "A very manly slab of meat, don't eat it raw!"
+	desc = "A prime slab of meat, considered a delicacy by many imperial nobles. The trader will want this."
 	icon_state = "bearmeat"
 	filling_color = "#db0000"
 	center_of_mass = "x=16;y=10"
-	sales_price = 5
+	sales_price = 25
 
 	New()
 		..()
@@ -691,11 +691,11 @@
 
 /obj/item/reagent_containers/food/snacks/shaframeat
 	name = "shafra meat"
-	desc = "A surprisingly tasty cut of lean meat, don't eat it raw!"
+	desc = "A prime slab of meat, considered a delicacy by many imperial nobles. The trader will want this."
 	icon_state = "bearmeat"
 	filling_color = "#08acf8cc"
 	center_of_mass = "x=16;y=10"
-	sales_price = 6
+	sales_price = 25
 
 	New()
 		..()
@@ -709,7 +709,7 @@
 	icon_state = "bearmeat"
 	filling_color = "#08acf8cc"
 	center_of_mass = "x=16;y=10"
-	sales_price = 15
+	sales_price = 30
 
 	New()
 		..()


### PR DESCRIPTION
Made all trench related construction activities significantly faster. Guardsmen should now not have to spend 45 minutes every round staring at a progression bar.

Also buffed the sale price of some raw types of meat gotten from simple mobs as part of an economy update.
![mwq7RgUtED](https://github.com/WoodenTucker/40K-Eipharius/assets/139377634/44ca211d-03ce-49fe-a45e-9c08f1ef4cb9)

