### PR TITLE
Nurgle Heal Rework

### DIFF
--- a/code/modules/cultist/effects/nurgle.dm
+++ b/code/modules/cultist/effects/nurgle.dm
@@ -64,14 +64,26 @@
 /mob/living/carbon/human/proc/nurgle_heal()
 	set category = "Ruinous Powers"
 	set name = "Heal (20)"
-	set desc = "Heal injuries in exchange for taking toxin damage, and tiring yourself."
+	set desc = "Heal injuries in exchange for tiring yourself."
+	
+	if(!ishuman(src))
+		return
+	if(src.stat == DEAD)
+		to_chat(src, "<span class='notice'>You can't do this while you're dead.</span>")
+		return
 	if(staminaloss >= staminaexhaust / 2)
 		return FALSE
-	visible_message("[src]'s body covers their wounds with large puss-filled growths!")
-	adjustOxyLoss(-1)
-	adjustToxLoss(1)
+	if(src.quote_cd == 0)
+		visible_message("[src]'s body covers their wounds with large pus-filled growths!")
+		src.quote_cd = 1
+		sleep(20)
+		src.quote_cd = 0
+	else
+		to_chat(src, "You cannot do that yet.")
+		return
+	adjustOxyLoss(-2)
 	adjustBruteLoss(-2)
-	adjustFireLoss(-1)
+	adjustFireLoss(-2)
 	eye_blurry = 0
 	ear_deaf = 0
 	ear_damage = 0


### PR DESCRIPTION
Wounds will no longer be covered with kittens. Removed toxin being added. Made it stronger but also added a cooldown and removed the ability to spam it when you're super dead.
![JddzWKfecg](https://github.com/WoodenTucker/40K-Eipharius/assets/139377634/63986c22-c56b-4486-9725-92c49597950c)
