### PR TITLE
Second Breakfast

### DIFF
--- a/code/datums/outfits/civilian.dm
+++ b/code/datums/outfits/civilian.dm
@@ -131,7 +131,7 @@
 	belt = /obj/item/device/flashlight/lantern
 	back = /obj/item/storage/backpack/satchel/warfare
 	shoes = /obj/item/clothing/shoes/jackboots
-	suit = /obj/item/clothing/suit/armor/preacher
+	suit = null
 	l_hand = /obj/item/staff/ministorumstaff
 	r_hand = null
 	backpack_contents = list(

--- a/code/game/jobs/job/adeptus_ministorum.dm
+++ b/code/game/jobs/job/adeptus_ministorum.dm
@@ -688,7 +688,7 @@
 	back = /obj/item/storage/backpack/satchel/warfare
 	shoes = /obj/item/clothing/shoes/jackboots
 	glasses = /obj/item/clothing/glasses/hud/health
-	suit = /obj/item/clothing/suit/armor/preacher
+	suit = null
 	l_hand = /obj/item/staff/ministorumstaff
 	r_hand = null
 	backpack_contents = list(

--- a/code/game/jobs/job/pilgrims.dm
+++ b/code/game/jobs/job/pilgrims.dm
@@ -243,7 +243,7 @@ Pilgrim Fate System
 			U.stat = CONSCIOUS
 			U.sleeping = 0
 			to_chat(U, "<span class='goodmood'>+ You awaken from your slumber... +</span>\n")
-			if(prob(15))
+			if(prob(25))
 				to_chat(U,"<span class='danger'><b><font size=4>THE PALADIN</font></b></span>")
 				to_chat(U,"<span class='goodmood'>A holy warrior of your chosen god, you work on behalf of the Ecclesiarchy(or the cult) as a slayer of the heretical and unfaithful. Face against the dark and protect your flock... for a price.</font></b></span>")
 				U.add_stats(rand(16,18), rand(14,16), rand(16,18), rand (10,12)) //veteran mercenary
@@ -255,7 +255,7 @@ Pilgrim Fate System
 					deity.add_cultist(U)
 				if(prob(45))
 					new /obj/item/device/radio/headset/headset_sci(src.loc)
-			else if(prob(15))
+			else if(prob(10))
 				to_chat(U,"<span class='danger'><b><font size=4>THE OPERATIVE</font></b></span>")
 				to_chat(U,"<span class='goodmood'>You are an operative sent here by your benefactors, mysterious patrons from worlds away to do work that may unlock the final steps to their ultimate plan((A-Help with your idea or even ask for a mission if you can't think of anything.))</font></b></span>")
 				U.add_stats(rand(13,17), rand(14,17), rand(14,17), rand (10,12)) //veteran mercenary
@@ -274,6 +274,16 @@ Pilgrim Fate System
 					new /obj/item/device/radio/headset/headset_sci(src.loc)
 				if(prob(15))
 					new /obj/item/device/radio/headset/blue_team/all(src.loc)
+			else if(prob(15))
+				to_chat(U,"<span class='danger'><b><font size=4>THE WITCH HUNTER</font></b></span>")
+				to_chat(U,"<span class='goodmood'>You are a Witch Hunter -- a unique subset of the Bounty Hunter Guild attached to the Chamber Militant, working both as Servant to the Ecclesiarchy and a 'bounty hunter' that the Ecclesiarchy can rely upon without tainting their own hands.</font></b></span>")
+				U.add_stats(rand(13,17), rand(14,17), rand(14,17), rand (10,12)) //veteran mercenary
+				U.add_stats(rand(16,18), rand(14,16), rand(16,18), rand (10,12)) //veteran mercenary
+				new /obj/item/melee/sword/cane(src.loc)
+				new /obj/item/reagent_containers/food/snacks/threebread(src.loc)
+				new /obj/item/clothing/suit/armor/witch(src.loc)
+				new /obj/item/clothing/head/helmet/witch(src.loc)
+				new /obj/item/device/radio/headset/headset_sci(src.loc)
 			else
 				to_chat(U,"<span class='danger'><b><font size=4>THE BOUNTY HUNTER</font></b></span>")
 				to_chat(U,"<span class='goodmood'>A vicious bounty hunter traveling from system to system in search of their next payday, you live luxuriously only for moments before being plunged back into poverty. Hitching a ride to Eipharius with the last of your thrones, you gamble on the hope of finding work out here.(A-Help if nobody is hiring bounty hunters for a bounty target+pay)</font></b></span>")
@@ -311,7 +321,7 @@ Pilgrim Fate System
 
 	var/mob/living/carbon/human/U = src
 	U.verbs -= list(/mob/living/carbon/human/proc/citizenclass,) //removes verb
-	var/fates = list("Mysterious Citizen","PDF","Miner","Fate Touched","Disgraced Noble","Palace Guard")
+	var/fates = list("Mysterious Citizen","PDF","Miner","Fate Touched","Disgraced Noble","Honour Guard")
 
 
 	var/classchoice = input("Choose your fate", "Available fates") as anything in fates
@@ -407,7 +417,7 @@ Pilgrim Fate System
 			U.verbs -= list(/mob/living/carbon/human/proc/citizenclass,)
 			U.sleeping = 0
 			to_chat(U, "<span class='goodmood'>+ You awaken from your slumber... +</span>\n")
-		if("Palace Guard")
+		if("Honour Guard")
 			U.add_stats(rand(15,17), rand(14,17), rand(14,16), rand (13,15)) //
 			U.add_skills(rand(6,8),rand(6,8),rand(4,6),rand(5,6),rand(2,6)) //melee, ranged, med, eng, surgery
 			new /obj/item/clothing/gloves/thick(src.loc)
@@ -422,7 +432,7 @@ Pilgrim Fate System
 			new /obj/item/clothing/suit/armor/brigandine/palace(src.loc)
 			new /obj/item/melee/trench_axe/glaive/adamantine(src.loc)
 			to_chat(U,"<span class='danger'><b><font size=4>THE PROTECTORATE</font></b></span>")
-			to_chat(U,"<span class='goodmood'><b><font size=3>Skilled in the arts of blade and gun lore, you are one of the rare individuals selected by the Governor to protect them personally from the heretic, the alien and worst of all -- the human. Find the Steward/Commissar or Governor for your assignment...</font></b></span>")
+			to_chat(U,"<span class='goodmood'><b><font size=3>Skilled in the arts of blade and gun lore, you are one of the rare individuals selected by EITHER; The Ecclesiarchy or House Sondar(Your Choice) to protect them from the heretic, the alien and worst of all -- the human. Find the Steward/Commissar or Governor for your assignment...</font></b></span>")
 			U.stat = CONSCIOUS
 			U.verbs -= list(/mob/living/carbon/human/proc/citizenclass,)
 			U.sleeping = 0

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -260,7 +260,7 @@
 	icon_state = "mecha_missilerack"
 	projectile = /obj/item/missile
 	fire_sound = 'sound/effects/bang.ogg'
-	projectiles = 8
+	projectiles = 2
 	projectile_energy_cost = 200 KILOWATTS
 	equip_cooldown = 60
 
@@ -453,7 +453,7 @@
     projectile = /obj/item/missile/hk
     fire_sound = 'sound/effects/bang.ogg'
     fire_volume = 100 //Loud
-    projectiles = 6
+    projectiles = 1
     projectile_energy_cost = 150 KILOWATTS
     equip_cooldown = 60
 

--- a/code/game/objects/items/weapons/cane.dm
+++ b/code/game/objects/items/weapons/cane.dm
@@ -65,7 +65,8 @@
 	icon_state = "cane_sword"
 	slot_flags = SLOT_BELT|SLOT_BACK|SLOT_S_STORE
 	block_chance = 40
-	force = 32
+	force = 31
+	force_wielded = 35
 	armor_penetration = 20
 	weapon_speed_delay = 7
 	sharp = 1
@@ -75,3 +76,5 @@
 	desc = "A sword specially modified to nest inside the body of a cane, extremely sharp"
 	grab_sound_is_loud = TRUE
 	grab_sound = 'sound/items/unholster_sword01.ogg'
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HEAD
+	armor = list(melee = 20, bullet = 20, laser = 20, energy = 10, bomb = 10, bio = 0, rad = 0)

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -285,7 +285,7 @@
 	item_state = "powersword"
 	icon_state = "powersword"
 	wielded_icon = "powersword-w"
-	active_force = 43 //should be enough to cut off most limbs
+	active_force = 39 //should be enough to cut off most limbs
 	active_throwforce = 18
 	icon = 'icons/obj/guardpower_gear_32xOBJ.dmi'
 	force = 34
@@ -309,6 +309,9 @@
 	drop_sound = 'sound/items/drop_sword.ogg'
 	grab_sound = 'sound/items/unholster_sword02.ogg'
 	equipsound = 'sound/items/holster_sword1.ogg'
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HEAD
+	armor = list(melee = 10, bullet = 25, laser = 25, energy = 10, bomb = 10, bio = 0, rad = 0)
+
 /obj/item/melee/energy/powersword/activate(mob/living/user)
 	..()
 	icon_state = "powersword_on"
@@ -325,9 +328,9 @@
 	item_state = "powersword" // There is no on-mob for powersword we must use this. It looks alright.
 	icon_state = "powersword"
 	wielded_icon = "powersword-w"
-	active_force = 46 //should be enough to cut off most limbs
+	active_force = 39 //should be enough to cut off most limbs
 	active_throwforce = 20
-	force = 36 //its just a adamantium sword when offline
+	force = 34 //its just a adamantium sword when offline
 	throwforce = 15
 	throw_speed = 1
 	throw_range = 4
@@ -349,9 +352,9 @@
 	icon_state = "powerclaw-alt_mag"
 	item_state = "none"
 	wielded_icon = "none"
-	active_force = 40 
+	active_force = 38
 	active_throwforce = 0
-	force = 30
+	force = 33
 	throwforce = 1
 	throw_speed = 1
 	throw_range = 1
@@ -365,6 +368,8 @@
 	atom_flags = 0
 	origin_tech = list(TECH_MAGNET = 1, TECH_COMBAT = 1)
 	attack_verb = list("mauled", "clawed", "cleaved", "torn", "cut")
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HEAD
+	armor = list(melee = 10, bullet = 10, laser = 10, energy = 10, bomb = 10, bio = 0, rad = 0)
 
 /obj/item/melee/energy/powersword/claw/integrated/activate(mob/living/user)
 	..()

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -97,6 +97,8 @@
 	origin_tech = list(TECH_COMBAT = 5)
 	attack_verb = list("flicked", "whipped", "lashed")
 	var/slan = 1
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HEAD
+	armor = list(melee = 15, bullet = 25, laser = 25, energy = 10, bomb = 10, bio = 0, rad = 0)
 
 //code copypasted from the mutated arm
 /obj/item/melee/whip/lashoftorment/attack(mob/living/carbon/C as mob, var/mob/living/carbon/human/user as mob) //

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -32,6 +32,8 @@
 	drop_sound = 'sound/items/drop_sword.ogg'
 	sales_price = 0
 	var/isblessed = 0
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HEAD
+	armor = list(melee = 10, bullet = 15, laser = 15, energy = 10, bomb = 10, bio = 0, rad = 0)
 
 /obj/item/melee/sword/handle_shield(mob/living/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
 	if(default_sword_parry(user, damage, damage_source, attacker, def_zone, attack_text))
@@ -113,6 +115,14 @@
 	icon = 'icons/obj/weapons/melee/misc.dmi'
 	w_class = ITEM_SIZE_NORMAL
 
+
+
+//////////////
+//AXES/CLUBS//
+/////////////
+
+
+
 /obj/item/melee/sword/commissword //The commissar gets the best aspects of all swords
 	name = "commissar's sword"
 	desc = "An orante officer's sword and the Commissar's prized possession. Used to cut down heretics and cowards alike"
@@ -120,40 +130,17 @@
 	icon_state = "commissword"
 	item_state = "commissword"
 	attack_verb = list("stabbed", "chopped", "cut", "sliced")
-	force = 40
-	force_wielded = 45
+	force = 35
+	force_wielded = 37
 	sharp = 1
-	block_chance = 55
+	block_chance = 45
 	w_class = ITEM_SIZE_NORMAL
 	origin_tech = list(TECH_MATERIAL = 2, TECH_COMBAT = 2)
 	slot_flags = SLOT_BELT
 	sales_price = 0
-	weapon_speed_delay = 7
-
-//////////////
-//AXES/CLUBS//
-/////////////
-
-/obj/item/melee/trench_axe
-	name = "trench axe"
-	desc = "Used mainly for murdering those on the enemy side."
-	icon = 'icons/obj/weapons/melee/misc.dmi'
-	icon_state = "trenchaxe"
-	item_state = "trenchaxe"
-	wielded_icon = "trenchaxe-w"
-	slot_flags = SLOT_BELT|SLOT_BACK|SLOT_S_STORE
-	force = 31
-	armor_penetration = 10
-	throwforce = 18
-	block_chance = 30
-	sharp = TRUE
-	hitsound = "slash_sound"
-	drop_sound = 'sound/items/handle/axe_drop.ogg'
-	equipsound = 'sound/items/equip/axe_equip.ogg'
-	grab_sound = 'sound/items/handle/axe_grab.ogg'
-	grab_sound_is_loud = TRUE
 	weapon_speed_delay = 8
-	w_class = ITEM_SIZE_HUGE
+	armor = list(melee = 15, bullet = 20, laser = 20, energy = 10, bomb = 10, bio = 0, rad = 0)
+	
 
 /obj/item/melee/sword/commissword/sabre
 	name = "Sabre"
@@ -195,8 +182,8 @@
 	item_state = "mercychainsword"
 	slot_flags = SLOT_BELT|SLOT_BACK|SLOT_S_STORE
 	str_requirement = 12
-	force = 31
-	force_wielded = 36
+	force = 32
+	force_wielded = 37
 	armor_penetration = 10
 	block_chance = 15
 	sharp = 1
@@ -209,6 +196,8 @@
 	weapon_speed_delay = 9
 	sales_price = 40
 	w_class = ITEM_SIZE_NORMAL
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HEAD
+	armor = list(melee = 10, bullet = 15, laser = 15, energy = 10, bomb = 10, bio = 0, rad = 0)
 
 /obj/item/melee/chain/guard
 	name = "Imperial Guard chainsword"
@@ -539,7 +528,7 @@
 	force_wielded = 36
 	armor_penetration = 12
 	throwforce = 18
-	block_chance = 12
+	block_chance = 25
 	sharp = 1
 	edge = 1
 	hitsound = "slash_sound"
@@ -549,6 +538,8 @@
 	grab_sound_is_loud = TRUE
 	weapon_speed_delay = 9
 	w_class = ITEM_SIZE_LARGE
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HEAD
+	armor = list(melee = 10, bullet = 10, laser = 10, energy = 10, bomb = 10, bio = 0, rad = 0)
 
 
 /obj/item/melee/trench_axe/glaive
@@ -564,6 +555,7 @@
 	block_chance = 35
 	weapon_speed_delay = 10
 	w_class = ITEM_SIZE_HUGE
+	armor = list(melee = 10, bullet = 20, laser = 20, energy = 10, bomb = 10, bio = 0, rad = 0)
 
 /obj/item/melee/trench_axe/glaive/adamantine
 	name = "adamantium saintie"
@@ -586,7 +578,7 @@
 	throwforce = 15
 	block_chance = 20
 	weapon_speed_delay = 9
-	w_class = ITEM_SIZE_LARGE 
+	w_class = ITEM_SIZE_LARGE
 
 /obj/item/melee/trench_axe/bardiche/beast
 	name = "beastly axe"
@@ -598,6 +590,7 @@
 	block_chance = 24
 	weapon_speed_delay = 8
 	w_class = ITEM_SIZE_LARGE 
+	armor = list(melee = 10, bullet = 20, laser = 20, energy = 10, bomb = 10, bio = 0, rad = 0)
 
 /obj/item/melee/trench_axe/bspear
 	name = "hunting spear"
@@ -613,6 +606,7 @@
 	weapon_speed_delay = 8
 	edge = 0
 	w_class = ITEM_SIZE_LARGE 
+	armor = list(melee = 10, bullet = 15, laser = 15, energy = 10, bomb = 10, bio = 0, rad = 0)
 
 /obj/item/melee/trench_axe/bspear/hunter
 	name = "fine hunting spear"
@@ -647,15 +641,6 @@
 	armor_penetration = 25
 	sales_price = 0
 
-/obj/item/melee/sword/commissword/sabre
-	name = "Sabre"
-	desc = "A masteredcrafted sabre of exceptional quality, it has a duelists grip."
-	icon = 'icons/obj/weapons/melee/misc.dmi'
-	icon_state = "sabre"
-	item_state = "sabre"
-	block_chance = 22
-	sales_price = 0
-
 /obj/item/melee/sword/choppa
 	name = "choppa"
 	desc = "Fixed out of a rusted sheet of metal, this choppa looks too big to be a sword. More like a piece of iron."
@@ -676,6 +661,8 @@
 	slot_flags = SLOT_BELT
 	sales_price = 0
 	weapon_speed_delay = 8
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HEAD
+	armor = list(melee = 10, bullet = 25, laser = 25, energy = 10, bomb = 10, bio = 0, rad = 0)
 
 /obj/item/melee/classic_baton/daemonhammer
 	name = "Daemonhammer"
@@ -694,6 +681,8 @@
 	weapon_speed_delay = 8
 	edge = TRUE
 	sales_price = 0
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HEAD
+	armor = list(melee = 35, bullet = 15, laser = 15, energy = 10, bomb = 10, bio = 0, rad = 0)
 
 // KNIVES AND SMALL WEAPONS //
 // KNIVES AND SMALL WEAPONS //
@@ -718,6 +707,8 @@
 	drop_sound = 'sound/items/knife_drop.ogg'
 	swing_sound = "blunt_swing"
 	armor_penetration = 8
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HEAD
+	armor = list(melee = 10, bullet = 15, laser = 15, energy = 10, bomb = 10, bio = 0, rad = 0)
 
 /obj/item/melee/sword/combat_knife/attack(mob/living/carbon/C as mob, mob/living/user as mob)
 	if(user.a_intent == I_HELP && (C.handcuffed) && (istype(C.handcuffed, /obj/item/handcuffs/cable)))
@@ -787,6 +778,7 @@
 	block_chance = 35
 	str_requirement = 12 //i don't want to hear it, anyone below 12 str is supposed to be a child or a old man.
 	weapon_speed_delay = 7
+	armor = list(melee = 15, bullet = 20, laser = 20, energy = 10, bomb = 10, bio = 0, rad = 0)
 
 
 //knife for astartes/ogryn
@@ -817,25 +809,6 @@
 	slot_flags = SLOT_BACK
 	origin_tech = list(TECH_MATERIAL = 2, TECH_COMBAT = 2)
 	attack_verb = list("chopped", "sliced", "cut", "reaped")
-
-/obj/item/melee/sword/commissword
-	name = "commissar's sword"
-	desc = "An orante officer's sword and the Commissar's prized possession. Used to cut down heretics and cowards alike"
-	icon = 'icons/obj/weapons/melee/misc.dmi'
-	icon_state = "commissword"
-	item_state = "commissword"
-	attack_verb = list("stabbed", "chopped", "cut", "sliced")
-	force = 31
-	force_wielded = 36
-	sharp = 1
-	block_chance = 22
-	w_class = ITEM_SIZE_NORMAL
-	origin_tech = list(TECH_MATERIAL = 2, TECH_COMBAT = 2)
-	slot_flags = SLOT_BELT
-	sales_price = 0
-	weapon_speed_delay = 7
-	armor_penetration = 45
-
 
 //knife for astartes/ogryn
 /obj/item/melee/sword/combat_knife/catachan/giant

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -322,12 +322,21 @@
 
 // NEW HELMETS
 
+/obj/item/clothing/head/helmet/witch
+	name = "Witch Hunter Hat"
+	desc = "An armored hat... how?"
+	armor = list(melee = 30, bullet = 40, laser = 40, energy = 35, bomb = 30, bio = 30, rad = 30)
+	sales_price = 0
+	icon_state = "brim-hat"
+	item_state = "brim-hat"
+	flags_inv = BLOCKHEADHAIR
+
 /obj/item/clothing/head/helmet/soul
 	name = "Seolite Helmet"
 	desc = "A xenos helmet from the seolite forgemasters, remarkbly resistant to thermal damage."
 	icon_state = "soul"
 	item_state = "soul"
-	armor = list(melee = 30, bullet = 40, laser = 58, energy = 35, bomb = 50, bio = 100, rad = 50)
+	armor = list(melee = 30, bullet = 40, laser = 48, energy = 35, bomb = 50, bio = 100, rad = 50)
 	sales_price = 0
 
 /obj/item/clothing/head/helmet/seolhelm
@@ -335,7 +344,7 @@
 	desc = "A xenos power helmet from the seolite forgemasters, remarkbly resistant to thermal damage."
 	icon_state = "seolhelm"
 	item_state = "seolhelm"
-	armor = list(melee = 40, bullet = 48, laser = 68, energy = 35, bomb = 50, bio = 100, rad = 50)
+	armor = list(melee = 40, bullet = 48, laser = 58, energy = 35, bomb = 50, bio = 100, rad = 50)
 	sales_price = 0
 
 /obj/item/clothing/head/helmet/hauberk
@@ -355,11 +364,11 @@
 	sales_price = 2
 
 /obj/item/clothing/head/helmet/hevhelm/palace
-	name = "Palace Guard Helm"
+	name = "Honour Guard Helm"
 	desc = "A heavy metal helmet for your noggin."
 	icon_state = "hevhelm"
 	item_state = "hevhelm"
-	color = "#606d24"
+	color = "#ad9b30"
 	armor = list(melee = 45, bullet = 30, laser = 45, energy = 35, bomb = 30, bio = 50, rad = 30)
 	sales_price = 2
 

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -650,7 +650,7 @@
 // cultists, pilgrims ect
 
 /obj/item/clothing/head/heretichood
-	name = "cultist hood"
+	name = "mysterious hood"
 	desc = "A filth hood rag"
 	icon_state = "hood1"
 	item_state = "hood1"

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -331,7 +331,7 @@
 	icon_state = "brim-hat"
 	item_state = "brim-hat"
 	flags_inv = BLOCKHEADHAIR
-	armor = list(melee = 15, bullet = 0, laser = 15, energy = 15, bomb = 0, bio = 0, rad = 0)
+	armor = list(melee = 40, bullet = 48, laser = 40, energy = 60, bomb = 60, bio = 100, rad = 100)
 
 /obj/item/clothing/head/hospitallerhelm
 	name = "blessed head garments"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -390,17 +390,6 @@ obj/item/clothing/suit/armor
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | ARMS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 
-/obj/item/clothing/suit/armor/preacher
-	name = "Preacher's Gambeson"
-	desc = "The gambeson chosen by the fanatical Frateris, Preachers and Fanatics of the ecclesiarchy"
-	icon_state = "preacherarmor"
-	item_state = "preacherarmor"
-	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
-	armor = list(melee = 35, bullet = 25, laser = 20, energy = 30, bomb = 10, bio = 10, rad = 10)
-	sales_price = 5
-	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
-	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
-
 //// PILGRIMS
 
 /obj/item/clothing/suit/storage/hooded/miner
@@ -1279,6 +1268,18 @@ obj/item/clothing/suit/armor
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 
+/obj/item/clothing/suit/armor/witch
+	name = "Witch Hunter's Gambeson"
+	desc = "The gambeson chosen by the fanatical Frateris Witch Hunters of the Ecclesiarchy"
+	icon_state = "preacherarmor"
+	item_state = "preacherarmor"
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	armor = list(melee = 48, bullet = 44, laser = 48, energy = 25, bomb = 30, bio = 30, rad = 30)
+	sales_price = 5
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
 /obj/item/clothing/suit/armor/trinet
 	name = "Iron Cuirass"
 	desc = "An iron-alloy breastplate forged by local hands, it's craftsmanship is questionable but the exotic alloy is remarkbly unique to Eipharius."
@@ -1748,11 +1749,11 @@ obj/item/clothing/suit/armor
 	slowdown_per_slot[slot_wear_suit] = 0.3
 
 /obj/item/clothing/suit/armor/brigandine/palace
-	name = "Royal Brigandine"
-	desc = "A heavy set of fine plated leather overlayn with carapace to protect against even the most unconventional of weapons. Worn by the Palace Guard of Messina."
-	icon_state = "brigandine"
-	item_state = "brigandine"
-	color = "#606d24"
+	name = "Honour Guard Cuirass"
+	desc = "A heavy set of fine plat with carapace inserts to protect against even the most unconventional of weapons. Worn by the Honour Guard of Messina."
+	icon_state = "templar"
+	item_state = "templar"
+	color = "#ad9b30"
 	armor = list(melee = 51, bullet = 45, laser = 49, energy = 25, bomb = 50, bio = 30, rad = 50)
 	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS

--- a/maps/delta/warhammer-1.dmm
+++ b/maps/delta/warhammer-1.dmm
@@ -81,13 +81,6 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/caves/dark)
-"av" = (
-/obj/machinery/artifact_harvester,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/turf/clockwork,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "aw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -158,17 +151,6 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/new_hive/caves)
-"aL" = (
-/obj/effect/floor_decal/turf/bloodbar/off,
-/obj/structure/table/rack/dark,
-/obj/item/cell/pulserifle{
-	name = "xenos battery"
-	},
-/obj/item/cell/pulserifle{
-	name = "xenos battery"
-	},
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "aM" = (
 /obj/structure/closet/cabinet{
 	color = "grey"
@@ -332,12 +314,6 @@
 	icon = 'icons/map_project/ship/tilesnovos.dmi'
 	},
 /area/cadiaoutpost/new_hive/caves)
-"bq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/shieldgen,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "br" = (
 /obj/machinery/door/airlock/ancient_ship/med{
 	name = "Operation Room"
@@ -356,12 +332,6 @@
 /turf/simulated/floor/tiled{
 	color = "grey"
 	},
-/area/cadiaoutpost/oa/caves/dark)
-"bu" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/stone/old4,
 /area/cadiaoutpost/oa/caves/dark)
 "bv" = (
 /obj/machinery/light{
@@ -483,12 +453,6 @@
 	icon = 'icons/map_project/ship/tilesnovos.dmi'
 	},
 /area/cadiaoutpost/new_hive/caves)
-"bN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/obj/item/stack/material/diamond,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "bO" = (
 /obj/item/device/radio/intercom{
 	pixel_y = 32
@@ -911,11 +875,6 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/caves/dark)
-"dp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "dq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1199,12 +1158,6 @@
 	icon = 'icons/map_project/ship/tilesnovos.dmi'
 	},
 /area/cadiaoutpost/new_hive/caves)
-"en" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/crystal_static,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "eq" = (
 /obj/effect/floor_decal/turf/surgery2,
 /obj/machinery/bodyscanner{
@@ -1305,14 +1258,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/cadiaoutpost/oa/caves/undercity)
-"eC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/obj/machinery/computer/rdconsole/core{
-	req_access = list()
-	},
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "eD" = (
 /turf/unsimulated/oldship{
 	icon_state = "rwall15"
@@ -1672,20 +1617,6 @@
 	icon = 'icons/map_project/ship/tilesnovos.dmi'
 	},
 /area/cadiaoutpost/new_hive/caves)
-"fL" = (
-/obj/effect/floor_decal/turf/plating,
-/obj/machinery/door/airlock/arbiter{
-	color = "grey";
-	maxhealth = 3000;
-	name = "Groomlake Facility";
-	req_access = list()
-	},
-/obj/machinery/door/blast/bordergater{
-	begins_closed = 0;
-	id = "archeo2"
-	},
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "fM" = (
 /obj/structure/table/marble{
 	color = "grey"
@@ -1911,12 +1842,6 @@
 /obj/machinery/light/small/red,
 /turf/simulated/floor/ship_floor/engines,
 /area/cadiaoutpost/new_hive/caves)
-"gp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/obj/machinery/integrated_circuit_printer,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "gr" = (
 /obj/structure/table/marble{
 	color = "grey"
@@ -2304,17 +2229,6 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/shuttle/cargo1)
-"hX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/obj/machinery/mecha_part_fabricator,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
-"hY" = (
-/obj/structure/telearray/centreleft,
-/obj/effect/floor_decal/turf/bloodbar/off,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "hZ" = (
 /obj/machinery/light/small/red{
 	dir = 4
@@ -2677,11 +2591,6 @@
 	icon = 'icons/map_project/ship/tilesnovos.dmi'
 	},
 /area/cadiaoutpost/new_hive/caves)
-"jf" = (
-/obj/effect/floor_decal/turf/bloodbar/off,
-/obj/structure/cult/clockworkobelisk,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "jh" = (
 /obj/machinery/light/purple{
 	dir = 8
@@ -2830,16 +2739,6 @@
 /turf/simulated/floor/tiled{
 	color = "grey"
 	},
-/area/cadiaoutpost/oa/caves/dark)
-"jF" = (
-/obj/effect/floor_decal/turf/bloodbar/off,
-/obj/structure/table/rack/dark,
-/obj/item/cell/plasma,
-/obj/item/storage/belt/utility/atmostech{
-	color = "grey";
-	name = "forge belt"
-	},
-/turf/simulated/floor/seolite,
 /area/cadiaoutpost/oa/caves/dark)
 "jH" = (
 /obj/structure/closet/secure_closet/security{
@@ -3354,11 +3253,6 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/caves/dark)
-"lr" = (
-/obj/effect/floor_decal/turf/bloodbar/off,
-/obj/structure/gemwasher,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "ls" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3611,11 +3505,6 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/caves/undercity)
-"mb" = (
-/obj/structure/telearray/lowleft,
-/obj/effect/floor_decal/turf/bloodbar/off,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "mc" = (
 /obj/structure/sign/ship{
 	icon_state = "trading";
@@ -3676,17 +3565,6 @@
 	icon = 'icons/map_project/ship/tilesnovos.dmi'
 	},
 /area/cadiaoutpost/new_hive/caves)
-"mi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/turf/plating,
-/obj/machinery/door/airlock/arbiter{
-	color = "grey";
-	maxhealth = 3000;
-	name = "Groomlake Facility";
-	req_access = list(221,222)
-	},
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "mj" = (
 /obj/machinery/computer/shuttle_control/ferry/bloodpact,
 /turf/simulated/floor,
@@ -4462,18 +4340,6 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/caves/dark)
-"oM" = (
-/obj/effect/floor_decal/turf/bloodbar/off,
-/obj/structure/cult/talisman{
-	desc = "A dusty table constructed from stone - handcut and covered in runic scripture.";
-	name = "Ancient Table"
-	},
-/obj/item/reagent_containers/hypospray/autoinjector/tau{
-	desc = "A disgusting red liquid sloshes around inside the tube.";
-	name = "Mysterious Injector"
-	},
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "oN" = (
 /obj/item/ammo_magazine/ork/slugga,
 /turf/simulated/floor/stone,
@@ -4599,10 +4465,7 @@
 	},
 /area/cadiaoutpost/oa/caves/undercity)
 "pc" = (
-/obj/effect/floor_decal/turf/bloodbar/off,
-/obj/structure/reagent_dispensers/acid{
-	pixel_x = -30
-	},
+/mob/living/simple_animal/hostile/mining_borg/behemoth,
 /turf/simulated/floor/seolite,
 /area/cadiaoutpost/oa/caves/dark)
 "pf" = (
@@ -4983,13 +4846,6 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/caves/undercity)
-"qP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/obj/item/rnd/eng3,
-/obj/structure/table/rack/dark,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "qQ" = (
 /obj/effect/floor_decal/newcorner/trench_flooring{
 	dir = 8
@@ -5091,17 +4947,6 @@
 	icon = 'icons/map_project/ship/tilesnovos.dmi'
 	},
 /area/cadiaoutpost/new_hive/caves)
-"ri" = (
-/obj/effect/floor_decal/turf/plating,
-/obj/machinery/door/blast/bordergatec{
-	begins_closed = 0;
-	desc = "A large mechanical gate. This one is inscribed with various prayers, sigils, and lathered in holy oil.";
-	id = "archeo1";
-	name = "consecrated gate";
-	opaque = 1
-	},
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "rj" = (
 /obj/structure/table/marble{
 	color = "grey"
@@ -5231,15 +5076,6 @@
 /obj/item/reagent_containers/hypospray/autoinjector/tau{
 	desc = "A disgusting red liquid sloshes around inside the tube.";
 	name = "Mysterious Injector"
-	},
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
-"rH" = (
-/obj/machinery/door/airlock/arbiter{
-	color = "grey";
-	maxhealth = 3000;
-	name = "Groomlake Facility";
-	req_access = list()
 	},
 /turf/simulated/floor/seolite,
 /area/cadiaoutpost/oa/caves/dark)
@@ -5445,18 +5281,6 @@
 	icon_state = "r_window"
 	},
 /area/cadiaoutpost/new_hive/caves)
-"sx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/obj/structure/table/rack/dark,
-/obj/item/stack/material/phoron,
-/obj/item/stack/material/phoron,
-/obj/item/stack/material/phoron,
-/obj/item/stack/material/phoron,
-/obj/item/stack/material/phoron,
-/obj/item/stack/material/phoron,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "sz" = (
 /obj/effect/decal/cleanable/blood{
 	color = "black"
@@ -5616,15 +5440,6 @@
 /turf/simulated/floor/tiled{
 	color = "grey"
 	},
-/area/cadiaoutpost/oa/caves/dark)
-"sX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/obj/machinery/computer/drone_control{
-	dronefab = "Cadia";
-	req_access = list()
-	},
-/turf/simulated/floor/seolite,
 /area/cadiaoutpost/oa/caves/dark)
 "tc" = (
 /obj/structure/sink{
@@ -6522,16 +6337,6 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/caves/undercity)
-"we" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/obj/machinery/cell_charger,
-/obj/structure/table/steel,
-/obj/random/tech_supply,
-/obj/random/powercell,
-/obj/random/powercell,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "wg" = (
 /obj/item/reagent_containers/hypospray/autoinjector/morphine{
 	pixel_y = 16
@@ -7221,11 +7026,6 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/caves/undercity)
-"yJ" = (
-/obj/effect/floor_decal/turf/bloodbar/off,
-/obj/machinery/vending/phoronresearch,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "yK" = (
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/ship_floor/steel{
@@ -7892,13 +7692,6 @@
 	icon_state = "evil"
 	},
 /area/cadiaoutpost/new_hive/caves)
-"AW" = (
-/obj/machinery/artifact_scanpad,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/obj/item/gun/energy/pulse/plasma/pistol/glock,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "AX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8027,12 +7820,6 @@
 	dir = 8
 	},
 /area/cadiaoutpost/new_hive/caves)
-"Bp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/obj/machinery/r_n_d/protolathe,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "Bq" = (
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
@@ -8179,18 +7966,6 @@
 	icon = 'icons/map_project/ship/tilesnovos.dmi'
 	},
 /area/cadiaoutpost/new_hive/caves)
-"BP" = (
-/obj/effect/floor_decal/turf/bloodbar/off,
-/obj/item/card/id/silver{
-	access = list(221,222);
-	color = "grey";
-	job_access_type = null;
-	name = "L2 Access Card"
-	},
-/obj/item/clothing/suit/armor/seolarmor,
-/obj/item/clothing/head/helmet/soul,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "BQ" = (
 /turf/simulated/floor/tiled{
 	color = "gray"
@@ -8474,15 +8249,6 @@
 	icon = 'icons/map_project/ship/tilesnovos.dmi'
 	},
 /area/cadiaoutpost/new_hive/caves)
-"CH" = (
-/obj/machinery/button/remote/blast_door/id_scan{
-	name = "pristine ID lock";
-	id = "secretdoor";
-	req_one_access = list(221,222)
-	},
-/obj/structure/table/graf/rusty_table,
-/turf/simulated/floor/stone/old4,
-/area/cadiaoutpost/oa/caves/dark)
 "CI" = (
 /obj/structure/sign/neon/cargo{
 	pixel_x = -32
@@ -8996,18 +8762,6 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/caves/undercity)
-"En" = (
-/obj/effect/floor_decal/turf/bloodbar/off,
-/obj/item/card/id/silver{
-	access = list(221,222);
-	color = "grey";
-	job_access_type = null;
-	name = "L2 Access Card"
-	},
-/obj/item/clothing/suit/armor/seolarmor,
-/obj/item/clothing/head/helmet/seolhelm,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "Eo" = (
 /obj/effect/floor_decal/corner/beige{
 	icon_state = "corner_white";
@@ -9703,15 +9457,11 @@
 /obj/item/mining_scanner,
 /turf/simulated/floor/stone,
 /area/cadiaoutpost/oa/caves/undercity)
-"GA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/obj/machinery/r_n_d/destructive_analyzer,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "GC" = (
-/obj/effect/floor_decal/turf/bloodbar/off,
-/obj/structure/forge,
+/obj/structure/table/marble{
+	color = "grey"
+	},
+/obj/item/clothing/head/helmet/seolhelm,
 /turf/simulated/floor/seolite,
 /area/cadiaoutpost/oa/caves/dark)
 "GD" = (
@@ -10161,14 +9911,6 @@
 	dir = 1
 	},
 /area/cadiaoutpost/new_hive/caves)
-"In" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/obj/item/stack/material/diamond{
-	amount = 5
-	},
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "Io" = (
 /obj/item/campfire/self_lit{
 	desc = "A campfire.";
@@ -10415,20 +10157,6 @@
 	dir = 1
 	},
 /area/cadiaoutpost/oa/caves/dark)
-"IR" = (
-/obj/effect/floor_decal/turf/plating,
-/obj/machinery/door/airlock/arbiter{
-	color = "grey";
-	maxhealth = 3000;
-	name = "Groomlake Facility";
-	req_access = list()
-	},
-/obj/machinery/door/blast/bordergatel{
-	begins_closed = 0;
-	id = "archeo2"
-	},
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "IS" = (
 /obj/effect/floor_decal/turf/surgery2,
 /obj/structure/table/marble{
@@ -10540,11 +10268,6 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/caves/dark)
-"Jp" = (
-/obj/effect/floor_decal/turf/bloodbar/off,
-/obj/machinery/power/port_gen/pacman/super/potato,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "Jq" = (
 /obj/effect/floor_decal/turf/basalt9,
 /turf/simulated/floor/stone,
@@ -10571,15 +10294,6 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/caves/undercity)
-"Jy" = (
-/obj/effect/floor_decal/turf/bloodbar/off,
-/obj/structure/table/rack/dark,
-/obj/item/grenade/spawnergrenade/manhacks{
-	name = "mysterious grenade"
-	},
-/obj/random/loot/tech2,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "Jz" = (
 /obj/structure/shipdecor{
 	icon_state = "reading"
@@ -10754,16 +10468,6 @@
 	desc = "Don't drink the water... it makes you forget!";
 	description_fluff = null;
 	name = "Carbonated Water"
-	},
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
-"JU" = (
-/obj/effect/floor_decal/turf/bloodbar/off,
-/obj/structure/table/rack/dark,
-/obj/item/gun/energy/pulse/pulserifle{
-	charge_cost = 55;
-	desc = "The remains of an ancient salvage, close examination reveals the power pack is drained and there are even cracks within the crystal assembly.";
-	name = "Salvaged Pulse Rifle"
 	},
 /turf/simulated/floor/seolite,
 /area/cadiaoutpost/oa/caves/dark)
@@ -11042,6 +10746,7 @@
 	color = "grey"
 	},
 /obj/effect/floor_decal/turf/lfloorscorched1,
+/obj/item/clothing/head/helmet/soul,
 /turf/simulated/floor/seolite,
 /area/cadiaoutpost/oa/caves/dark)
 "KO" = (
@@ -11080,11 +10785,6 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/caves/dark)
-"KU" = (
-/mob/living/simple_animal/tomato,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "KV" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/seolite,
@@ -11119,15 +10819,6 @@
 /obj/item/gun/launcher/grenade/mezoa,
 /turf/simulated/floor/ship_floor/steel,
 /area/cadiaoutpost/new_hive/caves)
-"Lc" = (
-/obj/effect/floor_decal/turf/bloodbar/off,
-/obj/structure/cult/talisman{
-	desc = "A dusty table constructed from stone - handcut and covered in runic scripture.";
-	name = "Ancient Table"
-	},
-/obj/random/loot/tech2,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "Ld" = (
 /turf/simulated/wall/castle,
 /area/cadiaoutpost/new_hive/caves)
@@ -11138,28 +10829,6 @@
 /turf/simulated/floor/tiled{
 	color = "grey"
 	},
-/area/cadiaoutpost/oa/caves/dark)
-"Lj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/obj/structure/table/rack/dark,
-/obj/item/paper/crumpled/bloody{
-	name = "reseach instructions";
-	desc = "get ingots. turn into strange alloy. put in the protolathe. find archeotech or steal it from your rivals. become one with the machine god."
-	},
-/obj/item/card/id/silver{
-	access = list(221,222,223);
-	color = "grey";
-	job_access_type = null;
-	name = "L3 Access Card"
-	},
-/obj/item/card/id/silver{
-	access = list(221,222,223);
-	color = "grey";
-	job_access_type = null;
-	name = "L3 Access Card"
-	},
-/turf/simulated/floor/seolite,
 /area/cadiaoutpost/oa/caves/dark)
 "Lk" = (
 /obj/machinery/light/red,
@@ -11348,14 +11017,6 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/caves/undercity)
-"LN" = (
-/obj/effect/floor_decal/turf/plating,
-/obj/machinery/door/blast/bordergatel{
-	begins_closed = 0;
-	id = "archeo1"
-	},
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "LP" = (
 /obj/structure/sign/ship/blood_signs{
 	icon_state = "BLOOD"
@@ -11799,13 +11460,6 @@
 /obj/random/coin,
 /turf/simulated/floor/seolite,
 /area/cadiaoutpost/oa/caves/undercity)
-"NA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/obj/item/rnd/biospace3,
-/obj/structure/table/rack/dark,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "NC" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/paper_bin{
@@ -11877,12 +11531,6 @@
 	icon = 'icons/map_project/ship/tilesnovos.dmi'
 	},
 /area/cadiaoutpost/new_hive/caves)
-"NP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/obj/machinery/r_n_d/circuit_imprinter,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "NR" = (
 /obj/machinery/igniter{
 	desc = null;
@@ -12245,8 +11893,8 @@
 	},
 /area/cadiaoutpost/oa/caves/dark)
 "Pc" = (
-/obj/structure/telearray/centreright,
-/obj/effect/floor_decal/turf/bloodbar/off,
+/obj/effect/floor_decal/turf/plating,
+/mob/living/simple_animal/hostile/mining_borg/behemoth,
 /turf/simulated/floor/seolite,
 /area/cadiaoutpost/oa/caves/dark)
 "Pg" = (
@@ -12556,9 +12204,6 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/caves/dark)
-"Qa" = (
-/turf/simulated/floor/stone/old4,
-/area/cadiaoutpost/oa/caves/dark)
 "Qc" = (
 /obj/structure/table/steel,
 /obj/item/reagent_containers/food/drinks/bottle/bluecuracao{
@@ -12756,11 +12401,6 @@
 /turf/simulated/floor/tiled{
 	color = "grey"
 	},
-/area/cadiaoutpost/oa/caves/dark)
-"QB" = (
-/obj/structure/telearray/lowright,
-/obj/effect/floor_decal/turf/bloodbar/off,
-/turf/simulated/floor/seolite,
 /area/cadiaoutpost/oa/caves/dark)
 "QE" = (
 /obj/random/loot/tech1,
@@ -13084,15 +12724,6 @@
 	},
 /turf/simulated/floor/carpet/purple,
 /area/cadiaoutpost/oa/caves/undercity)
-"RZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/obj/structure/table/rack/dark,
-/obj/item/stack/material/glass/fifty,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "Sa" = (
 /obj/item/reagent_containers/food/snacks/meat/rat_meat,
 /turf/simulated/floor/ship_floor/steel{
@@ -13146,12 +12777,6 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/caves/dark)
-"Sg" = (
-/obj/machinery/artifact_analyser,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "Sh" = (
 /obj/item/material/shard,
 /obj/effect/decal/cleanable/cobweb,
@@ -13165,13 +12790,6 @@
 	icon_state = "evil"
 	},
 /area/cadiaoutpost/new_hive/caves)
-"Sk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/obj/item/rnd/illegal10,
-/obj/structure/table/rack/dark,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "Sm" = (
 /obj/structure/statue/prayer,
 /turf/simulated/floor/stone/old4,
@@ -13188,32 +12806,6 @@
 	icon_state = "evil"
 	},
 /area/cadiaoutpost/new_hive/caves)
-"St" = (
-/obj/effect/floor_decal/turf/bloodbar/off,
-/obj/structure/table/rack/dark,
-/obj/item/gun/energy/pulse/ionrifle{
-	charge_cost = 50;
-	desc = "The remains of an ancient salvage, close examination reveals the power pack is drained and there are even cracks within the crystal assembly.";
-	name = "Salvaged ION rifle"
-	},
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
-"Su" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/obj/machinery/button/remote/blast_door/lever{
-	id = "archeo1";
-	name = "Inner Gate";
-	pixel_x = -10
-	},
-/obj/machinery/button/remote/blast_door/lever{
-	id = "archeo2";
-	name = "Outer Gate";
-	pixel_x = 10
-	},
-/obj/structure/table/steel,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "Sw" = (
 /obj/structure/window/reinforced{
 	color = "grey";
@@ -13296,12 +12888,6 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/caves/dark)
-"SP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/crystal_static/pink,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "SQ" = (
 /obj/machinery/door/window/westleft,
 /obj/structure/cable{
@@ -13367,14 +12953,6 @@
 	},
 /turf/simulated/floor/stone,
 /area/cadiaoutpost/new_hive/caves)
-"Ta" = (
-/obj/effect/floor_decal/turf/plating,
-/obj/machinery/door/blast/bordergater{
-	begins_closed = 0;
-	id = "archeo1"
-	},
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "Tb" = (
 /obj/structure/cult/tome,
 /turf/simulated/floor/tiled{
@@ -13645,10 +13223,6 @@
 	},
 /turf/unsimulated/mineral,
 /area/cadiaoutpost/new_hive/caves)
-"TY" = (
-/obj/structure/stairs/south,
-/turf/simulated/floor/stone/old4,
-/area/cadiaoutpost/oa/caves/dark)
 "TZ" = (
 /obj/structure/table/marble{
 	color = "grey"
@@ -14205,19 +13779,6 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/caves/dark)
-"VP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/implantchair,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
-"VQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/obj/structure/table/rack/dark,
-/obj/item/stack/material/steel/fifty,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "VS" = (
 /obj/effect/decal/cleanable/blood/gibs/core,
 /turf/simulated/floor/tiled{
@@ -14441,11 +14002,6 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/caves/dark)
-"WN" = (
-/obj/structure/telearray/upperleft,
-/obj/effect/floor_decal/turf/bloodbar/off,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "WO" = (
 /obj/machinery/door/airlock/gold{
 	color = "grey"
@@ -14578,22 +14134,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled{
-	color = "grey"
-	},
-/area/cadiaoutpost/oa/caves/dark)
-"Xo" = (
-/obj/item/reagent_containers/hypospray/autoinjector/tau{
-	desc = "A disgusting red liquid sloshes around inside the tube.";
-	name = "Mysterious Injector"
-	},
-/obj/effect/floor_decal/turf/carpetn00,
-/obj/item/newore/gems/ruby/cut,
-/obj/item/device/holyoils,
-/obj/item/device/autochisel,
-/obj/item/device/hammer,
-/obj/effect/floor_decal/turf/bloodbar/off,
-/obj/item/rnd/combat10,
-/turf/simulated/floor/tiled/dark{
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/caves/dark)
@@ -14913,12 +14453,6 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/caves/dark)
-"Yi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/turf/lfloorscorched1,
-/obj/machinery/vending/robotics,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "Yj" = (
 /obj/machinery/light/small/red,
 /turf/simulated/floor/fancyfloor/coralg,
@@ -15118,15 +14652,6 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/caves/dark)
-"YH" = (
-/obj/machinery/door/blast/id_door{
-	req_access = list(302);
-	name = "Secret Door";
-	id = "secretdoor";
-	maxhealth = 9000
-	},
-/turf/simulated/floor/factory_floor,
-/area/cadiaoutpost/oa/caves/dark)
 "YJ" = (
 /obj/machinery/door/airlock/ancient_ship/command/capitan,
 /turf/simulated/floor/ship_floor/steel{
@@ -15247,16 +14772,6 @@
 	icon = 'icons/map_project/ship/tilesnovos.dmi'
 	},
 /area/cadiaoutpost/new_hive/caves)
-"Ze" = (
-/obj/effect/floor_decal/turf/bloodbar/off,
-/obj/machinery/button/remote/blast_door/id_scan{
-	name = "pristine ID lock";
-	id = "secretdoor";
-	req_one_access = list(221,222)
-	},
-/obj/structure/table/graf/rusty_table,
-/turf/simulated/floor/seolite,
-/area/cadiaoutpost/oa/caves/dark)
 "Zf" = (
 /obj/machinery/door/airlock/ancient_ship/med{
 	name = "Medical Bay"
@@ -32235,7 +31750,7 @@ GX
 IO
 IO
 IO
-IO
+Pc
 IO
 PK
 wZ
@@ -32249,7 +31764,7 @@ lf
 eS
 fn
 yV
-fn
+GC
 EN
 Jt
 Jt
@@ -33259,7 +32774,7 @@ Jt
 Jt
 Jt
 Jt
-Jt
+pc
 iE
 Jt
 Jt
@@ -41065,7 +40580,7 @@ zx
 Ih
 Ih
 MU
-dd
+MU
 Ih
 Ih
 MU
@@ -41299,7 +40814,7 @@ zx
 dd
 eS
 Jk
-KU
+qt
 Jk
 eS
 VO
@@ -41317,8 +40832,8 @@ zx
 Ih
 MU
 MU
-dd
-dd
+MU
+MU
 Fa
 MU
 MU
@@ -41551,7 +41066,7 @@ zx
 dd
 eS
 Jk
-KU
+qt
 Jk
 eS
 VO
@@ -41570,7 +41085,7 @@ Ih
 MU
 MU
 MU
-dd
+MU
 MU
 MU
 MU
@@ -41822,8 +41337,8 @@ Ih
 MU
 MU
 MU
-dd
-dd
+MU
+MU
 MU
 Ih
 Ih
@@ -42054,7 +41569,7 @@ zx
 zx
 dd
 pO
-KU
+qt
 qt
 le
 pO
@@ -42306,7 +41821,7 @@ zx
 zx
 dd
 eS
-KU
+qt
 qt
 Bz
 eS
@@ -42801,13 +42316,13 @@ zx
 zx
 zx
 zx
-dd
-dd
-dd
-dd
-dd
-dd
-dd
+zx
+zx
+zx
+zx
+zx
+zx
+zx
 dd
 eS
 Jk
@@ -43053,14 +42568,14 @@ zx
 zx
 zx
 zx
-dd
-eS
-eS
-eS
-pO
-eS
-eS
-eS
+zx
+jV
+jV
+jV
+jV
+jV
+jV
+jV
 eS
 eS
 wy
@@ -43305,19 +42820,19 @@ zx
 zx
 zx
 zx
-dd
-eS
-Lj
-NA
-qP
-Sk
-eC
-av
-we
+zx
+jV
+jV
+jV
+jV
+jV
+jV
+jV
+jV
 eS
 IO
 IO
-LN
+IO
 IO
 IO
 IO
@@ -43557,19 +43072,19 @@ zx
 zx
 zx
 zx
-dd
-eS
-Sg
-dp
-dp
-dp
-dp
-dp
-dp
+zx
+jV
+jV
+jV
+jV
+jV
+jV
+jV
+jV
 eS
 IO
 IO
-ri
+IO
 IO
 IO
 IO
@@ -43809,19 +43324,16 @@ zx
 zx
 zx
 zx
-dd
+zx
+jV
+jV
+jV
+jV
+jV
+jV
+jV
+jV
 eS
-AW
-dp
-GA
-Bp
-gp
-NP
-dp
-pO
-IO
-IO
-Ta
 IO
 IO
 IO
@@ -43831,7 +43343,10 @@ IO
 IO
 IO
 IO
-IR
+IO
+IO
+IO
+XG
 IO
 IO
 IO
@@ -44061,16 +43576,16 @@ zx
 zx
 zx
 zx
-dd
-pO
-VP
-dp
-dp
-In
-dp
-dp
-dp
-mi
+zx
+jV
+jV
+jV
+jV
+jV
+jV
+jV
+jV
+eS
 IO
 IO
 pO
@@ -44083,7 +43598,7 @@ IO
 eS
 Pq
 IO
-fL
+XG
 IO
 IO
 IO
@@ -44313,16 +43828,16 @@ zx
 zx
 zx
 zx
-dd
+zx
+jV
+jV
+jV
+jV
+jV
+jV
+jV
+jV
 eS
-SP
-dp
-hX
-RZ
-VQ
-sx
-dp
-pO
 IO
 IO
 eS
@@ -44565,15 +44080,15 @@ zx
 zx
 zx
 zx
-dd
-eS
-dp
-dp
-dp
-bN
-dp
-dp
-dp
+zx
+jV
+jV
+jV
+jV
+jV
+jV
+jV
+jV
 eS
 eS
 IO
@@ -44817,15 +44332,15 @@ zx
 zx
 zx
 zx
-dd
-eS
-en
-sX
-Yi
-dp
-Su
-bq
-bq
+zx
+jV
+jV
+jV
+jV
+jV
+jV
+jV
+jV
 eS
 eS
 IO
@@ -45069,15 +44584,15 @@ zx
 zx
 zx
 zx
-dd
-eS
-eS
-eS
-eS
-rH
-eS
-pO
-eS
+zx
+jV
+jV
+jV
+jV
+jV
+jV
+jV
+jV
 eS
 eS
 qE
@@ -45321,15 +44836,15 @@ zx
 zx
 zx
 zx
-dd
-dd
-eS
-eS
-pc
-Ia
-Ia
-oM
-Lc
+zx
+zx
+jV
+jV
+jV
+jV
+jV
+jV
+jV
 eS
 eS
 eS
@@ -45574,15 +45089,15 @@ zx
 zx
 zx
 zx
-dd
-eS
-lr
-Ia
-Ia
-BP
-Ia
-Ia
-GC
+zx
+jV
+jV
+jV
+jV
+jV
+jV
+jV
+jV
 eS
 eS
 eS
@@ -45826,17 +45341,17 @@ zx
 zx
 zx
 zx
-dd
-eS
-Jy
-Ia
-Ia
-Ia
-Ia
-Ia
-Ia
-eS
-bu
+zx
+jV
+jV
+jV
+jV
+jV
+jV
+jV
+jV
+jV
+jV
 eS
 eS
 eS
@@ -46078,18 +45593,18 @@ zx
 zx
 zx
 zx
-dd
-eS
-jF
-Ia
-Ia
-WN
-Ia
-Ia
-Ia
-YH
-Qa
-TY
+zx
+jV
+jV
+jV
+jV
+jV
+jV
+jV
+jV
+jV
+jV
+jV
 eS
 zx
 zx
@@ -46330,17 +45845,17 @@ zx
 zx
 zx
 zx
-dd
-eS
-yJ
-Ia
-jf
-hY
-mb
-Ia
-Ze
-eS
-CH
+zx
+jV
+jV
+jV
+jV
+jV
+jV
+jV
+jV
+jV
+jV
 eS
 eS
 zx
@@ -46582,15 +46097,15 @@ zx
 zx
 zx
 zx
-dd
-eS
-St
-Ia
-BP
-Pc
-QB
-En
-Jp
+zx
+jV
+jV
+jV
+jV
+jV
+jV
+jV
+jV
 eS
 eS
 eS
@@ -46834,14 +46349,14 @@ zx
 zx
 zx
 zx
-dd
-eS
-JU
-Ia
-Ia
-Xo
-Ia
-Ia
+zx
+jV
+jV
+jV
+jV
+jV
+jV
+jV
 eS
 eS
 zx
@@ -47086,13 +46601,13 @@ zx
 zx
 dd
 dd
-dd
-eS
-aL
-Ia
-Ia
-Ia
-Ia
+zx
+jV
+jV
+jV
+jV
+jV
+jV
 eS
 eS
 eS

--- a/maps/delta/warhammer-2.dmm
+++ b/maps/delta/warhammer-2.dmm
@@ -216,6 +216,16 @@
 /obj/item/device/flashlight/lantern,
 /turf/simulated/floor/ceramic/surgery2,
 /area/cadiaoutpost/new_hive/caves)
+"amR" = (
+/obj/effect/floor_decal/turf/bloodbar/off,
+/obj/structure/table/rack/dark,
+/obj/item/cell/plasma,
+/obj/item/storage/belt/utility/atmostech{
+	color = "grey";
+	name = "forge belt"
+	},
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "anh" = (
 /turf/unsimulated/wall/fakeglass{
 	dir = 4;
@@ -243,6 +253,20 @@
 	color = "grey"
 	},
 /turf/simulated/floor/dirty,
+/area/cadiaoutpost/oa/farm)
+"aoI" = (
+/obj/effect/decal/cleanable/cobweb{
+	dir = 8
+	},
+/obj/random/loot/randomammo1,
+/obj/random/loot/randomammo1,
+/obj/random/loot/randomammo1,
+/obj/random/loot/randomammo1,
+/obj/random/loot/randomammo1,
+/obj/random/loot/randomammo1,
+/obj/random/loot/randomammo1,
+/obj/structure/closet/crate,
+/turf/simulated/floor/darkwood/rotten,
 /area/cadiaoutpost/oa/farm)
 "aoJ" = (
 /obj/structure/table/rack,
@@ -1548,6 +1572,15 @@
 	},
 /turf/simulated/floor/factory_floor,
 /area/cadiaoutpost/gma/inquisitoracolyte)
+"bDt" = (
+/obj/machinery/door/blast/id_door{
+	req_access = list(302);
+	name = "Secret Door";
+	id = "secretdoor2";
+	maxhealth = 9000
+	},
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "bDw" = (
 /obj/structure/reagent_dispensers/waterbarrel,
 /turf/simulated/floor/darkwood/rotten,
@@ -1620,6 +1653,7 @@
 	dir = 1;
 	icon_state = "tube1"
 	},
+/obj/machinery/organ_printer,
 /turf/simulated/floor/tiled{
 	desc = "We are beset by many terrible foes in these dark times, but we walk in the light of the Emperor, and we shall not let a single foe stay us from our duty. We are the Sisters of the great Ecclesiarchy, and we will fight to the bitter end.";
 	icon_state = "white1"
@@ -2961,10 +2995,11 @@
 	},
 /area/cadiaoutpost/new_hive/caves)
 "cUF" = (
-/turf/simulated/floor/tiled/dark{
-	icon_state = "steel"
-	},
-/area/cadiaoutpost/oa/caves/dark)
+/obj/machinery/artifact_analyser,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "cUZ" = (
 /obj/machinery/light/small/red,
 /turf/simulated/floor/plating,
@@ -3374,8 +3409,9 @@
 	},
 /area/cadiaoutpost/oa/medicae)
 "dnS" = (
-/turf/simulated/wall/seolite,
-/area/cadiaoutpost/oa/caves/dark)
+/obj/effect/floor_decal/turf/bloodbar/off,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "dod" = (
 /obj/effect/floor_decal/turf/metal/six,
 /obj/machinery/optable,
@@ -3515,6 +3551,11 @@
 /turf/simulated/floor/factory_floor{
 	dir = 4
 	},
+/area/cadiaoutpost/oa/farm)
+"dsw" = (
+/obj/effect/floor_decal/turf/bloodbar/off,
+/obj/structure/gemwasher,
+/turf/simulated/floor/seolite,
 /area/cadiaoutpost/oa/farm)
 "dsC" = (
 /turf/simulated/floor/darkwood,
@@ -3919,12 +3960,9 @@
 /turf/simulated/floor/dirty/tough,
 /area/cadiaoutpost/oa/caves/undercity)
 "dLz" = (
-/obj/structure/closet/hive/iron_c{
-	anchored = 1
-	},
-/obj/random/loot/guardgear,
-/obj/random/loot/guardgear,
-/turf/simulated/floor/darkwood/rotten,
+/obj/structure/telearray/centreleft,
+/obj/effect/floor_decal/turf/bloodbar/off,
+/turf/simulated/floor/seolite,
 /area/cadiaoutpost/oa/farm)
 "dMa" = (
 /obj/structure/table/rack/dark,
@@ -4306,7 +4344,7 @@
 	armor = list("melee"=35,"bullet"=35,"laser"=35,"energy"=5,"bomb"=0,"bio"=100,"rad"=100)
 	},
 /turf/simulated/floor/stone,
-/area/cadiaoutpost/new_hive/caves)
+/area/cadiaoutpost/oa/farm)
 "efP" = (
 /obj/structure/table/rack/shelf{
 	color = "grey"
@@ -4631,6 +4669,12 @@
 	},
 /turf/simulated/floor/dirty/tough,
 /area/cadiaoutpost/oa/caves/undercity)
+"esc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/obj/machinery/r_n_d/destructive_analyzer,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "esf" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/reagent_containers/glass/beaker/large{
@@ -4787,7 +4831,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/stone,
-/area/cadiaoutpost/new_hive/caves)
+/area/cadiaoutpost/oa/farm)
 "ezO" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -5447,6 +5491,18 @@
 	},
 /turf/simulated/floor/stone/old4,
 /area/cadiaoutpost/new_hive/caves)
+"fdf" = (
+/obj/effect/floor_decal/turf/bloodbar/off,
+/obj/structure/cult/talisman{
+	desc = "A dusty table constructed from stone - handcut and covered in runic scripture.";
+	name = "Ancient Table"
+	},
+/obj/item/reagent_containers/hypospray/autoinjector/tau{
+	desc = "A disgusting red liquid sloshes around inside the tube.";
+	name = "Mysterious Injector"
+	},
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "fdE" = (
 /obj/random/obstruction,
 /turf/simulated/floor/darkwood/rotten,
@@ -6606,6 +6662,15 @@
 /obj/effect/floor_decal/newcorner/shaft,
 /turf/simulated/floor/factory_floor,
 /area/cadiaoutpost/oa/research/robotics)
+"gjz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/obj/structure/table/rack/dark,
+/obj/item/stack/material/glass/fifty,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "gjB" = (
 /obj/effect/floor_decal/newcorner/reinforced{
 	dir = 4
@@ -6842,7 +6907,7 @@
 	},
 /obj/item/clothing/head/chaossack,
 /turf/simulated/floor/stone,
-/area/cadiaoutpost/new_hive/caves)
+/area/cadiaoutpost/oa/farm)
 "gue" = (
 /obj/structure/table/graf/rusty_table,
 /obj/item/device/cassette/heresy1,
@@ -6944,6 +7009,13 @@
 	icon_state = "steel"
 	},
 /area/cadiaoutpost/oa/security/barracks)
+"gBj" = (
+/obj/effect/floor_decal/turf/plating,
+/obj/machinery/shieldgen,
+/turf/simulated/floor/tiled{
+	color = "grey"
+	},
+/area/cadiaoutpost/oa/research/robotics)
 "gBK" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/reagent_containers/glass/bottle/pacid{
@@ -7103,6 +7175,21 @@
 	},
 /turf/simulated/floor/factory_floor,
 /area/cadiaoutpost/oa/service/chapel/chapeldorm)
+"gHd" = (
+/obj/structure/closet/crate,
+/obj/item/clothing/head/heretichood/alt2{
+	name = "mysterious hood"
+	},
+/obj/item/clothing/head/heretichood/alt2{
+	name = "mysterious hood"
+	},
+/obj/item/clothing/head/heretichood/alt2{
+	name = "mysterious hood"
+	},
+/obj/item/clothing/suit/armor/heretcoat,
+/obj/item/clothing/suit/armor/heretcoat,
+/turf/simulated/floor/darkwood/rotten,
+/area/cadiaoutpost/oa/farm)
 "gHX" = (
 /obj/structure/table/rack,
 /obj/item/gun/projectile/shotgun/pump,
@@ -7138,20 +7225,13 @@
 /turf/simulated/floor/plating,
 /area/cadiaoutpost/oa/caves/dark)
 "gIB" = (
-/obj/structure/closet/hive/darkwood{
-	anchored = 1
+/obj/effect/floor_decal/turf/bloodbar/off,
+/obj/structure/cult/talisman{
+	desc = "A dusty table constructed from stone - handcut and covered in runic scripture.";
+	name = "Ancient Table"
 	},
-/obj/random/loot/randomarmor,
-/obj/random/loot/randomarmor,
-/obj/random/loot/randomarmor,
-/obj/random/loot/randomarmor,
-/obj/item/clothing/accessory/mfcloak,
-/obj/item/clothing/accessory/mfcloak,
-/obj/item/clothing/accessory/pcloak,
-/obj/item/clothing/accessory/pcloak,
-/obj/item/clothing/accessory/bishopcloak,
-/obj/item/clothing/accessory/bishopcloak,
-/turf/simulated/floor/darkwood/rotten,
+/obj/random/loot/tech2,
+/turf/simulated/floor/seolite,
 /area/cadiaoutpost/oa/farm)
 "gJq" = (
 /obj/effect/floor_decal/industrial/hatch/blue,
@@ -7624,6 +7704,18 @@
 	},
 /turf/simulated/floor/dirty/tough,
 /area/cadiaoutpost/oa/caves/undercity)
+"hfB" = (
+/obj/random/loot/randomitemcaves,
+/obj/random/loot/randomitemcaves,
+/obj/random/loot/randomitemcaves,
+/obj/random/loot/randomitemtown,
+/obj/random/loot/randomitemtown,
+/obj/random/loot/randomlasammo,
+/obj/random/loot/randomlasammo,
+/obj/random/loot/randomsupply,
+/obj/structure/closet/crate,
+/turf/simulated/floor/darkwood/rotten,
+/area/cadiaoutpost/oa/farm)
 "hgf" = (
 /obj/effect/floor_decal/newcorner/mine_walls{
 	icon_state = "04";
@@ -7819,12 +7911,37 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/cadiaoutpost/oa/medicae)
+"hqk" = (
+/obj/machinery/door/blast/id_door{
+	req_access = list(302);
+	name = "Secret Door";
+	id = "secretdoor";
+	maxhealth = 9000
+	},
+/turf/simulated/floor/factory_floor,
+/area/cadiaoutpost/oa/farm)
 "hqo" = (
 /turf/simulated/wall/wattle,
 /area/cadiaoutpost/new_hive/caves)
 "hqB" = (
 /turf/simulated/floor/stone,
 /area/cadiaoutpost/new_hive/caves)
+"hrI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/obj/structure/table/rack/dark,
+/obj/item/paper/crumpled/bloody{
+	name = "reseach instructions";
+	desc = "get ingots. turn into strange alloy. put in the protolathe. find archeotech or steal it from your rivals. become one with the machine god."
+	},
+/obj/item/card/id/silver{
+	access = list(221,222,223);
+	color = "grey";
+	job_access_type = null;
+	name = "L3 Access Card"
+	},
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "htc" = (
 /obj/effect/floor_decal/newcorner/stone/corner{
 	dir = 1
@@ -7920,6 +8037,15 @@
 	},
 /turf/simulated/floor/factory_floor,
 /area/cadiaoutpost/gma/inquisitoracolyte)
+"hxD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/obj/machinery/computer/drone_control{
+	dronefab = "Cadia";
+	req_access = list()
+	},
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "hxK" = (
 /obj/machinery/light/small/red{
 	dir = 1
@@ -8456,7 +8582,7 @@
 	name = "disgusting hood"
 	},
 /turf/simulated/floor/stone,
-/area/cadiaoutpost/new_hive/caves)
+/area/cadiaoutpost/oa/farm)
 "hSA" = (
 /obj/effect/floor_decal/newcorner/green/corner{
 	dir = 4
@@ -8800,6 +8926,10 @@
 	icon_state = "bulb1"
 	},
 /turf/simulated/floor/tiled,
+/area/cadiaoutpost/new_hive/caves)
+"ikr" = (
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/turf/simulated/floor/seolite,
 /area/cadiaoutpost/new_hive/caves)
 "ikv" = (
 /obj/structure/sign/chaos{
@@ -9646,6 +9776,18 @@
 	dir = 8
 	},
 /area/cadiaoutpost/oa/research/robotics)
+"iWJ" = (
+/obj/random/loot/randomarmor,
+/obj/random/loot/randomarmor,
+/obj/item/clothing/accessory/mfcloak,
+/obj/item/clothing/accessory/mfcloak,
+/obj/item/clothing/accessory/pcloak,
+/obj/item/clothing/accessory/pcloak,
+/obj/item/clothing/accessory/bishopcloak,
+/obj/item/clothing/accessory/bishopcloak,
+/obj/structure/closet/crate,
+/turf/simulated/floor/darkwood/rotten,
+/area/cadiaoutpost/oa/farm)
 "iWS" = (
 /obj/structure/table/rack/dark,
 /obj/item/ammo_box/shotgun/msslug{
@@ -9938,6 +10080,16 @@
 	icon_state = "white1"
 	},
 /area/cadiaoutpost/oa/service/inn)
+"jhy" = (
+/obj/effect/floor_decal/turf/bloodbar/off,
+/obj/structure/table/rack/dark,
+/obj/item/gun/energy/pulse/pulserifle{
+	charge_cost = 55;
+	desc = "The remains of an ancient salvage, close examination reveals the power pack is drained and there are even cracks within the crystal assembly.";
+	name = "Salvaged Pulse Rifle"
+	},
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "jiB" = (
 /obj/effect/floor_decal/newcorner/plating/quarter,
 /turf/simulated/floor/darkfloor{
@@ -10187,6 +10339,11 @@
 	},
 /turf/simulated/floor/darkwood,
 /area/cadiaoutpost/oa/hallway/centralhall)
+"jtL" = (
+/obj/structure/telearray/lowleft,
+/obj/effect/floor_decal/turf/bloodbar/off,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "jtN" = (
 /obj/effect/water/bottom,
 /obj/effect/water/top,
@@ -10856,14 +11013,10 @@
 	},
 /area/cadiaoutpost/oa/security/barracks)
 "jWN" = (
-/obj/machinery/door/blast/id_door{
-	req_access = list(302);
-	name = "Secret Door";
-	id = "secretdoor";
-	maxhealth = 9000
-	},
-/turf/simulated/floor/stone,
-/area/cadiaoutpost/oa/caves/dark)
+/obj/effect/floor_decal/turf/bloodbar/off,
+/obj/machinery/vending/phoronresearch,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "jXf" = (
 /obj/structure/table/graf/reinf_table,
 /turf/simulated/floor/darkwood/rotten,
@@ -10972,7 +11125,7 @@
 "kcg" = (
 /obj/structure/hivedecor/skulls,
 /turf/simulated/floor/stone,
-/area/cadiaoutpost/new_hive/caves)
+/area/cadiaoutpost/oa/farm)
 "kcz" = (
 /obj/item/reagent_containers/spray/cleaner/warfare,
 /obj/structure/table/graf/reinf_table{
@@ -12679,6 +12832,11 @@
 /obj/item/stack/thrones2/five,
 /turf/simulated/floor/darkwood,
 /area/cadiaoutpost/oa/service/chapel/chapeldorm)
+"lwp" = (
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/obj/item/pickaxe,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/new_hive/caves)
 "lwB" = (
 /obj/structure/table/rack,
 /obj/item/storage/box/ifak{
@@ -12932,6 +13090,17 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/security/barracks)
+"lHF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/shieldgen,
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
+"lHT" = (
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/new_hive/caves)
 "lIT" = (
 /obj/random/trash,
 /obj/effect/decal/cleanable/cobweb{
@@ -13896,6 +14065,15 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/research/robotics)
+"mEi" = (
+/obj/effect/floor_decal/turf/bloodbar/off,
+/obj/structure/table/rack/dark,
+/obj/item/grenade/spawnergrenade/manhacks{
+	name = "mysterious grenade"
+	},
+/obj/random/loot/tech2,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "mEk" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 4
@@ -13974,13 +14152,19 @@
 	},
 /area/cadiaoutpost/oa/villageinside/lab/muffled)
 "mHe" = (
-/obj/structure/closet/hive/iron_c{
-	anchored = 1
+/obj/effect/floor_decal/turf/bloodbar/off,
+/obj/item/card/id/silver{
+	access = list(221,222);
+	color = "grey";
+	job_access_type = null;
+	name = "L2 Access Card"
 	},
-/obj/random/loot/badweapon,
-/obj/random/loot/badweapon,
-/obj/random/loot/badweapon,
-/turf/simulated/floor/darkwood/rotten,
+/obj/item/clothing/suit/armor/seolarmor,
+/obj/item/clothing/head/helmet/soul,
+/obj/item/clothing/head/heretichood/alt2{
+	name = "mysterious hood"
+	},
+/turf/simulated/floor/seolite,
 /area/cadiaoutpost/oa/farm)
 "mHQ" = (
 /obj/structure/railing{
@@ -14007,6 +14191,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/darkwood,
 /area/cadiaoutpost/oa/magistratumpost)
+"mKW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/obj/machinery/r_n_d/protolathe,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "mLz" = (
 /obj/structure/table/graf/rusty_table,
 /obj/item/card/id/key/middle/jail{
@@ -14239,6 +14429,11 @@
 /obj/item/rnd/illegal3,
 /turf/simulated/floor/stone/ancient_stone_floor3,
 /area/cadiaoutpost/oa/caves/undercity)
+"mTW" = (
+/obj/structure/telearray/centreright,
+/obj/effect/floor_decal/turf/bloodbar/off,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "mTY" = (
 /obj/structure/table/graf/big_wood_table{
 	dir = 8
@@ -14273,6 +14468,16 @@
 /obj/effect/floor_decal/turf/plating,
 /turf/simulated/floor/tiled/dark,
 /area/cadiaoutpost/oa/service/inn)
+"mVs" = (
+/obj/effect/floor_decal/turf/bloodbar/off,
+/obj/structure/table/rack/dark,
+/obj/item/gun/energy/pulse/ionrifle{
+	charge_cost = 50;
+	desc = "The remains of an ancient salvage, close examination reveals the power pack is drained and there are even cracks within the crystal assembly.";
+	name = "Salvaged ION rifle"
+	},
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "mVL" = (
 /obj/structure/hivedecor/bookcase{
 	pixel_x = -11
@@ -14320,6 +14525,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/cadiaoutpost/oa/magistratumpost)
+"mXA" = (
+/obj/effect/floor_decal/turf/bloodbar/off,
+/obj/item/card/id/silver{
+	access = list(221,222);
+	color = "grey";
+	job_access_type = null;
+	name = "L2 Access Card"
+	},
+/obj/item/clothing/suit/armor/seolarmor,
+/obj/item/clothing/head/heretichood/alt2{
+	name = "mysterious hood"
+	},
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "mXC" = (
 /obj/effect/floor_decal/newcorner/red,
 /obj/effect/floor_decal/newcorner/plating{
@@ -14347,6 +14566,13 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/research/robotics)
+"mYQ" = (
+/obj/item/pyre/self_lit{
+	invisibility = 100;
+	name = "Invisible Light"
+	},
+/turf/simulated/wall/castle,
+/area/cadiaoutpost/oa/farm)
 "mYZ" = (
 /obj/structure/table/rack,
 /obj/item/grenade/frag/high_yield/krak,
@@ -14908,6 +15134,11 @@
 	dir = 1
 	},
 /area/cadiaoutpost/oa/caves/dark)
+"nyx" = (
+/obj/effect/floor_decal/turf/bloodbar/off,
+/obj/structure/cult/clockworkobelisk,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "nyz" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -15203,6 +15434,17 @@
 /obj/structure/bed/chair/cage,
 /turf/simulated/floor/stone,
 /area/cadiaoutpost/new_hive/caves)
+"nLK" = (
+/obj/effect/floor_decal/turf/bloodbar/off,
+/obj/machinery/button/remote/blast_door/id_scan{
+	name = "pristine ID lock";
+	id = "secretdoor";
+	req_one_access = list(247)
+	},
+/obj/structure/table/graf/rusty_table,
+/obj/effect/floor_decal/turf/bloodbar/off,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "nMc" = (
 /obj/effect/floor_decal/newcorner/stone,
 /obj/effect/floor_decal/newcorner/stone{
@@ -15225,8 +15467,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/cadiaoutpost/new_hive/caves)
 "nNn" = (
-/turf/simulated/open,
-/area/cadiaoutpost/oa/caves/dark)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/obj/machinery/computer/rdconsole/core{
+	req_access = list()
+	},
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "nNy" = (
 /obj/structure/warfare/barricade/sandbag,
 /turf/simulated/floor/surface_floor,
@@ -16021,6 +16268,12 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/shuttle/inquisition)
+"ouy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/obj/machinery/vending/robotics,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "ouL" = (
 /obj/structure/closet/crate{
 	anchored = 1
@@ -16692,6 +16945,13 @@
 	dir = 4
 	},
 /area/cadiaoutpost/oa/caves/dark)
+"pbO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/obj/item/rnd/eng3,
+/obj/structure/table/rack/dark,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "pbX" = (
 /obj/effect/floor_decal/turf/metal/nine,
 /turf/simulated/floor/tiled{
@@ -16770,7 +17030,7 @@
 /obj/item/device/boombox,
 /obj/item/device/cassette/clockwork1,
 /turf/simulated/floor/stone,
-/area/cadiaoutpost/new_hive/caves)
+/area/cadiaoutpost/oa/farm)
 "pfn" = (
 /obj/effect/floor_decal/newcorner/reinforced{
 	dir = 1
@@ -16877,18 +17137,10 @@
 /turf/simulated/floor/darkwood/rotten,
 /area/cadiaoutpost/oa/farm)
 "pjP" = (
-/obj/structure/closet/hive/darkwood{
-	anchored = 1
-	},
-/obj/random/loot/randomitemcaves,
-/obj/random/loot/randomitemcaves,
-/obj/random/loot/randomitemcaves,
-/obj/random/loot/randomitemtown,
-/obj/random/loot/randomitemtown,
-/obj/random/loot/randomlasammo,
-/obj/random/loot/randomlasammo,
-/obj/random/loot/randomsupply,
-/turf/simulated/floor/darkwood/rotten,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/obj/machinery/mecha_part_fabricator,
+/turf/simulated/floor/seolite,
 /area/cadiaoutpost/oa/farm)
 "pkJ" = (
 /obj/effect/floor_decal/newcorner/plating{
@@ -17258,6 +17510,16 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/new_hive/caves)
+"pFC" = (
+/obj/effect/floor_decal/turf/bloodbar/off,
+/obj/machinery/button/remote/blast_door/id_scan{
+	name = "pristine ID lock";
+	id = "secretdoor2";
+	req_one_access = list(247)
+	},
+/obj/structure/table/graf/rusty_table,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "pFP" = (
 /obj/effect/floor_decal/newcorner/plating{
 	dir = 8;
@@ -17281,6 +17543,16 @@
 /obj/item/reagent_containers/food/drinks/glass2/chaos/tzeench,
 /obj/structure/table/graf/big_wood_table,
 /turf/simulated/floor/stone/old4,
+/area/cadiaoutpost/oa/farm)
+"pGG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/obj/machinery/cell_charger,
+/obj/structure/table/steel,
+/obj/random/tech_supply,
+/obj/random/powercell,
+/obj/random/powercell,
+/turf/simulated/floor/seolite,
 /area/cadiaoutpost/oa/farm)
 "pGT" = (
 /obj/effect/gibspawner,
@@ -17916,19 +18188,7 @@
 	},
 /area/cadiaoutpost/oa/security/barracks)
 "qjY" = (
-/obj/structure/closet/hive/narnia{
-	name = "Narnia closet"
-	},
-/obj/effect/decal/cleanable/cobweb{
-	dir = 8
-	},
-/obj/random/loot/randomammo1,
-/obj/random/loot/randomammo1,
-/obj/random/loot/randomammo1,
-/obj/random/loot/randomammo1,
-/obj/random/loot/randomammo1,
-/obj/random/loot/randomammo1,
-/obj/random/loot/randomammo1,
+/obj/effect/floor_decal/turf/bloodbar/off,
 /turf/simulated/floor/darkwood/rotten,
 /area/cadiaoutpost/oa/farm)
 "qkr" = (
@@ -18075,11 +18335,17 @@
 /area/cadiaoutpost/new_hive/caves)
 "qox" = (
 /obj/machinery/door/airlock/imperiumdoor{
-	req_access = list(331);
-	name = "Heir Room"
+	name = "Heir Room";
+	req_one_access = list(331)
 	},
 /turf/simulated/floor/factory_floor,
 /area/cadiaoutpost/oa/hallway/centralhall)
+"qpK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/obj/machinery/integrated_circuit_printer,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "qqh" = (
 /obj/random/trap,
 /turf/simulated/floor/tiled/dark{
@@ -18298,7 +18564,7 @@
 "qAS" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/stone,
-/area/cadiaoutpost/new_hive/caves)
+/area/cadiaoutpost/oa/farm)
 "qAZ" = (
 /obj/structure/sign/chaos{
 	pixel_x = 32
@@ -18313,6 +18579,12 @@
 	},
 /turf/simulated/floor/surface_floor,
 /area/cadiaoutpost/new_hive/caves)
+"qBY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/crystal_static/pink,
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "qCj" = (
 /obj/machinery/door/airlock/highsecurity/imperiumdoor{
 	name = "Imperialis Doorway - Monasterium";
@@ -18365,6 +18637,17 @@
 	name = "necron tome"
 	},
 /turf/simulated/floor/stone/old4,
+/area/cadiaoutpost/oa/farm)
+"qEW" = (
+/obj/effect/floor_decal/turf/bloodbar/off,
+/obj/structure/table/rack/dark,
+/obj/item/cell/pulserifle{
+	name = "xenos battery"
+	},
+/obj/item/cell/pulserifle{
+	name = "xenos battery"
+	},
+/turf/simulated/floor/seolite,
 /area/cadiaoutpost/oa/farm)
 "qEY" = (
 /turf/simulated/floor/tiled{
@@ -19056,8 +19339,9 @@
 /turf/simulated/floor/ceramic,
 /area/cadiaoutpost/oa/service/chapel/chapeldorm)
 "reI" = (
+/obj/random/loot/guardgear,
+/obj/random/loot/guardgear,
 /obj/structure/closet/crate,
-/obj/random/loot/tech1,
 /turf/simulated/floor/darkwood/rotten,
 /area/cadiaoutpost/oa/farm)
 "reZ" = (
@@ -19259,7 +19543,7 @@
 	sales_price = 0
 	},
 /turf/simulated/floor/stone,
-/area/cadiaoutpost/new_hive/caves)
+/area/cadiaoutpost/oa/farm)
 "roR" = (
 /obj/structure/closet/crate/secure/weapon,
 /obj/machinery/light/darkblue{
@@ -19878,12 +20162,23 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/medicae)
+"rQE" = (
+/obj/effect/floor_decal/turf/bloodbar/off,
+/obj/machinery/power/port_gen/pacman/super/potato,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "rQJ" = (
 /obj/structure/hivedecor/statue8,
 /turf/simulated/floor/tiled{
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/magistratumpost)
+"rQO" = (
+/obj/random/loot/meleespawner,
+/obj/random/loot/meleespawner,
+/obj/structure/closet/crate,
+/turf/simulated/floor/darkwood/rotten,
+/area/cadiaoutpost/oa/farm)
 "rQR" = (
 /obj/structure/bed/chair/wood/simple,
 /obj/effect/floor_decal/newcorner/plating{
@@ -19980,6 +20275,13 @@
 	dir = 6
 	},
 /area/cadiaoutpost/oa/service/chapel/chapeldorm)
+"rXt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/obj/item/rnd/illegal10,
+/obj/structure/table/rack/dark,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "rXI" = (
 /obj/structure/closet/hive/metal{
 	anchored = 1
@@ -20278,6 +20580,12 @@
 "slE" = (
 /turf/unsimulated/mineral,
 /area/cadiaoutpost/new_hive/caves)
+"smt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/crystal_static,
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "snd" = (
 /obj/item/reagent_containers/food/drinks/glass2/pint{
 	pixel_y = 6;
@@ -21004,6 +21312,11 @@
 /obj/effect/floor_decal/industrial/outline/orange,
 /turf/simulated/floor/ceramic/blackstone,
 /area/cadiaoutpost/oa/magistratumpost)
+"sSa" = (
+/obj/structure/telearray/lowright,
+/obj/effect/floor_decal/turf/bloodbar/off,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "sSo" = (
 /obj/structure/torchwall{
 	dir = 4;
@@ -22111,6 +22424,15 @@
 	icon_state = "dark1"
 	},
 /area/cadiaoutpost/oa/security/barracks)
+"tPo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/obj/structure/table/rack/dark,
+/obj/item/stack/material/steel/fifty,
+/obj/item/stack/material/phoron/ten,
+/obj/item/stack/material/diamond/ten,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "tPv" = (
 /turf/simulated/floor/fancyfloor/carpet{
 	dir = 10
@@ -22361,6 +22683,13 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/security/barracks)
+"tZf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/obj/item/rnd/biospace3,
+/obj/structure/table/rack/dark,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "tZx" = (
 /obj/structure/closet/crate{
 	name = "Governor's Funds"
@@ -22547,6 +22876,11 @@
 	},
 /turf/simulated/floor/greengrid,
 /area/cadiaoutpost/oa/research/robotics)
+"ufB" = (
+/obj/structure/telearray/upperleft,
+/obj/effect/floor_decal/turf/bloodbar/off,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "ufL" = (
 /obj/machinery/door/airlock/glass_medical{
 	color = null;
@@ -23495,6 +23829,13 @@
 	},
 /turf/simulated/floor/darkwood/rotten,
 /area/cadiaoutpost/oa/hallway/centralhall)
+"viR" = (
+/obj/machinery/artifact_harvester,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/turf/clockwork,
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "vkl" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -23502,6 +23843,12 @@
 	},
 /turf/simulated/floor/ceramic/old,
 /area/cadiaoutpost/oa/hallway/centralhall)
+"vkM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/implantchair,
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "vlb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/tank/oxygen,
@@ -24253,14 +24600,9 @@
 /turf/simulated/floor/dirty/tough,
 /area/cadiaoutpost/oa/caves/undercity)
 "vTV" = (
-/obj/structure/closet/hive/iron_c{
-	anchored = 1
-	},
-/obj/random/loot/meleespawner,
-/obj/random/loot/meleespawner,
-/obj/random/loot/meleespawner,
-/obj/random/loot/meleespawner,
-/turf/simulated/floor/darkwood/rotten,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/turf/simulated/floor/seolite,
 /area/cadiaoutpost/oa/farm)
 "vUf" = (
 /obj/structure/railing,
@@ -24738,7 +25080,7 @@
 /obj/item/reagent_containers/food/snacks/poo,
 /obj/effect/decal/cleanable/blood/gibs/vomit,
 /turf/simulated/floor/stone,
-/area/cadiaoutpost/new_hive/caves)
+/area/cadiaoutpost/oa/farm)
 "wpI" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -25248,6 +25590,17 @@
 /obj/structure/sign/aquilalong,
 /turf/simulated/floor/stone/old4,
 /area/cadiaoutpost/oa/service/chapel/chapeldorm)
+"wQm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/obj/structure/table/steel,
+/obj/machinery/button/remote/blast_door/id_scan{
+	name = "pristine ID lock";
+	id = "secretdoor2";
+	req_one_access = list(247)
+	},
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "wQT" = (
 /obj/effect/floor_decal/newcorner/plating,
 /turf/simulated/floor/tiled,
@@ -25396,16 +25749,21 @@
 	},
 /area/cadiaoutpost/oa/service/chapel/chapelsurgery)
 "wWe" = (
-/obj/machinery/button/remote/blast_door/id_scan{
-	name = "pristine ID lock";
-	id = "secretdoor";
-	req_one_access = list(221,222)
+/obj/item/reagent_containers/hypospray/autoinjector/tau{
+	desc = "A disgusting red liquid sloshes around inside the tube.";
+	name = "Mysterious Injector"
 	},
-/obj/structure/table/graf/rusty_table,
+/obj/effect/floor_decal/turf/carpetn00,
+/obj/item/newore/gems/ruby/cut,
+/obj/item/device/holyoils,
+/obj/item/device/autochisel,
+/obj/item/device/hammer,
+/obj/effect/floor_decal/turf/bloodbar/off,
+/obj/item/rnd/combat10,
 /turf/simulated/floor/tiled/dark{
-	icon_state = "steel"
+	color = "grey"
 	},
-/area/cadiaoutpost/oa/caves/dark)
+/area/cadiaoutpost/oa/farm)
 "wWM" = (
 /obj/machinery/chemical_dispenser/full,
 /obj/effect/floor_decal/newcorner/blue/solid,
@@ -25806,6 +26164,12 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/new_hive/caves)
+"xlm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/obj/machinery/r_n_d/circuit_imprinter,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "xmb" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -26283,6 +26647,15 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/research/robotics)
+"xFB" = (
+/obj/machinery/door/airlock/arbiter{
+	color = "grey";
+	maxhealth = 3000;
+	name = "Groomlake Facility";
+	req_access = list()
+	},
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "xGZ" = (
 /obj/structure/shipdecor{
 	icon_state = "off";
@@ -26342,6 +26715,13 @@
 	dir = 1
 	},
 /area/cadiaoutpost/oa/villageinside/lab/muffled)
+"xJX" = (
+/obj/effect/floor_decal/turf/bloodbar/off,
+/obj/structure/reagent_dispensers/acid{
+	pixel_x = -30
+	},
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "xKw" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -26402,6 +26782,14 @@
 	icon_state = "r_window"
 	},
 /area/cadiaoutpost/oa/villageinside/lab/muffled)
+"xMz" = (
+/obj/machinery/artifact_scanpad,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/turf/lfloorscorched1,
+/obj/item/grenade/spawnergrenade/manhacks,
+/obj/item/grenade/spawnergrenade/manhacks,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "xNq" = (
 /obj/structure/sign/plate/stoneshrine{
 	pixel_x = 32
@@ -26654,7 +27042,7 @@
 	armor = list("melee"=38,"bullet"=38,"laser"=38,"energy"=20,"bomb"=30,"bio"=10,"rad"=20)
 	},
 /turf/simulated/floor/stone,
-/area/cadiaoutpost/new_hive/caves)
+/area/cadiaoutpost/oa/farm)
 "xZe" = (
 /obj/effect/floor_decal/industrial/warning_red{
 	dir = 9
@@ -26808,7 +27196,7 @@
 /obj/item/reagent_containers/food/drinks/glass2/chaos,
 /obj/structure/table/graf/pagan,
 /turf/simulated/floor/stone,
-/area/cadiaoutpost/new_hive/caves)
+/area/cadiaoutpost/oa/farm)
 "yeF" = (
 /obj/random/glasses,
 /obj/random/junk,
@@ -26876,6 +27264,11 @@
 	icon_state = "steel"
 	},
 /area/cadiaoutpost/oa/security/barracks)
+"yke" = (
+/obj/effect/floor_decal/turf/bloodbar/off,
+/obj/structure/forge,
+/turf/simulated/floor/seolite,
+/area/cadiaoutpost/oa/farm)
 "ykg" = (
 /obj/structure/toilet{
 	pixel_y = 14
@@ -57319,11 +57712,11 @@ tOB
 tOB
 tOB
 tOB
-dnS
-dnS
-dnS
-dnS
-dnS
+tOB
+tOB
+tOB
+tOB
+tOB
 tOB
 tOB
 wcj
@@ -57571,11 +57964,11 @@ tOB
 tOB
 tOB
 tOB
-dnS
-nNn
-nNn
-cUF
-jWN
+tOB
+tOB
+tOB
+tOB
+tOB
 gpl
 tOB
 wcj
@@ -57823,11 +58216,11 @@ tOB
 tOB
 tOB
 tOB
-dnS
-dnS
-dnS
-dnS
-dnS
+tOB
+tOB
+tOB
+tOB
+tOB
 dID
 gpl
 wcj
@@ -58078,8 +58471,8 @@ tOB
 tOB
 tOB
 tOB
-wWe
-gpl
+tOB
+tOB
 gpl
 gpl
 wcj
@@ -62743,7 +63136,7 @@ vAj
 mcb
 wUD
 eKm
-oYr
+gBj
 vAj
 hIg
 xHL
@@ -74792,7 +75185,7 @@ dxB
 dxB
 dxB
 dxB
-dxB
+nma
 dxB
 dxB
 uMF
@@ -82828,7 +83221,7 @@ tpQ
 tpQ
 tpQ
 tpQ
-tpQ
+tOB
 jqp
 jqp
 jqp
@@ -83332,7 +83725,7 @@ tOB
 tOB
 tOB
 tOB
-tOB
+lwp
 tOB
 tOB
 tOB
@@ -83584,7 +83977,7 @@ tOB
 tOB
 tOB
 tOB
-tOB
+ikr
 tOB
 tOB
 tOB
@@ -83835,8 +84228,8 @@ tOB
 tOB
 tOB
 tOB
-tOB
-tOB
+ikr
+ikr
 tOB
 tOB
 tOB
@@ -84087,7 +84480,7 @@ tOB
 tOB
 tOB
 tOB
-tOB
+ikr
 tOB
 tOB
 tOB
@@ -84337,9 +84730,9 @@ tOB
 tOB
 tOB
 tOB
-tOB
-tOB
-tOB
+ikr
+ikr
+ikr
 tOB
 tOB
 tOB
@@ -84588,8 +84981,8 @@ tOB
 tOB
 tOB
 tOB
-tOB
-tOB
+ikr
+lHT
 tOB
 tOB
 tOB
@@ -84839,9 +85232,9 @@ tOB
 tOB
 tOB
 tOB
-tOB
-tOB
-tOB
+wQm
+ikr
+ikr
 tOB
 tOB
 tOB
@@ -85089,16 +85482,16 @@ tOB
 tOB
 tOB
 tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tpQ
-tpQ
-tOB
+uru
+uru
+uru
+mYQ
+bDt
+uru
+uru
+uru
+uru
+uru
 tOB
 tOB
 tOB
@@ -85341,16 +85734,16 @@ tOB
 tOB
 tOB
 tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tpQ
-tpQ
-tOB
-tOB
+uru
+hrI
+tZf
+pbO
+vTV
+nNn
+viR
+wQm
+uru
+uru
 tOB
 tOB
 tOB
@@ -85593,16 +85986,16 @@ tOB
 tOB
 tOB
 tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tpQ
-tOB
-tOB
-tOB
+uru
+cUF
+vTV
+vTV
+vTV
+vTV
+vTV
+vTV
+uru
+uru
 tOB
 tOB
 tOB
@@ -85845,16 +86238,16 @@ tOB
 tOB
 tOB
 tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tpQ
-tpQ
-tOB
-tOB
-tOB
+uru
+xMz
+vTV
+esc
+mKW
+qpK
+xlm
+vTV
+uru
+uru
 tOB
 tOB
 tOB
@@ -86097,16 +86490,16 @@ tOB
 tOB
 tOB
 tOB
-tOB
-tOB
-tOB
-tpQ
-tpQ
-tpQ
-tpQ
-tOB
-slE
-slE
+mYQ
+vkM
+vTV
+vTV
+vTV
+vTV
+vTV
+vTV
+uru
+uru
 slE
 slE
 slE
@@ -86349,15 +86742,15 @@ tOB
 tOB
 tOB
 tOB
-tOB
-tpQ
-tpQ
-tpQ
-tOB
-tOB
-tOB
-tOB
-slE
+uru
+qBY
+vTV
+pjP
+gjz
+tPo
+rXt
+vTV
+uru
 uru
 uru
 uru
@@ -86601,19 +86994,19 @@ tOB
 tOB
 tOB
 tpQ
-tpQ
-tpQ
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-slE
+uru
+vTV
+vTV
+vTV
+vTV
+vTV
+vTV
+vTV
+uru
 uru
 reI
-reI
-reI
+rQO
+hfB
 uru
 hiv
 aQW
@@ -86853,19 +87246,19 @@ tOB
 tpQ
 tpQ
 tpQ
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-slE
 uru
-xes
-xes
-xes
+smt
+hxD
+ouy
+vTV
+pGG
+lHF
+lHF
+uru
+uru
+iWJ
+gHd
+aoI
 uru
 aQW
 aQW
@@ -87105,15 +87498,15 @@ tpQ
 tpQ
 tOB
 tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-slE
+uru
+uru
+uru
+uru
+xFB
+uru
+mYQ
+uru
+uru
 uru
 hhl
 xes
@@ -87357,15 +87750,15 @@ tpQ
 tOB
 tOB
 tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-slE
+uMF
+uru
+uru
+xJX
+dnS
+dnS
+fdf
+gIB
+uru
 uru
 hSs
 obC
@@ -87609,15 +88002,15 @@ tOB
 tOB
 tOB
 tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-slE
+uMF
+uru
+dsw
+dnS
+dnS
+mHe
+dnS
+dnS
+yke
 uru
 uru
 uru
@@ -87861,19 +88254,19 @@ tOB
 tOB
 tOB
 tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-slE
+uMF
 uru
-dLz
-vTV
-mHe
+mEi
+dnS
+dnS
+dnS
+dnS
+dnS
+dnS
+uru
+qjY
+qjY
+qjY
 uru
 xes
 xes
@@ -88113,19 +88506,19 @@ tOB
 tOB
 tOB
 tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-slE
+uMF
 uru
-xes
-xes
-xes
+amR
+dnS
+dnS
+ufB
+dnS
+dnS
+dnS
+hqk
+qjY
+qjY
+qjY
 uru
 hhl
 xes
@@ -88365,19 +88758,19 @@ tOB
 tOB
 tOB
 tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-slE
+uMF
 uru
-hhl
-xes
-xes
+jWN
+dnS
+nyx
+dLz
+jtL
+dnS
+pFC
+uru
+nLK
+qjY
+qjY
 drU
 xes
 xes
@@ -88394,10 +88787,10 @@ qkv
 uru
 uru
 uru
-kGm
-kGm
-kGm
-tOB
+uru
+uru
+uru
+nma
 tOB
 tOB
 tOB
@@ -88617,19 +89010,19 @@ tOB
 tOB
 tOB
 tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-slE
+uMF
+uru
+mVs
+dnS
+dnS
+mTW
+sSa
+mXA
+rQE
 uru
 qjY
-gIB
-pjP
+qjY
+qjY
 uru
 xes
 xes
@@ -88648,8 +89041,8 @@ qAS
 gtW
 xYM
 pfa
-kGm
-kGm
+uru
+uru
 tOB
 tOB
 tOB
@@ -88869,15 +89262,15 @@ tOB
 tOB
 tOB
 tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-slE
+uMF
+uru
+jhy
+dnS
+dnS
+wWe
+dnS
+dnS
+uru
 uru
 uru
 uru
@@ -88899,9 +89292,9 @@ fEN
 hSx
 kcg
 yer
-hqB
+qrf
 wpz
-kGm
+uru
 tOB
 tOB
 tOB
@@ -89121,16 +89514,16 @@ tOB
 tOB
 tOB
 tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-slE
-tOB
+uMF
+uru
+qEW
+dnS
+dnS
+dnS
+dnS
+uru
+uru
+uru
 tOB
 tOB
 tOB
@@ -89151,9 +89544,9 @@ uru
 efD
 ezq
 roL
-hqB
-kGm
-kGm
+qrf
+uru
+uru
 tOB
 tOB
 tOB
@@ -89373,16 +89766,16 @@ tOB
 tOB
 tOB
 tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-tOB
-slE
-tOB
+nma
+uru
+uru
+uru
+uru
+uru
+uru
+uru
+uMF
+nma
 tOB
 tOB
 tOB
@@ -89400,12 +89793,12 @@ tOB
 tOB
 tOB
 kGm
-kGm
-kGm
-kGm
-kGm
-kGm
-tOB
+uru
+uru
+uru
+uru
+uru
+nma
 tOB
 tOB
 tOB

--- a/maps/delta/warhammer-3.dmm
+++ b/maps/delta/warhammer-3.dmm
@@ -4262,6 +4262,17 @@
 	},
 /turf/simulated/floor/ceramic,
 /area/cadiaoutpost/oa/service/chapel)
+"ehe" = (
+/obj/machinery/door/unpowered/inn/berryfarm{
+	req_access = list();
+	name = "the farmhouse";
+	req_one_access = list(230,211)
+	},
+/obj/structure/banner/blue{
+	pixel_y = -32
+	},
+/turf/simulated/floor/factory_floor,
+/area/cadiaoutpost/oa/farm)
 "ehM" = (
 /obj/structure/table/woodentable{
 	color = "#36261B"
@@ -4331,8 +4342,13 @@
 /turf/simulated/floor/darkwood,
 /area/cadiaoutpost/new_hive/hive_city)
 "elK" = (
-/obj/structure/sign/medical1,
-/turf/simulated/wall/concrete,
+/obj/structure/grille/iron_fence,
+/obj/structure/banner/blue{
+	pixel_y = -32
+	},
+/turf/simulated/floor/factory_floor{
+	dir = 8
+	},
 /area/cadiaoutpost/oa/farm)
 "emg" = (
 /obj/effect/floor_decal/newcorner/shaft/quarter,
@@ -5141,6 +5157,15 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/new_hive/hive_city)
+"fcZ" = (
+/obj/effect/floor_decal/newcorner/trench_flooring{
+	dir = 5
+	},
+/obj/structure/banner/blue{
+	pixel_y = -32
+	},
+/turf/simulated/floor/dirty,
+/area/cadiaoutpost/oa/groxpen)
 "fde" = (
 /obj/random/firstaid,
 /obj/random/firstaid,
@@ -7226,6 +7251,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/cadiaoutpost/oa/engineering)
+"gSY" = (
+/obj/structure/banner/blue{
+	pixel_y = -32
+	},
+/turf/simulated/wall/concrete/strong,
+/area/cadiaoutpost/new_hive/hive_city)
 "gTn" = (
 /obj/structure/sign/imperial{
 	pixel_y = -30
@@ -7835,6 +7866,12 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/oa/gatehouse)
+"hvK" = (
+/obj/structure/banner/blue{
+	pixel_y = -32
+	},
+/turf/simulated/floor/stone/crafted_floor,
+/area/cadiaoutpost/oa/farm)
 "hvZ" = (
 /obj/effect/floor_decal/newcorner/grass{
 	icon_state = "grass2"
@@ -10573,8 +10610,10 @@
 /turf/simulated/floor/stone,
 /area/cadiaoutpost/oa/bridge/hallway)
 "jOH" = (
-/obj/structure/sign/imperial,
-/turf/simulated/wall/concrete/strong,
+/obj/structure/banner/blue{
+	pixel_y = -32
+	},
+/turf/simulated/floor/dirty,
 /area/cadiaoutpost/new_hive/hive_city)
 "jOK" = (
 /obj/machinery/autolathe{
@@ -16055,6 +16094,16 @@
 	icon_state = "r_window"
 	},
 /area/cadiaoutpost/new_hive/hive_city)
+"oXl" = (
+/obj/machinery/door/unpowered/inn/berryfarm{
+	req_access = list();
+	name = "the farmhouse";
+	req_one_access = list(230,211)
+	},
+/turf/simulated/floor/tiled{
+	color = "grey"
+	},
+/area/cadiaoutpost/oa/groxpen)
 "oYj" = (
 /obj/structure/railing,
 /obj/effect/floor_decal/newcorner/plating,
@@ -17177,6 +17226,9 @@
 /obj/machinery/door/unpowered/inn{
 	name = "Equipment Manufactorium"
 	},
+/obj/structure/banner/blue{
+	pixel_y = -32
+	},
 /turf/simulated/floor/factory_floor,
 /area/cadiaoutpost/new_hive/hive_city)
 "qep" = (
@@ -17230,6 +17282,15 @@
 "qiL" = (
 /turf/unsimulated/mineral,
 /area/cadiaoutpost/new_hive/hive_city)
+"qjo" = (
+/obj/effect/floor_decal/newcorner/trench_flooring{
+	dir = 10
+	},
+/obj/structure/banner/blue{
+	pixel_y = -32
+	},
+/turf/simulated/floor/dirty,
+/area/cadiaoutpost/oa/groxpen)
 "qlr" = (
 /obj/structure/sign/poster/poster3{
 	pixel_x = 32
@@ -19580,9 +19641,6 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/table/rack,
 /obj/item/clothing/suit/armor/armoredtrench,
-/obj/item/clothing/suit/armor/armoredtrench,
-/obj/item/clothing/suit/armor/breastplate,
-/obj/item/clothing/suit/armor/breastplate,
 /turf/simulated/floor/tiled{
 	color = "grey";
 	icon_state = "dark1"
@@ -21819,6 +21877,9 @@
 /obj/machinery/light/stolb{
 	on = 1
 	},
+/obj/structure/banner/blue{
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled,
 /area/cadiaoutpost/oa/farm)
 "uzj" = (
@@ -22905,6 +22966,13 @@
 	color = "grey"
 	},
 /area/cadiaoutpost/new_hive/hive_city)
+"vth" = (
+/obj/effect/floor_decal/turf/plating,
+/obj/mecha/combat/dreadnought,
+/turf/simulated/floor/tiled/dark{
+	color = "grey"
+	},
+/area/cadiaoutpost/oa/engineering)
 "vtz" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/simulated/floor/darkwood,
@@ -23194,7 +23262,6 @@
 /turf/simulated/floor/exoplanet/grass,
 /area/cadiaoutpost/oa/bridge/hallway)
 "vGC" = (
-/obj/structure/sign/medical1,
 /obj/item/pyre/self_lit{
 	invisibility = 100;
 	name = "Invisible Light"
@@ -23883,6 +23950,9 @@
 /obj/machinery/door/unpowered/inn{
 	name = "Equipment Manufactorium"
 	},
+/obj/structure/banner/blue{
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled/dark{
 	color = "grey"
 	},
@@ -23991,6 +24061,12 @@
 	},
 /turf/simulated/floor/dirty,
 /area/cadiaoutpost/new_hive/hive_city)
+"wxB" = (
+/obj/structure/banner/blue{
+	pixel_y = -32
+	},
+/turf/simulated/wall/concrete,
+/area/cadiaoutpost/oa/farm)
 "wyw" = (
 /obj/item/device/flashlight/flare,
 /turf/simulated/floor/dirty,
@@ -63984,7 +64060,7 @@ uFx
 dEh
 jxa
 sEV
-hEv
+vth
 tli
 jpk
 uNf
@@ -70201,7 +70277,7 @@ eTh
 iFU
 nSI
 nSI
-oli
+gSY
 oli
 qen
 oli
@@ -71733,7 +71809,7 @@ deG
 thv
 fPC
 deG
-cDu
+oXl
 emi
 emi
 deG
@@ -71743,7 +71819,7 @@ emi
 deG
 emi
 emi
-cDu
+oXl
 deG
 qTM
 aLk
@@ -71995,7 +72071,7 @@ eBr
 xPF
 tUX
 aDA
-eBr
+fcZ
 deG
 aLk
 bVV
@@ -72751,7 +72827,7 @@ aDA
 foE
 tSi
 eBr
-tUX
+qjo
 deG
 aLk
 bVV
@@ -73227,8 +73303,8 @@ eTh
 eTh
 oli
 oli
+gSY
 oli
-jOH
 wpc
 oli
 oli
@@ -73769,9 +73845,9 @@ aLk
 aLk
 aLk
 mQD
+wxB
 lOQ
-lOQ
-gbl
+ehe
 lOQ
 lOQ
 lOQ
@@ -74494,7 +74570,7 @@ ivO
 eTh
 eTh
 eTh
-eTh
+jOH
 vGC
 dVt
 dVt
@@ -74768,7 +74844,7 @@ mQf
 mQf
 dVt
 uzb
-elK
+lOQ
 aLk
 aLk
 aLk
@@ -75250,7 +75326,7 @@ ivO
 ivO
 eTh
 eTh
-eTh
+jOH
 fba
 dVt
 bVV
@@ -76280,7 +76356,7 @@ dVt
 dVt
 dVt
 uzb
-elK
+lOQ
 aLk
 aLk
 aLk
@@ -76774,11 +76850,11 @@ rrE
 rrE
 rrE
 rrE
-rrE
+elK
 lOQ
 bVV
 bVV
-bVV
+hvK
 lOQ
 rrE
 rrE

--- a/maps/delta/warhammer-4.dmm
+++ b/maps/delta/warhammer-4.dmm
@@ -3140,7 +3140,6 @@
 /obj/item/clothing/suit/armor/templar,
 /obj/item/gun/energy/pulse_rifle/pistol,
 /obj/item/clothing/under/syndicate/tacticool,
-/obj/random/drinkbottle,
 /turf/simulated/floor/wood,
 /area/cadiaoutpost/oa/supply/offices/roguetrader)
 "qj" = (
@@ -4971,6 +4970,17 @@
 	},
 /turf/simulated/floor/fancyfloor/coralg,
 /area/cadiaoutpost/oa/hallway/northern)
+"Ab" = (
+/obj/effect/floor_decal/turf/brick/two,
+/obj/item/card/id/key/grand/noble,
+/obj/structure/table/woodentable{
+	color = "#36261B"
+	},
+/obj/item/clothing/accessory/holster/armpit,
+/obj/item/device/radio/headset/headset_cargo,
+/obj/random/drinkbottle,
+/turf/simulated/floor/wood,
+/area/cadiaoutpost/oa/supply/offices/roguetrader)
 "Ac" = (
 /obj/structure/curtain/black,
 /turf/simulated/floor/factory_floor,
@@ -66870,7 +66880,7 @@ uG
 qv
 wU
 zA
-lm
+Ab
 Sm
 gx
 qh


### PR DESCRIPTION
Added the Witch Hunter sub-fate to the Mercenary Pilgrim Fate. With unique witch hunter armor.

Updated a number of melee weapons to now provide a basic ranged defense -- with the greatest defenses being offered from the Daemonhammer and the Powersword, as it can often be underwhelming to wield incredible daemon slaying weapons that genuinely make no difference in your protection. Hopefully people feel more encouraged to do melee knowing that choosing a big ass sword means you are slightly more protected then if you were wielding a gun. The canon idea is -- someone using a sword will be moving faster then if they were using a gun. Pulling a trigger accurately requires you stay still. Swinging a sword is the opposite.

Updated the mech missile rack to only have 2 missiles per reload instead of 8.

Re-did the Honour Guard fate to be aligned with either the Ecclesiarchy OR House Sondar instead of Governor(They get the Kasrkin + Guard + Commissar anyway). They also get a different armor sprite to better compliment their helmet and slightly brighter coloring. 

Mapping Updates;

Archeotechlab is now attached to House Sondar.

Many minor edits to map loot and the general aesthetics of House Sondar/Slums.

Gave the Mechanicus a Shield Generator and a Dreadnought.

Fixed the issue with the Grox Pen being unlocked.