### PR TITLE
Nullrod Fix

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1143,7 +1143,6 @@
 					/obj/item/device/flashlight/lamp = 2,
 					/obj/item/device/flashlight/lamp/green = 2,
 					/obj/item/reagent_containers/food/drinks/jar = 1,
-					/obj/item/nullrod = 1,
 					/obj/item/toy/cultsword = 1)
 
 //FOR ACTORS GUILD - Containers


### PR DESCRIPTION
Removed fully functional magical item from being dispensed from a toy machine. Think of the children!
![9HEijBwsbo](https://github.com/WoodenTucker/40K-Eipharius/assets/139377634/d373b03e-83ed-4e8b-a128-3f95b3eb837b)
