### PR TITLE
Sends Ogryns to the Gym 

### DIFF
--- a/code/modules/mob/living/carbon/human/species/races/ogryn.dm
+++ b/code/modules/mob/living/carbon/human/species/races/ogryn.dm
@@ -12,7 +12,7 @@
 	gluttonous = GLUT_ANYTHING
 	total_health = 350
 	mob_size = MOB_LARGE
-	strength = STR_HIGH
+	strength = STR_VHIGH
 	sexybits_location = BP_GROIN
 	var/bonehead = 0 //Boneheads are enhanced, more intelligent ogryn. Will make them a bit smarter
 	base_auras = list(


### PR DESCRIPTION
Changes Ogryn strength rating from high to very high to better reflect them being massive meat heads that prefer punching things (and to stop high rolling sisters from winning arm wrestles against low rolling ogryns)

All other stats haven't been changed, so while they could win an arm wrestle with an astartes (if they get lucky) they definitely aren't going to be winning a sprint against them
![image](https://github.com/WoodenTucker/40K-Eipharius/assets/33615250/862e6bc3-c799-4200-b85c-6fc889d5c0f4)


![image](https://github.com/WoodenTucker/40K-Eipharius/assets/33615250/685b67db-87da-4bf6-94a6-cd33d32fdd15)
