### PR TITLE
Reenables some accessory code and minor fixes

### DIFF
--- a/code/game/jobs/job/astra_militarum.dm
+++ b/code/game/jobs/job/astra_militarum.dm
@@ -667,11 +667,11 @@ datum/job/ig/bullgryn
 /decl/hierarchy/outfit/job/kasrkin
 	name = OUTFIT_JOB_NAME("Kasrkin")
 	uniform = /obj/item/clothing/under/cadian_uniform
-	suit = /obj/item/clothing/suit/armor/kasrkin
 	back = /obj/item/storage/backpack/satchel/warfare
 	belt = /obj/item/device/flashlight/lantern
 	gloves = /obj/item/clothing/gloves/combat/cadian
 	shoes = /obj/item/clothing/shoes/jackboots/cadian
+	suit = /obj/item/clothing/suit/armor/kasrkin
 	head = /obj/item/clothing/head/helmet/kasrkin
 	mask = /obj/item/clothing/mask/gas/half/cadianrespirator
 	glasses = /obj/item/clothing/glasses/cadian

--- a/code/game/jobs/job/astra_militarum.dm
+++ b/code/game/jobs/job/astra_militarum.dm
@@ -669,7 +669,7 @@ datum/job/ig/bullgryn
 	uniform = /obj/item/clothing/under/cadian_uniform
 	back = /obj/item/storage/backpack/satchel/warfare
 	belt = /obj/item/device/flashlight/lantern
-	gloves = /obj/item/clothing/gloves/combat/cadian
+	gloves = null
 	shoes = /obj/item/clothing/shoes/jackboots/cadian
 	suit = /obj/item/clothing/suit/armor/kasrkin
 	head = /obj/item/clothing/head/helmet/kasrkin
@@ -679,7 +679,7 @@ datum/job/ig/bullgryn
 	neck = /obj/item/reagent_containers/food/drinks/canteen
 	l_ear = /obj/item/device/radio/headset/red_team
 	l_pocket = /obj/item/storage/box/ifak
-	r_pocket = null
+	r_pocket = /obj/item/clothing/gloves/combat/cadian
 	suit_store = /obj/item/gun/energy/las/hotshot //Hotshots are annoyingly common, makes them standout more.
 	backpack_contents = list(
 	/obj/item/reagent_containers/food/snacks/warfare/rat = 1,

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -154,7 +154,7 @@
 		icon = sprite_sheets_obj[target_species]
 	else
 		icon = initial(icon)
-/*
+
 /obj/item/clothing/get_examine_line()
 	. = ..()
 	var/list/ties = list()
@@ -165,7 +165,7 @@
 		.+= " with [english_list(ties)] attached"
 	if(accessories.len > ties.len)
 		.+= ". <a href='?src=\ref[src];list_ungabunga=1'>\[See accessories\]</a>"
-*/
+
 /obj/item/clothing/CanUseTopic(var/user)
 	if(user in view(get_turf(src)))
 		return STATUS_INTERACTIVE

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -59,12 +59,12 @@
 		if("l_hand")
 			usr.put_in_l_hand(src)
 	src.add_fingerprint(usr)
-/*
+
 /obj/item/clothing/examine(var/mob/user)
 	. = ..(user)
 	for(var/obj/item/clothing/accessory/A in accessories)
 		to_chat(user, "\icon[A] \A [A] is attached to it.")
-*/
+
 /obj/item/clothing/proc/update_accessory_slowdown()
 	slowdown_accessory = 0
 	for(var/obj/item/clothing/accessory/A in accessories)
@@ -79,7 +79,7 @@
 /obj/item/clothing/proc/attach_accessory(mob/user, obj/item/clothing/accessory/A)
 	accessories += A
 	A.on_attached(src, user)
-	//src.verbs |= /obj/item/clothing/proc/removetie_verb
+	src.verbs |= /obj/item/clothing/proc/removetie_verb
 	update_accessory_slowdown()
 	update_clothing_icon()
 

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -156,7 +156,7 @@
 /obj/item/clothing/head/helmet/kasrkin
 	name = "kasrkin helmet"
 	desc = "A carapace helmet belonging to the elite stormtroopers of the Kasrkin. Cadia may not be intact, but your brain will when in combat with this on."
-	icon_state = "kasrkinhelmetb"
+	icon_state = "kasrkinhelmet"
 	armor = list(melee = 40, bullet = 45, laser = 45, energy = 35, bomb = 50, bio = 0, rad = 10)
 	siemens_coefficient = 0.6
 	sales_price = 25

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -754,8 +754,8 @@ obj/item/clothing/suit/armor
 /obj/item/clothing/suit/armor/whiteshield
 	name = "Cadian Pattern Conscript Flak Armour - Light"
 	desc = "The standard armour found throughout the Cadian-oriented PDF and Cadian Regiments, It is so common that it became symbol of the Astra Militarum as a whole. This one is in it light configuration, issued to the Whiteshields."
-	icon_state = "wshield"
-	item_state = "wshield"
+	icon_state = "fvest"
+	item_state = "fvest"
 	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
 	armor = list(melee = 38, bullet = 38, laser = 35, energy = 20, bomb = 30, bio = 40, rad = 30)
 	sales_price = 12
@@ -1753,8 +1753,8 @@ obj/item/clothing/suit/armor
 /obj/item/clothing/suit/armor/kasrkin
 	name = "Kasrkin Carapace"
 	desc = "The Carapace Armor of an Elite Kasrkin, a reliable stormtrooper armor."
-	icon_state = "kasrkinarmorb"
-	item_state = "kasrkinarmorb"
+	icon_state = "kasrkinarmor"
+	item_state = "kasrkinarmor"
 	armor = list(melee = 50, bullet = 62, laser = 62, energy = 25, bomb = 40, bio = 40, rad = 40)
 	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET


### PR DESCRIPTION
- The kasrkin is no longer neon, but why they won't put on their gloves, I don't know. They'll find them in their pocket instead.
- Whiteshields have actual ingame flakvests now instead of a missing sprite.
- Some accessory code has been uncommented so that players can view accessories others are wearing, on their clothes and also remove them from said clothes.
![image](https://github.com/WoodenTucker/40K-Eipharius/assets/87212324/785e5c8a-14e2-4170-b5b1-62983d15dac5)



