### PR TITLE
small dupe bug fix and some sprites changed

### DIFF
--- a/code/game/jobs/job/astra_militarum.dm
+++ b/code/game/jobs/job/astra_militarum.dm
@@ -667,10 +667,10 @@ datum/job/ig/bullgryn
 /decl/hierarchy/outfit/job/kasrkin
 	name = OUTFIT_JOB_NAME("Kasrkin")
 	uniform = /obj/item/clothing/under/cadian_uniform
-	suit = /obj/item/clothing/suit/armor/kasrkin
 	back = /obj/item/storage/backpack/satchel/warfare
 	belt = /obj/item/device/flashlight/lantern
 	gloves = /obj/item/clothing/gloves/combat/cadian
+	suit = /obj/item/clothing/suit/armor/kasrkin
 	shoes = /obj/item/clothing/shoes/jackboots/cadian
 	head = /obj/item/clothing/head/helmet/kasrkin
 	mask = /obj/item/clothing/mask/gas/half/cadianrespirator

--- a/code/game/jobs/job/pilgrims.dm
+++ b/code/game/jobs/job/pilgrims.dm
@@ -72,6 +72,10 @@ Pilgrim Fate System
 	if(src.stat == DEAD)
 		to_chat(src, "<span class='notice'>You can't choose a class when you're dead.</span>")
 		return
+	if(inmenu == TRUE)
+		to_chat(src, "<span class='notice'>There is only one fate for you, mortal.</span>")
+		return
+	inmenu = TRUE
 
 	var/mob/living/carbon/human/U = src
 	var/fates = list("Mercenary","Penitent","Nomad","Rat Catcher","Musician","Hunter","Drug Dealer")
@@ -228,6 +232,11 @@ Pilgrim Fate System
 	if(src.stat == DEAD)
 		to_chat(src, "<span class='notice'>You can't choose a class when you're dead.</span>")
 		return
+	if(inmenu == TRUE)
+		to_chat(src, "<span class='notice'>There is only one fate for you, mortal.</span>")
+		return
+	inmenu = TRUE
+
 
 	var/mob/living/carbon/human/U = src
 	var/fates = list("Merchant","PDF","Miner","Cleric","Private Investigator")

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -156,7 +156,7 @@
 /obj/item/clothing/head/helmet/kasrkin
 	name = "kasrkin helmet"
 	desc = "A carapace helmet belonging to the elite stormtroopers of the Kasrkin. Cadia may not be intact, but your brain will when in combat with this on."
-	icon_state = "kasrkinhelmetb"
+	icon_state = "kasrkinhelmet"
 	armor = list(melee = 40, bullet = 45, laser = 45, energy = 35, bomb = 50, bio = 0, rad = 10)
 	siemens_coefficient = 0.6
 	sales_price = 25

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -754,8 +754,8 @@ obj/item/clothing/suit/armor
 /obj/item/clothing/suit/armor/whiteshield
 	name = "Cadian Pattern Conscript Flak Armour - Light"
 	desc = "The standard armour found throughout the Cadian-oriented PDF and Cadian Regiments, It is so common that it became symbol of the Astra Militarum as a whole. This one is in it light configuration, issued to the Whiteshields."
-	icon_state = "wshield"
-	item_state = "wshield"
+	icon_state = "fvest"
+	item_state = "fvest"
 	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
 	armor = list(melee = 38, bullet = 38, laser = 35, energy = 20, bomb = 30, bio = 40, rad = 30)
 	sales_price = 12
@@ -1753,8 +1753,8 @@ obj/item/clothing/suit/armor
 /obj/item/clothing/suit/armor/kasrkin
 	name = "Kasrkin Carapace"
 	desc = "The Carapace Armor of an Elite Kasrkin, a reliable stormtrooper armor."
-	icon_state = "kasrkinarmorb"
-	item_state = "kasrkinarmorb"
+	icon_state = "kasrkinarmor"
+	item_state = "kasrkinarmor"
 	armor = list(melee = 50, bullet = 62, laser = 62, energy = 25, bomb = 40, bio = 40, rad = 40)
 	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -9,7 +9,7 @@
 	var/embedded_flag	  //To check if we've need to roll for damage on movement while an item is imbedded in us.
 	var/stealth = FALSE
 	var/scooldown = FALSE
-	var/inmenu = 0 //stop menu spammers
+	var/inmenu = FALSE //used to stop menu spammers in /datum/job/penitent
 	var/can_toggle = 1
 	var/is_toggled = 1 //armblade shit
 	var/gsc = 0 //for cult to hide icon


### PR DESCRIPTION
Splats the bug with the Select your Class verb duping some items if clicked enough, redirects the whiteshield flak armor to a sprite that exists and makes the Kasrkin less neon and put their gloves on when they spawn.
![image](https://github.com/WoodenTucker/40K-Eipharius/assets/87212324/36d2a19e-1438-4a4e-bf10-c034ba71938e)
