### PR TITLE
Silly Wil Update

### DIFF
--- a/code/_global_vars/misc.dm
+++ b/code/_global_vars/misc.dm
@@ -22,7 +22,7 @@ GLOBAL_VAR_INIT(deployed, 0)
 GLOBAL_VAR_INIT(partygang, 0)
 GLOBAL_VAR_INIT(partydelay, 48000)
 GLOBAL_VAR_INIT(thrones, 0) //used for cargo and reinforcement system, so it carries across computers
-GLOBAL_VAR_INIT(tax_rate, 0.1) //used for taxation
+GLOBAL_VAR_INIT(tax_rate, 0) //used for taxation
 GLOBAL_VAR_INIT(tithe_paid, 0) //did they pay their tithe or not yet?
 GLOBAL_VAR_INIT(partysize, 5)
 

--- a/code/datums/outfits/jobs/engineering.dm
+++ b/code/datums/outfits/jobs/engineering.dm
@@ -78,7 +78,7 @@
 		/obj/item/reagent_containers/food/snacks/warfare/rat = 1,
 		/obj/item/stack/thrones = 1,
 		/obj/item/stack/thrones2 = 1,
-		/obj/item/stack/thrones3/five = 1,
+		/obj/item/pickaxe/mechanicus = 1,
 		/obj/item/book/manual/ripley_build_and_repair = 1,
 )
 

--- a/code/game/jobs/job/adeptus_mechanicus.dm
+++ b/code/game/jobs/job/adeptus_mechanicus.dm
@@ -73,7 +73,7 @@
 	shotgun_skill = 6
 	lmg_skill = 6
 	smg_skill = 7
-	cultist_chance = 7
+	cultist_chance = 4
 
 	equip(var/mob/living/carbon/human/H)
 		var/current_name = H.real_name
@@ -117,7 +117,7 @@
 	shotgun_skill = 6
 	lmg_skill = 6
 	smg_skill = 6
-	cultist_chance = 11
+	cultist_chance = 8
 
 	equip(var/mob/living/carbon/human/H)
 		var/current_name = H.real_name
@@ -165,7 +165,7 @@
 	shotgun_skill = 6
 	lmg_skill = 6
 	smg_skill = 7
-	cultist_chance = 8
+	cultist_chance = 5
 
 	equip(var/mob/living/carbon/human/H)
 		var/current_name = H.real_name
@@ -211,7 +211,7 @@
 	shotgun_skill = 8
 	lmg_skill = 8
 	smg_skill = 8
-	cultist_chance = 6
+	cultist_chance = 4
 
 	equip(var/mob/living/carbon/human/H)
 		var/current_name = H.real_name

--- a/code/game/jobs/job/adeptus_ministorum.dm
+++ b/code/game/jobs/job/adeptus_ministorum.dm
@@ -36,6 +36,7 @@
 		H.get_idcard()?.access = list(access_heads, access_security, access_guard_common, access_all_personal_lockers, access_village, access_advchapel,)
 		H.warfare_language_shit(LANGUAGE_HIGH_GOTHIC)
 		H.adjustStaminaLoss(-INFINITY)
+		H.set_trait(new/datum/trait/death_tolerant())
 		H.warfare_faction = IMPERIUM
 		H.verbs += list(
 			/mob/living/carbon/human/proc/deaconclass)
@@ -233,6 +234,7 @@
 		H.get_equipped_item(slot_s_store)
 		H.warfare_faction = IMPERIUM
 		H.gender = FEMALE
+		H.set_trait(new/datum/trait/death_tolerant())
 		H.get_idcard()?.access = list(access_heads, access_security, access_guard_common, access_magi, access_all_personal_lockers, access_advchapel, access_medical, access_village)
 		H.warfare_language_shit(LANGUAGE_LOW_GOTHIC)
 		H.warfare_language_shit(LANGUAGE_HIGH_GOTHIC)
@@ -284,6 +286,7 @@
 		H.warfare_faction = IMPERIUM
 		H.gender = FEMALE
 		H.adjustStaminaLoss(-INFINITY)
+		H.set_trait(new/datum/trait/death_tolerant())
 		H.warfare_language_shit(LANGUAGE_LOW_GOTHIC)
 		H.warfare_language_shit(LANGUAGE_HIGH_GOTHIC)
 		H.f_style = "shaved"
@@ -346,6 +349,7 @@
 		H.warfare_language_shit(LANGUAGE_LOW_GOTHIC )
 		H.warfare_language_shit(LANGUAGE_HIGH_GOTHIC)
 		H.adjustStaminaLoss(-INFINITY)
+		H.set_trait(new/datum/trait/death_tolerant())
 		H.get_equipped_item(slot_s_store)
 		H.gender = FEMALE
 		H.warfare_faction = IMPERIUM

--- a/code/game/jobs/job/astra_militarum.dm
+++ b/code/game/jobs/job/astra_militarum.dm
@@ -121,7 +121,7 @@
 	shotgun_skill = 6
 	lmg_skill = 7
 	smg_skill = 7
-	cultist_chance = 15 // sir what is a heretic
+	cultist_chance = 10 // sir what is a heretic
 
 	equip(var/mob/living/carbon/human/H)
 		H.warfare_faction = IMPERIUM
@@ -202,8 +202,8 @@ datum/job/ig/bullgryn
 	title = "Bullgryn"
 	social_class = SOCIAL_CLASS_MED //is it lore accurate? no, does it make sense to have a bullgryn here? also no
 	selection_color = "#33813A"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 2
+	spawn_positions = 2
 	supervisors = "Da Emprah. Da Commesar, and da little on's!"
 	outfit_type = /decl/hierarchy/outfit/job/bullgryn
 	latejoin_at_spawnpoints = TRUE
@@ -219,6 +219,7 @@ datum/job/ig/bullgryn
 		H.add_stats(rand(20,30), rand(17,19), rand(15,18), rand (2,5)) //bullgryn are stronger and quicker than normal ogryn due to their advanced training
 		H.add_skills(rand(10,15),1,1,4,1) //melee, ranged, med, eng, surgery
 		H.warfare_language_shit(LANGUAGE_LOW_GOTHIC)
+		H.set_trait(new/datum/trait/death_tolerant())
 		H.vice = null
 		to_chat(H, "<span class='notice'><b><font size=3>MA BEST FREND'S DA EMPRAH. FREND OF GOBERNOR. FREND OF DA COMESSAR. PROTECT DA LITTL UN'S!</font></b></span>")
 
@@ -235,7 +236,7 @@ datum/job/ig/bullgryn
 	shotgun_skill = 6
 	lmg_skill = 7
 	smg_skill = 8
-	cultist_chance = 16 
+	cultist_chance = 10
 	alt_titles = list(
 		"Cadian Long Las" = /decl/hierarchy/outfit/job/sniper,
 		"Valhallan Scout Sniper" = /decl/hierarchy/outfit/job/sniper/valhalla,
@@ -323,6 +324,7 @@ datum/job/ig/bullgryn
 		H.set_trait(new/datum/trait/death_tolerant())
 		H.warfare_language_shit(LANGUAGE_LOW_GOTHIC)
 		H.adjustStaminaLoss(-INFINITY)
+		H.set_trait(new/datum/trait/death_tolerant())
 		H.assign_squad_leader(IMPERIUM)
 		H.warfare_faction = IMPERIUM
 //		H.vice = null //sarges seen some shit
@@ -445,6 +447,7 @@ datum/job/ig/bullgryn
 		H.warfare_language_shit(LANGUAGE_LOW_GOTHIC)
 		H.warfare_language_shit(LANGUAGE_HIGH_GOTHIC)
 		H.adjustStaminaLoss(-INFINITY)
+		H.set_trait(new/datum/trait/death_tolerant())
 		H.get_idcard()?.access = list(access_security, access_guard_common, access_magi, access_all_personal_lockers, access_village, access_guard_armory, access_armory)
 		H.warfare_faction = IMPERIUM
 //		H.vice = null //THE VETERAN HAS SEEN SOME SHIT BRO
@@ -493,6 +496,7 @@ datum/job/ig/bullgryn
 		H.warfare_language_shit(LANGUAGE_LOW_GOTHIC )
 		H.warfare_language_shit(LANGUAGE_HIGH_GOTHIC)
 		H.adjustStaminaLoss(-INFINITY)
+		H.set_trait(new/datum/trait/death_tolerant())
 		H.fully_replace_character_name("Commissar [current_name]")
 		H.get_idcard()?.access = list(access_security, access_guard_common, access_magi, access_all_personal_lockers, access_village, access_guard_armory, access_armory)
 		H.warfare_faction = IMPERIUM
@@ -779,6 +783,7 @@ datum/job/ig/bullgryn
 	backpack_contents = list(
 	/obj/item/cell/lasgun/hotshot = 1,
 	/obj/item/stack/thrones2 = 1,
+	/obj/item/clothing/accessory/holster/waist = 1,
 	/obj/item/stack/thrones3/five = 1
 	)
 
@@ -807,6 +812,7 @@ datum/job/ig/bullgryn
 	backpack_contents = list(
 	/obj/item/cell/lasgun/hotshot = 1,
 	/obj/item/stack/thrones2 = 1,
+	/obj/item/clothing/accessory/holster/waist = 1,
 	/obj/item/stack/thrones3/five = 1
 	)
 
@@ -834,6 +840,7 @@ datum/job/ig/bullgryn
 	/obj/item/cell/lasgun = 2,
 	/obj/item/stack/thrones2 = 1,
 	/obj/item/stack/thrones3/five = 1,
+	/obj/item/clothing/accessory/holster/waist = 1,
 	/obj/item/shovel/krieg = 1
 	)
 
@@ -859,6 +866,7 @@ datum/job/ig/bullgryn
 	/obj/item/reagent_containers/food/snacks/warfare/rat = 1,
 	/obj/item/stack/thrones2 = 1,
 	/obj/item/handcuffs = 1,
+	/obj/item/clothing/accessory/holster/waist = 1,
 	/obj/item/stack/thrones3/five = 1
 	)
 
@@ -880,6 +888,7 @@ datum/job/ig/bullgryn
 	backpack_contents = list(
 	/obj/item/ammo_magazine/c556/ms = 4,
 	/obj/item/stack/thrones2 = 1,
+	/obj/item/clothing/accessory/holster/waist = 1,
 	/obj/item/stack/thrones3/five = 1
 	)
 
@@ -906,6 +915,7 @@ datum/job/ig/bullgryn
 	/obj/item/reagent_containers/food/snacks/warfare/rat = 1,
 	/obj/item/stack/thrones = 1,
 	/obj/item/cell/lasgun/hotshot = 3,
+	/obj/item/clothing/accessory/holster/waist = 1
 	)
 
 
@@ -931,6 +941,7 @@ datum/job/ig/bullgryn
 	backpack_contents = list(
 	/obj/item/cell/plasma = 2,
 	/obj/item/stack/thrones2 = 1,
+	/obj/item/clothing/accessory/holster/waist = 1,
 	/obj/item/stack/thrones3/five = 1
 	)
 
@@ -958,6 +969,7 @@ datum/job/ig/bullgryn
 	backpack_contents = list(
 	/obj/item/ammo_magazine/box/a556/mg08/ms = 2,
 	/obj/item/stack/thrones2 = 1,
+	/obj/item/clothing/accessory/holster/waist = 1,
 	/obj/item/stack/thrones3/five = 1,
 	)
 
@@ -982,6 +994,7 @@ datum/job/ig/bullgryn
 	/obj/item/cell/lasgun/hotshot = 1,
 	/obj/item/stack/thrones2 = 1,
 	/obj/item/stack/thrones3/five = 1,
+	/obj/item/clothing/accessory/holster/waist = 1,
 	/obj/item/shovel/krieg = 1
 	)
 
@@ -1005,6 +1018,7 @@ datum/job/ig/bullgryn
 	backpack_contents = list(
 	/obj/item/ammo_magazine/flamer = 3,
 	/obj/item/stack/thrones2 = 1,
+	/obj/item/clothing/accessory/holster/waist = 1,
 	/obj/item/stack/thrones3/five = 1
 	)
 
@@ -1025,10 +1039,12 @@ datum/job/ig/bullgryn
 	r_ear = /obj/item/device/radio/headset/red_team
 	belt = /obj/item/device/flashlight/lantern
 	pda_slot = null
-	r_hand = /obj/item/shield/riot
+	r_hand = /obj/item/shield/riot/metal
 	l_hand = /obj/item/melee/classic_baton/trench_club
 	backpack_contents = list(
-	/obj/item/grenade/frag = 1
+	/obj/item/grenade/frag = 1,
+	/obj/item/shield/buckler = 1,
+	/obj/item/clothing/accessory/holster/waist = 1,
 	)
 
 
@@ -1229,7 +1245,7 @@ datum/job/ig/bullgryn
 	/obj/item/reagent_containers/food/snacks/warfare/rat = 1,
 	/obj/item/stack/thrones = 1,
 	/obj/item/stack/thrones2 = 1,
-	/obj/item/stack/thrones3/five = 1
+	/obj/item/clothing/accessory/holster/waist = 1
 	)
 
 	id_type = /obj/item/card/id/dog_tag/guardsman
@@ -1258,7 +1274,7 @@ datum/job/ig/bullgryn
 	/obj/item/reagent_containers/food/snacks/warfare/rat = 1,
 	/obj/item/stack/thrones = 1,
 	/obj/item/stack/thrones2 = 1,
-	/obj/item/stack/thrones3/five = 1,
+	/obj/item/clothing/accessory/holster/waist = 1,
 	/obj/item/handcuffs = 1,
 	/obj/item/shovel/krieg = 1
 	)
@@ -1283,7 +1299,7 @@ datum/job/ig/bullgryn
 	/obj/item/reagent_containers/food/snacks/warfare/rat = 1,
 	/obj/item/stack/thrones = 1,
 	/obj/item/stack/thrones2 = 1,
-	/obj/item/stack/thrones3/five = 1,
+	/obj/item/clothing/accessory/holster/waist = 1,
 	/obj/item/handcuffs = 1
 	)
 
@@ -1305,7 +1321,7 @@ datum/job/ig/bullgryn
 	/obj/item/reagent_containers/food/snacks/warfare/rat = 1,
 	/obj/item/stack/thrones = 1,
 	/obj/item/stack/thrones2 = 1,
-	/obj/item/stack/thrones3/five = 1,
+	/obj/item/clothing/accessory/holster/waist = 1,
 	/obj/item/handcuffs = 1
 	)
 
@@ -1336,7 +1352,7 @@ datum/job/ig/bullgryn
 	/obj/item/reagent_containers/food/snacks/warfare/rat = 1,
 	/obj/item/stack/thrones/five = 1,
 	/obj/item/stack/thrones2/five = 1,
-	/obj/item/stack/thrones3/five = 1,
+	/obj/item/clothing/accessory/holster/waist = 1,
 	/obj/item/handcuffs = 1
 	)
 
@@ -1562,6 +1578,7 @@ GLOBAL_LIST_INIT(lone_thoughts, list(
 	/obj/item/gun/energy/las/laspistol = 1,
 	/obj/item/stack/thrones = 1,
 	/obj/item/stack/thrones2 = 1,
+	/obj/item/clothing/accessory/holster/waist = 1,
 	)
 
 /decl/hierarchy/outfit/job/bloodpact2 // Old
@@ -1585,6 +1602,7 @@ GLOBAL_LIST_INIT(lone_thoughts, list(
 	/obj/item/cell/lasgun = 2,
 	/obj/item/grenade/frag/high_yield/krak = 1,
 	/obj/item/reagent_containers/food/snacks/warfare/rat = 1,
+	/obj/item/clothing/accessory/holster/waist = 1,
 	)
 
 /decl/hierarchy/outfit/job/vraks // generic culty boy
@@ -1607,6 +1625,7 @@ GLOBAL_LIST_INIT(lone_thoughts, list(
 	backpack_contents = list(
 	/obj/item/grenade/frag = 1,
 	/obj/item/reagent_containers/food/snacks/warfare/rat = 1,
+	/obj/item/clothing/accessory/holster/waist = 1,
 	)
 
 // chaos sgt

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -68,12 +68,13 @@
 	equip(var/mob/living/carbon/human/H)
 		var/current_name = H.real_name
 		..()
-		H.fully_replace_character_name("Farmer [current_name]")
-		H.add_stats(rand(14,16), rand(13,15), rand(14,16), rand(8,14)) //well fed and robust
+		H.fully_replace_character_name("[current_name]")
+		H.add_stats(rand(15,17), rand(14,16), rand(15,16), rand(8,14)) //well fed and robust
 		H.add_skills(rand(7,10),rand(6,10),rand(3,5),rand(2,4),3) //farmers are handy
 		H.assign_random_quirk()
 		H.warfare_language_shit(LANGUAGE_LOW_GOTHIC)
 		H.adjustStaminaLoss(-INFINITY)
+		H.set_trait(new/datum/trait/death_tolerant())
 		H.warfare_faction = IMPERIUM
 		to_chat(H, "<span class='notice'><b><font size=3>You are one of the few skilled hands on this frozen hellscape capable of keeping these apostates from starving in the winter.</font></b></span>")
 

--- a/code/game/jobs/job/governorship.dm
+++ b/code/game/jobs/job/governorship.dm
@@ -40,6 +40,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 		H.warfare_language_shit(LANGUAGE_LOW_GOTHIC)
 		H.warfare_language_shit(LANGUAGE_HIGH_GOTHIC )
 		H.adjustStaminaLoss(-INFINITY)
+		H.set_trait(new/datum/trait/death_tolerant())
 		H.warfare_faction = IMPERIUM
 		H.verbs += list(/mob/living/carbon/human/proc/hire)
 		to_chat(H, "<span class='notice'><b><font size=3>  </font></b></span>")
@@ -69,7 +70,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	shotgun_skill = 7
 	lmg_skill = 7
 	smg_skill = 7
-	cultist_chance = 15 // lots of delicacies growing up
+	cultist_chance = 5 // lots of delicacies growing up
 
 	equip(var/mob/living/carbon/human/H)
 		var/current_name = H.real_name
@@ -123,7 +124,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	switch(classchoice)
 
 		if("ROLL THE DICE!")
-			if(prob(95))
+			if(prob(65))
 				to_chat(U,"<span class='danger'><b><font size=4>THE LOYALIST</font></b></span>")
 				to_chat(U,"<span class='goodmood'><b><font size=3>A loyal servant to the imperium, as Governor of the Eipharius colony and proclaimed master of the xenos city of Eipharius it is your responsibility to ensure both the continued survival of The Imperium and your family. Resting upon your shoulders is the countless untold billions who might one day spawn from your world, of the countless wars that shall surely be fought in your families name. This is your duty, your curse -- this is how you died.</font></b></span>")
 				equip_to_slot_or_store_or_drop(new /obj/item/gun/projectile/bolter_pistol, slot_wear_suit)
@@ -174,7 +175,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	switch(classchoice)
 
 		if("ROLL THE DICE!")
-			if(prob(80))
+			if(prob(50))
 				to_chat(U,"<span class='danger'><b><font size=4>THE LOYALIST</font></b></span>")
 				to_chat(U,"<span class='goodmood'><b><font size=3>A loyal servant to the imperium livin and underling to the master of the xenos city of Eipharius it is your responsibility to ensure both the continued survival of The Imperium and the Governor's lineage. This is your duty, your curse -- this is how you died.</font></b></span>")
 			else
@@ -274,7 +275,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	shotgun_skill = 7
 	lmg_skill = 6
 	smg_skill = 7
-	cultist_chance = 15
+	cultist_chance = 10
 
 	equip(var/mob/living/carbon/human/H)
 		var/current_name = H.real_name

--- a/code/game/jobs/job/inquisition.dm
+++ b/code/game/jobs/job/inquisition.dm
@@ -26,7 +26,7 @@
 		var/current_name = H.real_name
 		..()
 		H.fully_replace_character_name("[current_name]")
-		H.add_stats(rand(15,18), rand(15,18), rand(15,18), rand(15,18)) //highly trained and skilled
+		H.add_stats(rand(16,18), rand(16,18), rand(16,18), rand(15,18)) //highly trained and skilled
 		H.add_skills(rand(9,10),rand(9,10),rand(5,7),rand(5,6),rand(6,7)) //SUFFER NOT THE ALIEN, SUFFER NOT THE HERETIC
 		H.assign_random_quirk()
 		H.witchblood()
@@ -53,8 +53,8 @@
 	title = "Inquisitor" // PLAN: Renegade. Cult. Loyalist.
 	department_flag = INQ
 	social_class = SOCIAL_CLASS_MIN
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	head_position = 1
 	supervisors = "The Golden Throne and the Inquisition"
 	selection_color = "#b4821c"
@@ -76,7 +76,7 @@
 		var/current_name = H.real_name
 		..()
 		H.fully_replace_character_name("[current_name]")
-		H.add_stats(rand(17,18), rand(17,18), rand(17,18), rand(17,19)) //PRAISE THE EMPEROR
+		H.add_stats(rand(17,20), rand(17,21), rand(17,21), rand(17,19)) //PRAISE THE EMPEROR
 		H.add_skills(10,10,rand(7,10),rand(5,7),rand(7,8)) //melee, ranged, med, eng, surgery
 		H.assign_random_quirk()
 		H.warfare_language_shit(LANGUAGE_LOW_GOTHIC )

--- a/code/game/jobs/job/magistratum.dm
+++ b/code/game/jobs/job/magistratum.dm
@@ -89,8 +89,8 @@
 /datum/job/enforcer
 	title = "Enforcer" // Cult. Criminal. Loyal.
 	supervisors = "the Planetary Marshal, Deacon and Inquisition"
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 2
+	spawn_positions = 2
 	social_class = SOCIAL_CLASS_MED
 	selection_color = "#f0ac25"
 	outfit_type = /decl/hierarchy/outfit/job/ig/enforcer
@@ -100,7 +100,7 @@
 	shotgun_skill = 9
 	lmg_skill = 7
 	smg_skill = 7
-	cultist_chance = 15
+	cultist_chance = 8
 	can_be_in_squad = FALSE
 	open_when_dead = FALSE
 	department_flag = INQ
@@ -123,6 +123,7 @@
 		H.witchblood() //Becoming a psyker can happen at any point of your life bro.
 		H.warfare_language_shit(LANGUAGE_LOW_GOTHIC )
 		H.adjustStaminaLoss(-INFINITY)
+		H.set_trait(new/datum/trait/death_tolerant())
 		H.warfare_faction = IMPERIUM
 		H.get_idcard()?.access = list(access_security, access_guard_common, access_magi, access_all_personal_lockers, access_village,)
 
@@ -142,7 +143,7 @@
 	shotgun_skill = 7
 	lmg_skill = 5
 	smg_skill = 5
-	cultist_chance = 20
+	cultist_chance = 8
 	can_be_in_squad = FALSE
 	open_when_dead = FALSE
 	department_flag = INQ
@@ -166,6 +167,7 @@
 //		H.witchblood() //Psyker Enforcers don't exist
 		H.warfare_language_shit(LANGUAGE_LOW_GOTHIC )
 		H.adjustStaminaLoss(-INFINITY)
+		H.set_trait(new/datum/trait/death_tolerant())
 		H.warfare_faction = IMPERIUM
 		H.get_idcard()?.access = list(access_security, access_guard_common, access_magi, access_all_personal_lockers, access_village,)
 

--- a/code/game/jobs/job/pilgrims.dm
+++ b/code/game/jobs/job/pilgrims.dm
@@ -570,8 +570,8 @@ Pilgrim Fate System
 	title = "Pathfinder"
 	department_flag = PIL
 	social_class = SOCIAL_CLASS_MED
-	total_positions = 0
-	spawn_positions = 0
+	total_positions = 1
+	spawn_positions = 1
 	open_when_dead = 0
 	supervisors = "Your own morality and ethics."
 	selection_color = "#848484"
@@ -589,6 +589,7 @@ Pilgrim Fate System
 		H.add_skills(rand(7,9),rand(7,10),rand(4,6),4,rand(6,8)) //melee, ranged, med, eng, surgery
 		H.warfare_language_shit(LANGUAGE_LOW_GOTHIC)
 		H.adjustStaminaLoss(-INFINITY)
+		H.set_trait(new/datum/trait/death_tolerant())
 		H.assign_random_quirk()
 		to_chat(H, "<span class='notice'><b><font size=3>Having arrived recently from the spires of Necromunda. You, a former courtier, sought to establish something of a collection here with your remaining wealth. For whatever reason the dark, insidious and terrible aspects of this planet intrigued you enough to abandon your world and seek out... Eipharius.</font></b></span>")
 
@@ -615,6 +616,7 @@ Pilgrim Fate System
 		H.add_skills(rand(6,8),rand(6,7),rand(8,10),4,rand(8,10)) //melee, ranged, med, eng, surgery
 		H.warfare_language_shit(LANGUAGE_LOW_GOTHIC)
 		H.adjustStaminaLoss(-INFINITY)
+		H.set_trait(new/datum/trait/death_tolerant())
 		H.assign_random_quirk()
 		to_chat(H, "<span class='notice'><b><font size=3>An experienced medicae from your homeworld, you are one of many who booked passage to Eipharius in the hopes of building industries of medicine on a new world.</font></b></span>")
 
@@ -775,7 +777,9 @@ Pilgrim Fate System
 
 /decl/hierarchy/outfit/job/scavenger
 	name = OUTFIT_JOB_NAME("Scavenger")
-	uniform = null
+	uniform = /obj/item/clothing/under/color/brown
+	suit = /obj/item/clothing/suit/armor/hauberk
+	head = /obj/item/clothing/head/helmet/hauberk
 	neck = /obj/item/reagent_containers/food/drinks/canteen
 	shoes = null
 	l_ear = null
@@ -783,19 +787,21 @@ Pilgrim Fate System
 	id_type = null
 	r_pocket = /obj/item/storage/box/coin
 	gloves = null
+	glasses = /obj/item/clothing/glasses/science/rat
 	pda_slot = null
 	l_hand = /obj/item/storage/toolbox/mechanical
 	back = /obj/item/storage/backpack/satchel/warfare
 	l_ear = /obj/item/device/radio/headset/headset_service
 	belt = /obj/item/device/flashlight/lantern
 	r_pocket = /obj/item/storage/box/coin
+	r_hand = /obj/item/melee/trench_axe/bspear/hunter
 
 /datum/job/scavenger
     title = "Scavenger"
     department_flag = PIL
     social_class = SOCIAL_CLASS_MIN //these boys are gross
-    total_positions = 1
-    spawn_positions = 1
+    total_positions = 2
+    spawn_positions = 2
     supervisors = "You-yourself, don't listen-hear to man-things!"
     selection_color = "#848484"
     outfit_type = /decl/hierarchy/outfit/job/scavenger
@@ -808,7 +814,7 @@ Pilgrim Fate System
     equip(var/mob/living/carbon/human/H)
         H.warfare_faction = IMPERIUM
         ..()
-        H.add_stats(rand(14,15), rand(16,20), rand(13,16), rand (13,16))
+        H.add_stats(rand(14,15), rand(18,20), rand(14,16), rand (13,16))
         H.add_skills(rand(7,9),rand(9,16),rand(4,6),4,6) //melee, ranged, med, eng, surgery
         H.warfare_language_shit(LANGUAGE_LOW_GOTHIC)
         H.adjustStaminaLoss(-INFINITY)
@@ -865,6 +871,7 @@ Pilgrim Fate System
 		..()
 		H.warfare_language_shit(LANGUAGE_LOW_GOTHIC)
 		H.adjustStaminaLoss(-INFINITY)
+		H.set_trait(new/datum/trait/death_tolerant())
 		H.stat = UNCONSCIOUS
 		H.assign_random_quirk()
 		H.verbs += list(
@@ -920,8 +927,8 @@ Pilgrim Fate System
 			new /obj/item/device/radio/headset/headset_sci(src.loc) 
 			equip_to_slot_or_store_or_drop(new /obj/item/card/id/pilgrim/penitent, slot_wear_id) 
 			new /obj/item/gun/projectile/automatic/machinepistol(src.loc) 
-			new /obj/item/ammo_magazine/c556(src.loc) 
-			new /obj/item/ammo_magazine/c556(src.loc)
+			new /obj/item/ammo_magazine/mc9mmt/machinepistol(src.loc) 
+			new /obj/item/ammo_magazine/mc9mmt/machinepistol(src.loc)
 			to_chat(U, "<span class='goodmood'><b><font size=3>You're the hitman, the shadow of the gang. Take out any who oppose you.</font></b></span>")
 			U.verbs -= list(/mob/living/carbon/human/proc/gangerclass,)
 			U.stat = CONSCIOUS
@@ -949,8 +956,8 @@ Pilgrim Fate System
 	title = "Bouncer"
 	department_flag = PIL
 	social_class = SOCIAL_CLASS_MIN //these boys are gross
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 2
+	spawn_positions = 2
 	supervisors = "The Underboss"
 	selection_color = "#530606"
 	outfit_type = /decl/hierarchy/outfit/job/bouncer

--- a/code/game/jobs/job/rogue_trader_retinue.dm
+++ b/code/game/jobs/job/rogue_trader_retinue.dm
@@ -26,7 +26,7 @@
 	shotgun_skill = 8
 	lmg_skill = 8
 	smg_skill = 8
-	cultist_chance = 40
+	cultist_chance = 30
 
 
 	equip(var/mob/living/carbon/human/H)
@@ -38,6 +38,7 @@
 		H.warfare_language_shit(LANGUAGE_LOW_GOTHIC)
 		H.warfare_language_shit(LANGUAGE_HIGH_GOTHIC )
 		H.adjustStaminaLoss(-INFINITY)
+		H.set_trait(new/datum/trait/death_tolerant())
 		H.witchblood()
 		H.warfare_faction = IMPERIUM
 		H.verbs += list(/mob/living/carbon/human/proc/hire)
@@ -74,7 +75,7 @@
 	shotgun_skill = 8
 	lmg_skill = 8
 	smg_skill = 8
-	cultist_chance = 20
+	cultist_chance = 5
 
 	equip(var/mob/living/carbon/human/H)
 		var/current_name = H.real_name
@@ -85,6 +86,7 @@
 		H.assign_random_quirk()
 		H.warfare_language_shit(LANGUAGE_LOW_GOTHIC)
 		H.warfare_language_shit(LANGUAGE_HIGH_GOTHIC)
+		H.set_trait(new/datum/trait/death_tolerant())
 		H.warfare_faction = IMPERIUM
 		to_chat(H, "<span class='notice'><b><font size=3>Three concepts hold primacy in Vessorine clan society to the exclusion of nearly all else: property, warcraft, and currency. The scarcity of resources and rocky landscape of Vessor made the ownership of arable land and grazing beasts one of the most important aspects of their primitive society. The populace grouped into clans for increased security and resources, and though the leader of a clan holds the title of Clansire, the term refers neither to patrilineal nor matrilineal descent. From an early age, typically after First Bonding, both male and female children begin training as janissaries. They undergo training to enhance their strength, stamina, and agility, sometimes doing so with only the food and water they can find in the wilderness. They also learn the three primary Vessorine battle arts: open-hand, blade, and gun lore. By the time they participate in their first contract, an ascension ritual called Second Bonding, they are formidable warriors equal to any in the Imperium. In preparation for Second Bonding, janissaries receive their first repatriation tattoo, which declares the bond a clan will pay for the return of their soldier if captured.</font></b></span>")
 
@@ -92,13 +94,13 @@
 	title = "Xeno Mercenary"
 	department_flag = SUP
 	social_class = SOCIAL_CLASS_MIN //these boys are gross
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 2
+	spawn_positions = 2
 	supervisors = "The Rogue Trader"
 	selection_color = "#315dd4"
 	latejoin_at_spawnpoints = TRUE
 	announced = FALSE
-	cultist_chance = 5
+	cultist_chance = 0
 
 
 	equip(var/mob/living/carbon/human/H)
@@ -108,6 +110,7 @@
 		H.add_skills(rand(10,12),rand(9,10),rand(3,5),5,rand(2,4)) //melee, ranged, med, eng, surgery
 		H.warfare_language_shit(LANGUAGE_LOW_GOTHIC)
 		H.adjustStaminaLoss(-INFINITY)
+		H.set_trait(new/datum/trait/death_tolerant())
 		H.assign_random_quirk()
 		H.witchblood()
 		H.stat = UNCONSCIOUS

--- a/code/game/objects/auras/aura.dm
+++ b/code/game/objects/auras/aura.dm
@@ -161,45 +161,52 @@ They should also be used for when you want to effect the ENTIRE mob, like having
 	//var/regen_message = "<span class='warning'>Your body throbs as you feel your body regenerates.</span>"
 	//var/innate_heal = TRUE // Whether the aura is on, basically.
 	can_regenerate_organs = TRUE
-	brute_mult = 33 // Value of 10 = 1 per second. Bleeding slows this down a lot, so a minimum of 15-20 is needed to stop bleeding.
-	fire_mult = 27
-	tox_mult = 5 // We don't want toxin to heal as quickly as we want death to still be possible -- only slowed down. Not stopped.
-	organheal = 0.3 // Leave this as is. Any higher and you become god.
+	brute_mult = 15 // Value of 10 = 1 per second. Bleeding slows this down a lot, so a minimum of 15-20 is needed to stop bleeding.
+	fire_mult = 15
+	tox_mult = 7 // We don't want toxin to heal as quickly as we want death to still be possible -- only slowed down. Not stopped.
+	organheal = 0.4 // Leave this as is. Any higher and you become god.
 
 /obj/aura/regenerating/human/ork
 	can_regenerate_organs = TRUE
-	brute_mult = 39
-	fire_mult = 30
-	tox_mult = 2
-	organheal = 0.3
+	brute_mult = 12
+	fire_mult = 12
+	tox_mult = 6
+	organheal = 0.4
 
 /obj/aura/regenerating/human/ogryn
 	can_regenerate_organs = TRUE
-	brute_mult = 20
+	brute_mult = 10
 	fire_mult = 10
-	tox_mult = 2
+	tox_mult = 4
 	organheal = 0.3
 
 /obj/aura/regenerating/human/khornate
 	can_regenerate_organs = TRUE
 	brute_mult = 5
 	fire_mult = 5
-	tox_mult = 1
+	tox_mult = 3
 	organheal = 0.2
 
 /obj/aura/regenerating/human/skinless
 	can_regenerate_organs = TRUE
-	brute_mult = 48
-	fire_mult = 48
-	tox_mult = 28
-	organheal = 0.6
+	brute_mult = 20
+	fire_mult = 20
+	tox_mult = 15
+	organheal = 0.4
 
 /obj/aura/regenerating/human/nid
 	can_regenerate_organs = TRUE
-	brute_mult = 38
-	fire_mult = 38
-	tox_mult = 20
-	organheal = 0.6
+	brute_mult = 16
+	fire_mult = 16
+	tox_mult = 16
+	organheal = 0.4
+
+/obj/aura/regenerating/human/rat
+	can_regenerate_organs = TRUE
+	brute_mult = 6
+	fire_mult = 6
+	tox_mult = 5
+	organheal = 0.3
 
 /obj/aura/regenerating/human/ultimate
 	//var/regen_message = "<span class='warning'>Your body throbs as you feel your body regenerates.</span>"

--- a/code/game/objects/explosion_recursive.dm
+++ b/code/game/objects/explosion_recursive.dm
@@ -126,10 +126,10 @@ proc/explosion_rec(turf/epicenter, power, shaped)
 	explosion_resistance = 2
 
 /turf/simulated/shuttle/wall
-	explosion_resistance = 10
+	explosion_resistance = 5
 
 /turf/simulated/wall
-	explosion_resistance = 10
+	explosion_resistance = 4
 
 /obj/machinery/door/get_explosion_resistance()
 	if(!density)

--- a/code/game/objects/items/weapons/baton.dm
+++ b/code/game/objects/items/weapons/baton.dm
@@ -57,7 +57,7 @@
 	item_state = "telebaton_0"
 	slot_flags = SLOT_BELT
 	w_class = ITEM_SIZE_SMALL
-	force = 5
+	force = 15
 	var/on = 0
 
 
@@ -70,7 +70,7 @@
 		icon_state = "telebaton_1"
 		item_state = "nullrod"//was teletbaton_1 but guess what... that icon doesn't exist
 		w_class = ITEM_SIZE_NORMAL
-		force = 24//quite robust
+		force = 26//quite robust
 		attack_verb = list("smacked", "struck", "slapped")
 	else
 		user.visible_message("<span class='notice'>\The [user] collapses their telescopic baton.</span>",\

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -122,12 +122,12 @@
 	icon = 'icons/obj/weapons/melee/misc.dmi'
 	icon_state = "buckler"
 	slot_flags = SLOT_BACK
-	force = 18
-	throwforce = 10
+	force = 21
+	throwforce = 20
 	base_block_chance = 30
 	throw_speed = 10
 	throw_range = 20
-	w_class = ITEM_SIZE_HUGE
+	w_class = ITEM_SIZE_NORMAL
 	origin_tech = list(TECH_MATERIAL = 1)
 	matter = list(DEFAULT_WALL_MATERIAL = 1000, "Wood" = 1000)
 	attack_verb = list("shoved", "bashed")

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -493,7 +493,7 @@
 	weapon_speed_delay = 8
 
 /obj/item/melee/sword/machete/chopper/heavy/slayer
-	name = "heavy blessed chopper"
+	name = "masterwork chopper"
 	desc = "A heavy blessed blade made of xenos alloy, it seems unnaturally heavy."
 	icon_state = "scrapsabre"
 	item_state = "salvagedmachete"

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -34,9 +34,6 @@
 	if(!damage)
 		return
 
-	if(!istype(Proj, /obj/item/projectile/beam))
-		damage *= 0.4 //non beams do reduced damage
-
 	health -= damage
 	..()
 	if(health <= 0)
@@ -154,8 +151,8 @@
 		wall_fake = 1
 
 	var/turf/Tsrc = get_turf(src)
-	Tsrc.ChangeTurf(/turf/simulated/wall)
-	var/turf/simulated/wall/T = get_turf(src)
+	Tsrc.ChangeTurf(/turf/simulated/wall/concrete)
+	var/turf/simulated/wall/concrete/T = get_turf(src)
 	//T.set_material(M, reinf_material)
 	if(wall_fake)
 		T.can_open = 1

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -108,7 +108,7 @@
 		return success_smash(user)
 
 	if(is_reinf())
-		if(damage >= max(60,80))
+		if(damage >= max(30,60))
 			return success_smash(user)
 	else if(wallbreaker == 2 || damage >= 60)
 		return success_smash(user)

--- a/code/game/turfs/simulated/wall_types.dm
+++ b/code/game/turfs/simulated/wall_types.dm
@@ -12,14 +12,14 @@
 	icon_state = "concrete0"
 	walltype = "concrete"
 	mineral = "rust"
-	integrity = 700 //Tough bois
+	integrity = 500 //Tough bois
 
 /turf/simulated/wall/ancient
 	name = "ancient wall"
 	desc = "An ancient wall of unknown origin."
 	icon_state = "rrwall0"
 	walltype = "rrwall"
-	integrity = 1500
+	integrity = 900
 
 /turf/simulated/wall/seolite
 	name = "Seolite Wall"
@@ -27,37 +27,37 @@
 	icon = 'icons/turf/seolitewall.dmi'
 	icon_state = "rrwall0"
 	walltype = "rrwall"
-	integrity = 1500
+	integrity = 1000
 
 /turf/simulated/wall/concrete/strong
 	desc = "Looks much stronger than a paper sheet."
-	integrity = 1000
+	integrity = 700
 
 /turf/simulated/wall/concrete/strong/chapel
 	name = "monastic stone wall"
 	desc = "Ornate stone packed together in a gothic fashion with various holy scribbles etching the framework. It looks extremely tough."
-	integrity = 1000
+	integrity = 900
 
 /turf/simulated/wall/rust
 	desc = "An old rusty wall. It's definitely seen better days."
 	icon_state = "rust0"
 	walltype = "rust"
 	mineral = "rust"
-	integrity = 600
+	integrity = 400
 
 /turf/simulated/wall/grim
 	name = "grim wall"
 	desc = "A grim looking metal wall"
 	icon_state = "grim0"
 	walltype = "grim"
-	integrity = 800 //Tough bois
+	integrity = 400 //Tough bois
 
 /turf/simulated/wall/techno
 	name = "techno wall"
 	desc = "A techno looking metal wall"
 	icon_state = "techno0"
 	walltype = "techno"
-	integrity = 1500 //Tough bois
+	integrity = 9000 //Tough bois
 
 /turf/simulated/wall/r_wall/containment
 	desc = "A strong containment wall. Used to \"contain\" things"
@@ -71,7 +71,7 @@
 	icon_state = "wall15"
 	desc = "A wall made from stone."
 	walltype = "stone"
-	integrity = 800
+	integrity = 400
 
 /turf/simulated/wall/wooden
 	name = "wood wall"
@@ -80,7 +80,7 @@
 	icon_state = "wood1"
 	walltype = "wood"
 	mineral = "wood"
-	integrity = 450
+	integrity = 350
 
 /turf/simulated/wall/snowcave
 	name = "snowy cave wall"
@@ -88,12 +88,12 @@
 	icon_state = "snow0"
 	walltype = "snow"
 	mineral = "stone"
-	integrity = 600
+	integrity = 500
 
 /turf/simulated/wall/cult
 	icon_state = "cult"
 	walltype = "cult"
-	integrity = 1200
+	integrity = 1000
 
 /turf/simulated/wall/cult/New(var/newloc, var/reinforce = 0)
 	..(newloc,)
@@ -186,4 +186,4 @@
 	icon_state = "brickstone0"
 	walltype = "brickstone"
 	mineral = "metal"
-	integrity = 1500
+	integrity = 800

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -18,7 +18,7 @@
 	var/active
 	var/can_open = 0
 	var/last_state
-	var/integrity = 2000
+	var/integrity = 500
 	var/construction_stage
 	var/hitsound = 'sound/weapons/Genhit.ogg'
 	var/floor_type = /turf/simulated/floor/plating //turf it leaves after destruction
@@ -78,9 +78,9 @@
 
 	if(is_reinf())
 		if(Proj.damage_type == BURN)
-			proj_damage /= 10
+			proj_damage /= 3
 		else if(Proj.damage_type == BRUTE)
-			proj_damage /= 8
+			proj_damage /= 4
 
 	//cap the amount of damage, so that things like emitters can't destroy walls in one hit.
 	var/damage = min(proj_damage, 100)

--- a/code/modules/admin/buildmode/basic.dm
+++ b/code/modules/admin/buildmode/basic.dm
@@ -24,12 +24,12 @@
 		else if(istype(object,/turf/simulated/floor))
 			var/turf/T = object
 			Log("Upgraded - [log_info_line(object)]")
-			T.ChangeTurf(/turf/simulated/wall)
+			T.ChangeTurf(/turf/simulated/wall/concrete)
 			return
 		else if(istype(object,/turf/simulated/wall))
 			var/turf/T = object
 			Log("Upgraded - [log_info_line(object)]")
-			T.ChangeTurf(/turf/simulated/wall/r_wall)
+			T.ChangeTurf(/turf/simulated/wall/concrete)
 			return
 	else if(pa["right"])
 		if(istype(object,/turf/simulated/wall))
@@ -42,7 +42,7 @@
 			Log("Downgraded - [log_info_line(object)]")
 			T.ChangeTurf(/turf/space)
 			return
-		else if(istype(object,/turf/simulated/wall/r_wall))
+		else if(istype(object,/turf/simulated/wall/concrete))
 			var/turf/T = object
 			Log("Downgraded - [log_info_line(object)]")
 			T.ChangeTurf(/turf/simulated/wall)

--- a/code/modules/cargo/cargoterminal.dm
+++ b/code/modules/cargo/cargoterminal.dm
@@ -168,7 +168,7 @@
 		var/obj/item/stack/M = O
 		if(M.amount > 1)
 			M.amount -=1
-			visible_message("[user] places [M] onto the [src]. With a flash of light and a crackle the item is transported to the Messina Spaceport.")
+			visible_message("[user] places [M] onto the [src]. ")
 			to_chat(user, "[M.sales_price - round(M.sales_price * GLOB.tax_rate,1)] has been added to the terminal.")
 			src.balance += M.sales_price - round(M.sales_price * GLOB.tax_rate, 1)
 			GLOB.thrones += round(M.sales_price * GLOB.tax_rate,1) //taxes on all sales through the system
@@ -176,14 +176,14 @@
 			M.update_icon() //so coins in hand update
 			return
 		else
-			visible_message("[user] places [M] onto the [src]. With a flash of light and a crackle the item is transported to the Messina Spaceport.")
+			visible_message("[user] places [M] onto the [src]. ")
 			to_chat(user, "[M.sales_price - round(M.sales_price * GLOB.tax_rate,1)] has been added to the terminal.")
 			src.balance += M.sales_price - round(M.sales_price * GLOB.tax_rate, 1)
 			GLOB.thrones += round(M.sales_price * GLOB.tax_rate) //taxes on all sales through the system
 			qdel(M)
 			return
 	else
-		visible_message("[user] places [O] onto the [src]. With a flash of light and a crackle the item is transported to the Messina Spaceport.")
+		visible_message("[user] places [O] onto the [src]. ")
 		to_chat(user, "[O.sales_price - round(O.sales_price * GLOB.tax_rate,1)] has been added to the terminal.")
 		src.balance += O.sales_price - round(O.sales_price * GLOB.tax_rate, 1)
 		GLOB.thrones += round(O.sales_price * GLOB.tax_rate,1) //taxes on all sales through the system
@@ -281,15 +281,15 @@
 			playsound(world, 'sound/effects/tithepaid.ogg', 90, 0, -1)
 
 	if (href_list["tax"])
-		var/taxrates = list("1", "5", "10", "15",) //lists tax rates, we'll do set ones for now
+		var/taxrates = list("0", "5", "10", "15",) //lists tax rates, we'll do set ones for now
 		var/taxchoice = input("Choose the tax rate", "Available rates") as null|anything in taxrates
 
 		switch(taxchoice)
-			if("1")
-				GLOB.tax_rate = 0.1
-				to_world("<span class='warning'>[usr] has set the tax rate to 1%!</span>")
+			if("0")
+				GLOB.tax_rate = 0
+				to_world("<span class='warning'>[usr] has set the tax rate to 0%!</span>")
 			if("5")
-				GLOB.tax_rate = 0.5
+				GLOB.tax_rate = 0.05
 				to_world("<span class='warning'>[usr] has set the tax rate to 5%!</span>")
 			if("10")
 				GLOB.tax_rate = 0.10

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -96,6 +96,23 @@
 	unacidable = 1
 	sales_price = 35
 
+/obj/item/clothing/glasses/science/rat
+	name = "rat goggles"
+	desc = "The goggles do nothing!"
+	hud = /obj/item/clothing/glasses/hud/health
+	icon_state = "thermoncle"
+	item_state = "thermoncle"
+	action_button_name = "Toggle Goggles"
+	darkness_view = 20
+	toggleable = 1
+	electric = 1
+	see_invisible = SEE_INVISIBLE_NOLIGHTING
+	vision_flags = SEE_MOBS|SEE_TURFS
+	flash_protection = FLASH_PROTECTION_MAJOR
+	canremove = 1
+	unacidable = 1
+	sales_price = 0
+
 /obj/item/clothing/glasses/science/tech
 	name = "priest goggles"
 	desc = "The goggles do nothing!"

--- a/code/modules/clothing/suits/ogryn.dm
+++ b/code/modules/clothing/suits/ogryn.dm
@@ -8,9 +8,9 @@
 	canremove = 0
 	desc = "Worn to shreds and covered in spikes."
 	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
-	armor = list(melee = 70, bullet = 50, laser = 50, energy = 25, bomb = 30, bio = 30, rad = 20)
+	armor = list(melee = 60, bullet = 50, laser = 50, energy = 25, bomb = 30, bio = 30, rad = 20)
 	sales_price = 60
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS|HEAD
 	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
@@ -38,4 +38,4 @@
 
 /obj/item/clothing/suit/armor/ogryn/bouncer
 	name = "Ogryn Bouncer Armor"
-	armor = list(melee = 60, bullet = 50, laser = 70, energy = 70, bomb = 50, bio = 100, rad = 100) //I just took 20% off of the main armor types and 10% off bomb. It ended up being pretty similar to skitarii vanguard armor, so it should still be pretty durable.
+	armor = list(melee = 60, bullet = 50, laser = 6	0, energy = 70, bomb = 50, bio = 100, rad = 100) //I just took 20% off of the main armor types and 10% off bomb. It ended up being pretty similar to skitarii vanguard armor, so it should still be pretty durable.

--- a/code/modules/clothing/suits/ogryn.dm
+++ b/code/modules/clothing/suits/ogryn.dm
@@ -38,4 +38,4 @@
 
 /obj/item/clothing/suit/armor/ogryn/bouncer
 	name = "Ogryn Bouncer Armor"
-	armor = list(melee = 60, bullet = 50, laser = 6	0, energy = 70, bomb = 50, bio = 100, rad = 100) //I just took 20% off of the main armor types and 10% off bomb. It ended up being pretty similar to skitarii vanguard armor, so it should still be pretty durable.
+	armor = list(melee = 60, bullet = 50, laser = 60, energy = 70, bomb = 50, bio = 100, rad = 100) //I just took 20% off of the main armor types and 10% off bomb. It ended up being pretty similar to skitarii vanguard armor, so it should still be pretty durable.

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -44,13 +44,13 @@
 	desc = "It's a pickaxe. You hit rocks with it. And people with it too if you feel like."
 	icon = 'icons/obj/mining.dmi'
 	slot_flags = SLOT_BELT|SLOT_BACK|SLOT_ICLOTHING
-	force = 15
-	throwforce = 4
+	force = 25
+	throwforce = 15
 	icon_state = "pickaxe"
 	item_state = "spickaxe"
 	w_class = ITEM_SIZE_NORMAL
 	matter = list(DEFAULT_WALL_MATERIAL = 3750)
-	var/digspeed = 55 //moving the delay to an item var so R&D can make improved picks. --NEO
+	var/digspeed = 45 //moving the delay to an item var so R&D can make improved picks. --NEO
 	origin_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
 	attack_verb = list("hit", "pierced", "sliced", "attacked")
 	var/list/drill_sound = list('sound/items/pickaxe1.ogg','sound/items/pickaxe2.ogg','sound/items/pickaxe3.ogg','sound/items/pickaxe4.ogg')
@@ -73,7 +73,15 @@
 	name = "silver pickaxe"
 	icon_state = "spickaxe"
 	item_state = "spickaxe"
-	digspeed = 60
+	digspeed = 50
+	origin_tech = list(TECH_MATERIAL = 2)
+	desc = "This makes no metallurgic sense."
+
+/obj/item/pickaxe/mechanicus
+	name = "mechanicus pickaxe"
+	icon_state = "spickaxe"
+	item_state = "spickaxe"
+	digspeed = 40
 	origin_tech = list(TECH_MATERIAL = 2)
 	desc = "This makes no metallurgic sense."
 
@@ -81,7 +89,7 @@
 	name = "advanced mining drill" // Can dig sand as well!
 	icon_state = "handdrill"
 	item_state = "jackhammer"
-	digspeed = 40
+	digspeed = 30
 	origin_tech = list(TECH_MATERIAL = 2, TECH_POWER = 2, TECH_ENGINEERING = 2)
 	desc = "Yours is the drill that will pierce through the rock walls."
 	drill_verb = "drilling"
@@ -90,7 +98,7 @@
 	name = "sonic jackhammer"
 	icon_state = "jackhammer"
 	item_state = "jackhammer"
-	digspeed = 42 //faster than drill, but cannot dig
+	digspeed = 32 //faster than drill, but cannot dig
 	origin_tech = list(TECH_MATERIAL = 2, TECH_POWER = 2, TECH_ENGINEERING = 2)
 	desc = "Cracks rocks with sonic blasts, perfect for killing cave lizards."
 	drill_verb = "hammering"
@@ -99,7 +107,7 @@
 	name = "golden pickaxe"
 	icon_state = "gpickaxe"
 	item_state = "gpickaxe"
-	digspeed = 67
+	digspeed = 57
 	origin_tech = list(TECH_MATERIAL = 2)
 	desc = "This makes no metallurgic sense."
 	drill_verb = "picking"
@@ -108,7 +116,7 @@
 	name = "diamond pickaxe"
 	icon_state = "dpickaxe"
 	item_state = "dpickaxe"
-	digspeed = 44
+	digspeed = 34
 	origin_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
 	desc = "A pickaxe with a diamond pick head."
 	drill_verb = "picking"
@@ -126,7 +134,7 @@
 	name = "cyborg mining drill"
 	icon_state = "diamonddrill"
 	item_state = "jackhammer"
-	digspeed = 25
+	digspeed = 15
 	desc = ""
 	drill_verb = "drilling"
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -185,7 +185,6 @@ var/list/mining_floors = list()
 
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
-			H.adjustStaminaLoss(rand(1,10))
 			H.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 
 		health -= rand(1,5)

--- a/code/modules/mob/living/carbon/human/species/races/rat.dm
+++ b/code/modules/mob/living/carbon/human/species/races/rat.dm
@@ -10,15 +10,17 @@
     min_age = 18
     max_age = 50
     gluttonous = GLUT_ANYTHING
-    total_health = 115
+    total_health = 135
     mob_size = MOB_MEDIUM
     strength = STR_MEDIUM
     sexybits_location = BP_GROIN
+    base_auras = list(
+		/obj/aura/regenerating/human/rat
+		)
     inherent_verbs = list(
 
         )
     unarmed_types = list(
-        /datum/unarmed_attack/stomp,
         /datum/unarmed_attack/kick,
         /datum/unarmed_attack/punch,
         /datum/unarmed_attack/bite,

--- a/code/modules/mob/living/carbon/human/vice.dm
+++ b/code/modules/mob/living/carbon/human/vice.dm
@@ -52,12 +52,12 @@
 
 		if(viceneed < 1000 && vice != "Glutton")
 			spawn(10)
-				viceneed += rand(1,2)
+				viceneed += rand(0,1)
 				clear_event("vice")
 
 		else if(viceneed < 1000 && vice == "Glutton" && nutrition < 375)
 			spawn(10)
-				viceneed += rand(1,2)
+				viceneed += rand(0,1)
 				clear_event("vice")
 
 		else if(viceneed <= 1000 && vice == "Glutton" && nutrition >= 375)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -18,6 +18,7 @@
 
 	var/shuttletarget = null
 	var/enroute = 0
+	environment_smash = 1
 
 	var/damtype = BRUTE
 	var/defense = "melee" //what armor protects against its attacks

--- a/code/modules/mob/living/simple_animal/hostile/smalldemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/smalldemon.dm
@@ -328,8 +328,8 @@
 
 	var/death_msg = "lets out a waning screech, bursting into a mess of entrails."
 
-	harm_intent_damage = 40
-	melee_damage_lower = 40
+	harm_intent_damage = 35
+	melee_damage_lower = 30
 	melee_damage_upper = 40
 	attacktext = "slashed"
 	attack_sound = 'sound/weapons/bite.ogg'
@@ -361,7 +361,7 @@
 	response_help = "passes through"
 	response_disarm = "shoves"
 	response_harm = "hits"
-	speed = -1
+	speed = 1
 	maxHealth = 320
 	health = 320
 
@@ -387,7 +387,7 @@
 	response_help = "passes through"
 	response_disarm = "shoves"
 	response_harm = "hits"
-	speed = 2
+	speed = 1.5
 	maxHealth = 285
 	health = 285
 
@@ -415,7 +415,7 @@
 	melee_damage_upper = 45
 	attacktext = "chomped"
 	attack_sound = 'sound/weapons/bite.ogg'
-	speed = 2
+	speed = 1.7
 
 /mob/living/simple_animal/hostile/mold/subject_08 // Xeno Research Area
 	desc = "Subject was found on the lower levels of Elipharius, possibly an human being before it was assimilated by some plant organism and turned into this, the area it was located contained several organism like the subject here."
@@ -434,7 +434,7 @@
 	melee_damage_upper = 45
 	attacktext = "chomped"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
-	speed = 2
+	speed = 1.8
 
 /mob/living/simple_animal/hostile/broken_servitor/death()
 	..(null, "blows apart!")
@@ -456,10 +456,10 @@
 	icon_state = "dire_avenger"
 	icon_living = "dire_avenger"
 	icon_dead = "dire_avenger" // Gotta add it dies horribly by gibbing due the lack of dead icon state
-	health = 150
-	maxHealth = 150
-	melee_damage_lower = 15
-	melee_damage_upper = 25
+	health = 350
+	maxHealth = 350
+	melee_damage_lower = 25
+	melee_damage_upper = 45
 	attacktext = "pierces"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
-	speed = 4
+	speed = 1

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -15,8 +15,8 @@
 	maxHealth = 250
 	health = 250
 	harm_intent_damage = 5
-	melee_damage_lower = 20
-	melee_damage_upper = 30
+	melee_damage_lower = 10
+	melee_damage_upper = 20
 	wander = 1
 	see_in_dark = 6
 	attacktext = "stabbed"

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -61,17 +61,17 @@
 				brute = pure_brute
 
 				if(burn_eligible && burn >= max_damage / DROPLIMB_THRESHOLD_DESTROY)
-					if(prob(burn/4) || force_droplimb)
+					if(prob(burn/5) || force_droplimb)
 						droplimb(0, DROPLIMB_BURN)
 						return
 
 				else if(edge_eligible && brute >= max_damage / DROPLIMB_THRESHOLD_EDGE)
-					if(prob(brute/3) || force_droplimb)
+					if(prob(brute/4) || force_droplimb)
 						droplimb(0, DROPLIMB_EDGE)
 						return
 
 				else if(brute >= max_damage / DROPLIMB_THRESHOLD_DESTROY)
-					if(prob(brute/3) || force_droplimb)
+					if(prob(brute/4) || force_droplimb)
 						droplimb(0, DROPLIMB_BLUNT)
 						return
 				/*

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -443,7 +443,7 @@
 	caliber = "melta"
 	matter = list(DEFAULT_WALL_MATERIAL = 1260)
 	ammo_type = /obj/item/ammo_casing/melta
-	max_ammo = 60
+	max_ammo = 100
 	multiple_sprites = 0
 
 /obj/item/ammo_magazine/melta/empty

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -222,14 +222,14 @@
 	one_hand_penalty = 0
 
 /obj/item/gun/projectile/meltagun
-	name = "Melta Rifle"
+	name = "Melta Gun"
 	desc = "Melta Weapons are extremely dangerous weapons which can melt heavy armor in a few shots, this one is a melta rifle and should be used with both hands."
 	icon_state = "melta"
 	item_state = "multimelta"
 	wielded_item_state = "multimelta"
 	icon = 'icons/cadia-sprites/migrated2/gun_2.dmi'
 	fire_sound = 'sound/weapons/gunshot/lasgun1.ogg'
-	slot_flags = SLOT_BELT|SLOT_BACK
+	slot_flags = SLOT_BACK|SLOT_S_STORE
 	ammo_type = /obj/item/ammo_casing/melta
 	caliber = "melta"
 	load_method = MAGAZINE
@@ -241,12 +241,12 @@
 	block_chance = 15 //pretty big, could be used as a shield in theory considering how armored it is
 	gun_type = GUN_SHOTGUN
 	move_delay = 8
-	accuracy = 0
-	fire_delay= 40
+	accuracy = -2
+	fire_delay= 20
 	sales_price = 50
-	burst = 20
+	burst = 35
 	
 	firemodes = list(
-		list(mode_name="OVERCHARGE", burst=15, fire_delay=40, burst_accuracy=null, dispersion=null, automatic = 0.5),
-		list(mode_name="STANDARD", burst=11, fire_delay=30, burst_accuracy=null, dispersion=null, automatic = 0.7),
+		list(mode_name="OVERCHARGE", burst=45, fire_delay=30, burst_accuracy=null, dispersion=null, automatic = 0.5),
+		list(mode_name="STANDARD", burst=35, fire_delay=20, burst_accuracy=null, dispersion=null, automatic = 0.7),
 	)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -679,10 +679,7 @@
 	overdose = 30
 
 /datum/reagent/toxin/corrupting/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
-	if (mask_check(m)) 
-		return
-	else
-		affect_blood(M,alien,removed*0.5)
+	affect_blood(M,alien,removed*0.5)
 
 /datum/reagent/toxin/corrupting/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	..()

--- a/code/modules/reagents/reagent_containers/food/snacks/meat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/meat.dm
@@ -10,6 +10,18 @@
 		reagents.add_reagent(/datum/reagent/nutriment/protein, 6)
 		src.bitesize = 3
 
+/obj/item/reagent_containers/food/snacks/meat2
+	name = "disgusting meat chunk"
+	desc = "A slab of meat."
+	icon_state = "meat"
+	health = 180
+	filling_color = "#ff1c1c"
+	center_of_mass = "x=16;y=14"
+	New()
+		..()
+		reagents.add_reagent(/datum/reagent/nutriment/protein, 1)
+		src.bitesize = 3
+
 /obj/item/reagent_containers/food/snacks/meat/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/material/knife))
 		new /obj/item/reagent_containers/food/snacks/rawcutlet(src)

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -313,6 +313,30 @@
 	origin_tech = list(TECH_BIO = 6, TECH_BLUESPACE = 6)
 	sales_price = 20
 
+/obj/item/rnd/biospacesample1
+	name = "tissue sample"
+	desc = "A vial of strange liquid storing organic material."
+	icon = 'icons/obj/xenoarchaeology.dmi'
+	icon_state = "box"
+	origin_tech = list(TECH_BIO = 4, TECH_PHORON = 2, TECH_ILLEGAL = 2)
+	sales_price = 10
+
+/obj/item/rnd/biospacesample2
+	name = "rare tissue sample"
+	desc = "A vial of strange liquid storing organic material."
+	icon = 'icons/obj/xenoarchaeology.dmi'
+	icon_state = "box"
+	origin_tech = list(TECH_BIO = 5, TECH_PHORON = 4, TECH_ILLEGAL = 3)
+	sales_price = 10
+
+/obj/item/rnd/biospacesample3
+	name = "exotic tissue sample"
+	desc = "A vial of strange liquid storing organic material."
+	icon = 'icons/obj/xenoarchaeology.dmi'
+	icon_state = "box"
+	origin_tech = list(TECH_BIO = 8, TECH_PHORON = 7, TECH_ILLEGAL = 6)
+	sales_price = 10
+
 /obj/item/rnd/biospace8
 	name = "xenos autodoc schematics"
 	desc = "Schematics to construct a medical autodoc used by the seolite... The Mechanicus will want to study it."
@@ -328,7 +352,6 @@
 	icon_state = "datadisk6"
 	origin_tech = list(TECH_BIO = 10, TECH_BLUESPACE = 10)
 	sales_price = 0
-
 
 /obj/item/rnd/combat3
 	name = "seolite firing mechanism"

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -233,7 +233,15 @@
 /datum/surgery_step/internal/remove_organ/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message("<span class='notice'>[user] has removed [target]'s [target.op_stage.current_organ] with \the [tool].</span>", \
 	"<span class='notice'>You have removed [target]'s [target.op_stage.current_organ] with \the [tool].</span>")
-
+	
+	if (prob(10)) 
+		new /obj/item/rnd/biospacesample1(target.loc)
+	else if(prob(5))
+		new /obj/item/rnd/biospacesample2(target.loc)
+	else if(prob(5))
+		new /obj/item/rnd/biospacesample3(target.loc)
+	else
+		new /obj/item/reagent_containers/food/snacks/meat(target.loc)
 	// Extract the organ!
 	var/obj/item/organ/O = target.op_stage.current_organ
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)


### PR DESCRIPTION
Digging is much easier.

Tech menials/priests start with an upgraded mechanicus pickaxe

Tax Rate is set to 0 by default without a Governor. This only effects the RT so it doesn't mean there is on taxes.

Regeneration Aura's nerfed across the board for all species.

Death Tolerance Trait added to many jobs.

Holsters given to Guard.

Pathfinder Enabled by default. Inquisitor closed by default.

Enforcer 2 from 3.

Walls easier to destroy. By a lot.

Vice Drain reduced.

Added environment_smash to hostile mobs.

Nerfed damage on nurgling, changed speed on other mobs.

Traitor Guard deal half melee damage now. Since they shoot + stab you at close range.

The droplimb chance is less in RNG now. Chances of shooting someone's head off is less likely. It should negate the meta of shooting someone at CQB with a high damage once to win a fight or spamming plasma guns. You should focus more on tactics now.

Melta Gun fires a default burst of 35 instead of 11 shots. It's burst delay is also reduced so you can get a second volley up without waiting a century. It's only nerf is it's accuracy is -1 from 0, so at a distance the volley isn't very good and can't be used to snipe people in trenches from far away.

The Melta Canister also holds 100 shots from 60 now.
//
Map Fixes requested are being done by Graf, they're coming in 2+ days along with new dungeons and map updates.

RT Xeno Merc Slots = 2
Bouncer = 2
Bullgryn = 2
Scavenger Rat = 2

Fixed compile error with a mask_check thing

Cultist chance reduced on a number of jobs.
Governor/Heir chances of rolling traitor sub-fates increased dramatically.