### PR TITLE
Guns, Holsters, Backpacks and Boomies

### DIFF
--- a/code/game/jobs/job/adeptus_astartes.dm
+++ b/code/game/jobs/job/adeptus_astartes.dm
@@ -142,7 +142,7 @@
 	suit_store = /obj/item/gun/projectile/boltrifle/bang
 	neck = /obj/item/reagent_containers/food/drinks/canteen
 	backpack_contents = list(
-	/obj/item/ammo_magazine/bolt_rifle_magazine/astartes = 3,
+	/obj/item/ammo_magazine/bolt_rifle_magazine_astartes = 3,
 	/obj/item/reagent_containers/food/snacks/warfare/rat = 1,
 	/obj/item/stack/thrones/five = 1,
 	/obj/item/stack/thrones2/five = 1,
@@ -217,7 +217,7 @@
 	neck = /obj/item/reagent_containers/food/drinks/canteen
 	backpack_contents = list(
 	/obj/item/melee/chain/pcsword = 1,
-	/obj/item/ammo_magazine/bolt_rifle_magazine/astartes = 3,
+	/obj/item/ammo_magazine/bolt_rifle_magazine_astartes = 3,
 	/obj/item/reagent_containers/food/snacks/warfare/rat = 1,
 	/obj/item/stack/thrones/five = 1,
 	/obj/item/stack/thrones2/five = 1,
@@ -308,7 +308,7 @@
 	l_ear = /obj/item/device/radio/headset/headset_sec
 	suit_store = /obj/item/gun/projectile/boltrifle/sally
 	backpack_contents = list(
-	/obj/item/ammo_magazine/bolt_rifle_magazine/astartes = 3,
+	/obj/item/ammo_magazine/bolt_rifle_magazine_astartes = 3,
 	/obj/item/reagent_containers/food/snacks/warfare/rat = 1,
 	/obj/item/stack/thrones/five = 1,
 	/obj/item/stack/thrones2/five = 1,
@@ -404,7 +404,7 @@
 	suit_store = /obj/item/gun/projectile/boltrifle
 	flags = OUTFIT_NO_BACKPACK|OUTFIT_NO_SURVIVAL_GEAR
 	backpack_contents = list(
-	/obj/item/ammo_magazine/bolt_rifle_magazine/astartes = 3,
+	/obj/item/ammo_magazine/bolt_rifle_magazine_astartes = 3,
 	/obj/item/reagent_containers/food/snacks/warfare/rat = 1,
 	/obj/item/stack/thrones/five = 1,
 	/obj/item/stack/thrones2/five = 1,

--- a/code/game/jobs/job/magistratum.dm
+++ b/code/game/jobs/job/magistratum.dm
@@ -243,6 +243,7 @@
 	/obj/item/handcuffs = 2,
 	/obj/item/stack/thrones2 = 1,
 	/obj/item/stack/thrones3/five = 1,
+	/obj/item/gun/energy/taser = 1,
 	)
 
 	flags = OUTFIT_NO_BACKPACK|OUTFIT_NO_SURVIVAL_GEAR
@@ -267,6 +268,7 @@
 	backpack_contents = list(
 	/obj/item/ammo_magazine/c50/ms = 1,
 	/obj/item/handcuffs = 1,
+	/obj/item/gun/energy/taser = 1,
 	/obj/item/stack/thrones/five = 1,
 	/obj/item/stack/thrones2/five = 1,
 	/obj/item/stack/thrones3/twenty = 1,
@@ -290,6 +292,7 @@
 	suit_store = null
 	backpack_contents = list(
 	/obj/item/ammo_magazine/c50/ms = 1,
+	/obj/item/gun/energy/taser = 1,
 	/obj/item/handcuffs = 1,
 	/obj/item/stack/thrones/five = 1,
 	/obj/item/stack/thrones2/five = 1,
@@ -314,6 +317,7 @@
 	r_pocket = /obj/item/device/flashlight/lantern
 	suit_store = /obj/item/gun/projectile/shotgun/pump/voxlegis
 	backpack_contents = list(
+	/obj/item/gun/energy/taser = 1,
 	/obj/item/handcuffs = 1,
 	/obj/item/reagent_containers/food/snacks/warfare/rat = 1,
 	/obj/item/ammo_box/shotgun = 1,

--- a/code/game/objects/items/devices/mechanicustoys.dm
+++ b/code/game/objects/items/devices/mechanicustoys.dm
@@ -532,7 +532,6 @@ obj/item/device/neuraladapter/attack(mob/living/carbon/human/skitarii/C, mob/liv
 	accuracy = 0
 	automatic = 1
 	fire_delay = 8
-	move_delay = 5
 	burst=1
 	magazine_type = /obj/item/ammo_magazine/flamer
 	allowed_magazines = /obj/item/ammo_magazine/flamer
@@ -561,7 +560,6 @@ obj/item/device/neuraladapter/attack(mob/living/carbon/human/skitarii/C, mob/liv
 	wielded_item_state = "autoshotty" // Do not remove this. We do not have any sprites for Bolters on-mob beyond this, it is perfect.
 	fire_delay = 2
 	burst = 1
-	move_delay = 3
 	automatic = 1
 	firemodes = list()
 	accuracy = 1
@@ -656,7 +654,6 @@ obj/item/device/neuraladapter/attack(mob/living/carbon/human/skitarii/C, mob/liv
 	w_class = ITEM_SIZE_NORMAL
 	force = 8
 	accuracy = -2
-	move_delay = 2
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/pulse/plasmapistol
@@ -679,7 +676,6 @@ obj/item/device/neuraladapter/attack(mob/living/carbon/human/skitarii/C, mob/liv
 	w_class = ITEM_SIZE_HUGE
 	force = 8
 	accuracy = -2
-	move_delay = 2
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/pulse/plasmarifle
@@ -701,7 +697,6 @@ obj/item/device/neuraladapter/attack(mob/living/carbon/human/skitarii/C, mob/liv
 	w_class = ITEM_SIZE_NORMAL
 	force = 8
 	accuracy = 2
-	move_delay = 2
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/neurotoxin
@@ -727,7 +722,6 @@ obj/item/device/neuraladapter/attack(mob/living/carbon/human/skitarii/C, mob/liv
 	sharp = 1
 	edge = 1
 	accuracy = 1
-	move_delay = 2
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/thallax/lightning

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -20,7 +20,7 @@
 	w_class = ITEM_SIZE_HUGE
 	slot_flags = SLOT_BACK
 	max_w_class = ITEM_SIZE_LARGE
-	max_storage_space = 12
+	max_storage_space = 16
 	var/is_satchel = FALSE //A bit hacky yeah, but satchels carry less so whatever.
 
 /obj/item/storage/backpack/equipped()
@@ -167,9 +167,9 @@
 
 /obj/item/storage/backpack/dufflebag/New()
 	..()
-	slowdown_per_slot[slot_back] = 3
-	slowdown_per_slot[slot_r_hand] = 1
-	slowdown_per_slot[slot_l_hand] = 1
+	slowdown_per_slot[slot_back] = 0.5
+	slowdown_per_slot[slot_r_hand] = 0.5
+	slowdown_per_slot[slot_l_hand] = 0.5
 
 /obj/item/storage/backpack/dufflebag/syndie
 	name = "black dufflebag"
@@ -178,7 +178,7 @@
 
 /obj/item/storage/backpack/dufflebag/syndie/New()
 	..()
-	slowdown_per_slot[slot_back] = 1
+	slowdown_per_slot[slot_back] = 0.4
 
 /obj/item/storage/backpack/dufflebag/syndie/med
 	name = "medical dufflebag"
@@ -218,7 +218,7 @@
 	name = "satchel"
 	desc = "A trendy looking satchel."
 	icon_state = "satchel-norm"
-	max_storage_space = DEFAULT_BOX_STORAGE
+	max_storage_space = DEFAULT_BOX_STORAGE +4
 	slot_flags = SLOT_BACK|SLOT_S_STORE//In your back or your second back slot. Backpacks can only go in the main one though.
 	is_satchel = TRUE
 

--- a/code/modules/clothing/rings/rings.dm
+++ b/code/modules/clothing/rings/rings.dm
@@ -25,7 +25,7 @@
 	name = "magic ring"
 	desc = "A strange ring with symbols carved on it in some arcane language."
 	icon_state = "magic"
-
+/* THIS RING IS BROKEN
 /obj/item/clothing/ring/magic/equipped(var/mob/living/carbon/human/H, var/slot)
 	..()
 	if(istype(H) && slot == SLOT_GLOVES)
@@ -37,7 +37,7 @@
 
 	if(istype(H))
 		H.remove_cloaking_source(src)
-
+*/
 /////////////////////////////////////////
 //Reagent Rings
 

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -60,10 +60,10 @@
  * Bomb protection
  */
 /obj/item/clothing/head/bomb_hood
-	name = "bomb hood"
+	name = "Heavy Flak helmet"
 	desc = "Use in case of bomb."
 	icon_state = "bombsuit"
-	armor = list(melee = 70, bullet = 15, laser = 30, energy = 50, bomb = 90, bio = 0, rad = 0)
+	armor = list(melee = 30, bullet = 45, laser = 40, energy = 50, bomb = 50, bio = 0, rad = 0)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHAIR
 	body_parts_covered = HEAD|FACE|EYES
 	siemens_coefficient = 0
@@ -71,13 +71,13 @@
 
 
 /obj/item/clothing/suit/bomb_suit
-	name = "bomb suit"
-	desc = "A suit designed for safety when handling explosives."
+	name = "Heavy Trooper Flak Suit"
+	desc = "A suit designed for the handling of heavy weapons."
 	icon_state = "bombsuit"
 	w_class = ITEM_SIZE_HUGE//bulky item
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.01
-	armor = list(melee = 20, bullet = 20, laser = 30, energy = 50, bomb = 90, bio = 90, rad = 40)
+	armor = list(melee = 50, bullet = 70, laser = 65, energy = 50, bomb = 60, bio = 90, rad = 40)
 	flags_inv = HIDEJUMPSUIT|HIDETAIL
 	heat_protection = UPPER_TORSO|LOWER_TORSO
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE
@@ -86,7 +86,7 @@
 
 /obj/item/clothing/suit/bomb_suit/New()
 	..()
-	slowdown_per_slot[slot_wear_suit] = 2
+	slowdown_per_slot[slot_wear_suit] = 0.9
 
 /obj/item/clothing/head/bomb_hood/security
 	icon_state = "bombsuitsec"

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -6,6 +6,7 @@
 	high_visibility = 1
 	var/obj/item/holstered = null
 	var/list/can_hold
+	can_hold = list(/obj/item/gun/projectile/automatic/machinepistol,/obj/item/gun/projectile/automatic/radcarbine/radpistol,/obj/item/gun/projectile/pistol,/obj/item/gun/energy/taser,/obj/item/gun/projectile/bolter_pistol,/obj/item/gun/projectile/eldar/spistol,/obj/item/gun/projectile/revolver,/obj/item/gun/projectile/necros,/obj/item/gun/projectile/slugrevolver,/obj/item/melee/sword/cutro,/obj/item/melee/sword/combat_knife,/obj/item/melee/sword/machete,/obj/item/gun/energy/las/laspistol,/obj/item/gun/energy/pulse/pulsepistol,/obj/item/gun/energy/pulse/plasma/pistol/toaster)
 
 /obj/item/clothing/accessory/holster/proc/holster(var/obj/item/I, var/mob/living/user)
 	if(holstered && istype(user))

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -434,12 +434,13 @@
 /obj/item/ammo_magazine/bolt_rifle_magazine/kp/empty
 	initial_ammo = 0
 
-/obj/item/ammo_magazine/bolt_rifle_magazine/astartes
+/obj/item/ammo_magazine/bolt_rifle_magazine_astartes
 	name = "Astartes Bolter Magazine"
 	icon_state = "bolty"
 	origin_tech = list(TECH_COMBAT = 2)
 	mag_type = MAGAZINE
 	caliber = ".95"
+	w_class = ITEM_SIZE_NORMAL
 	matter = list(DEFAULT_WALL_MATERIAL = 5260)
 	ammo_type = /obj/item/ammo_casing/bolter/astartes
 	max_ammo = 30

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -178,7 +178,6 @@
 	one_hand_penalty = 1
 	fire_delay = 3
 	accuracy = 0.5
-	move_delay = 3
 	origin_tech = list(TECH_COMBAT = 2, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/las/lasgun
@@ -194,6 +193,14 @@
 		list(mode_name="overcharge", fire_delay = 3.5, burst_accuracy=null, dispersion=null, automatic = 0, projectile_type=/obj/item/projectile/energy/las/lasgun/overcharge, charge_cost=140),
 		)
 
+/obj/item/gun/energy/las/lasgun/New()
+	..()
+	slowdown_per_slot[slot_back] = 0.05
+	slowdown_per_slot[slot_wear_suit] = 0.1
+	slowdown_per_slot[slot_belt] = 0.1
+	slowdown_per_slot[slot_r_hand] = 0.2
+	slowdown_per_slot[slot_l_hand] = 0.2
+
 /obj/item/gun/energy/las/triplex
 	name = "Triplex Pattern Lasgun"
 	desc = " A highly versatile refined lasgun used by the Mordian Iron Guard ."
@@ -205,7 +212,6 @@
 	one_hand_penalty = 1
 	fire_delay = 3
 	accuracy = 0.5
-	move_delay = 3
 	origin_tech = list(TECH_COMBAT = 2, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/las/lasgun
@@ -234,7 +240,6 @@
 	one_hand_penalty = 1.5
 	fire_delay = 5
 	accuracy = 0.5
-	move_delay = 5
 	charge_cost = 130
 	wielded_item_state = "semir"
 	charge_meter = FALSE
@@ -253,7 +258,6 @@
 	one_hand_penalty = 1.2
 	fire_delay = 4
 	accuracy = 0.5
-	move_delay = 3.2
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/las/lasgun/lucius
@@ -278,9 +282,8 @@
 	w_class = ITEM_SIZE_LARGE
 	force = 14
 	one_hand_penalty = 0.5
-	fire_delay = 2
-	accuracy = 0.7
-	move_delay = 2.5
+	fire_delay = 2.5
+	accuracy = 0.3
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/las/lasgun
@@ -296,6 +299,14 @@
 		list(mode_name="overcharge",       burst=1, fire_delay=3, burst_accuracy=null, dispersion=null, automatic = 0, projectile_type=/obj/item/projectile/energy/las/lasgun/overcharge, charge_cost=110),
 		)
 
+/obj/item/gun/energy/las/lasgun/catachan/New()
+	..()
+	slowdown_per_slot[slot_back] = 0.05
+	slowdown_per_slot[slot_wear_suit] = 0.1
+	slowdown_per_slot[slot_belt] = 0.1
+	slowdown_per_slot[slot_r_hand] = 0.15
+	slowdown_per_slot[slot_l_hand] = 0.15
+
 /obj/item/gun/energy/las/lasgun/accatran
 	name = "Accatran Mark VI Pattern Lasgun"
 	desc = "The Accatran Patterns are bullpup in design, affording them similar damage to that of a laspistol but with the capacity of a typical lasrifle and with a very high rate of fire for a lasgun. The choice pattern of the Elite Elysian Droptroopers."
@@ -307,7 +318,6 @@
 	one_hand_penalty = 0.7
 	fire_delay = 1.5
 	accuracy = 0.6
-	move_delay = 3.2
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/las/lasgun/pistol
@@ -331,11 +341,10 @@
 	item_state = "lascar"
 	slot_flags = SLOT_BACK|SLOT_S_STORE
 	w_class = ITEM_SIZE_LARGE
-	force = 22
+	force = 15
 	one_hand_penalty = 1.5
 	fire_delay = 3.1
 	accuracy = 0.6
-	move_delay = 4
 	self_recharge = 1
 	origin_tech = list(TECH_COMBAT = 4, TECH_MAGNET = 4)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
@@ -352,6 +361,14 @@
 		list(mode_name="burst",       burst=3, fire_delay=5.2, burst_accuracy=list(1,0,0), dispersion=null, automatic = 0, charge_cost=240),
 		) // Burst speed on hotshot is increased by -0.2(slightly faster then lasgun)
 
+/obj/item/gun/energy/las/hotshot/New()
+	..()
+	slowdown_per_slot[slot_back] = 0.1
+	slowdown_per_slot[slot_wear_suit] = 0.2
+	slowdown_per_slot[slot_belt] = 0.2
+	slowdown_per_slot[slot_r_hand] = 0.25
+	slowdown_per_slot[slot_l_hand] = 0.25
+
 /obj/item/gun/energy/las/hotshot/krieg
 	name = "Type XIV Lasgun Heavy"
 	desc = "The standard Hellgun issued to Grenadiers of the Death Korps of Krieg."
@@ -359,11 +376,10 @@
 	item_state = "hevluscius"
 	slot_flags = SLOT_BACK|SLOT_S_STORE
 	w_class = ITEM_SIZE_LARGE
-	force = 25
+	force = 15
 	one_hand_penalty = 1.7
 	fire_delay = 3.7
 	accuracy = 0.7
-	move_delay = 4
 	self_recharge = 3
 	recharge_time = 9
 	origin_tech = list(TECH_COMBAT = 4, TECH_MAGNET = 4)
@@ -404,9 +420,8 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	icon_state = "laspistol"
 	slot_flags = SLOT_BELT|SLOT_S_STORE
 	w_class = ITEM_SIZE_NORMAL
-	force = 8
+	force = 11
 	accuracy = 0
-	move_delay = 2.5
 	fire_delay = 1.85
 	origin_tech = list(TECH_COMBAT = 2, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
@@ -418,6 +433,13 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	sales_price = 10
 	wielded_item_state = "laspistol"
 
+/obj/item/gun/energy/las/laspistol/New()
+	..()
+	slowdown_per_slot[slot_back] = 0.05
+	slowdown_per_slot[slot_wear_suit] = 0.05
+	slowdown_per_slot[slot_belt] = 0.05
+	slowdown_per_slot[slot_r_hand] = 0.1
+	slowdown_per_slot[slot_l_hand] = 0.1
 
 /obj/item/gun/energy/las/laspistol/accatran
 	name = "Accatran MK II Pattern Laspistol"
@@ -429,7 +451,6 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	force = 10
 	accuracy = 0
 	fire_delay = 1.2
-	move_delay = 2.5
 	charge_cost = 80
 	cell_type = /obj/item/cell/lasgun
 	ammoType = /obj/item/cell/lasgun
@@ -491,7 +512,6 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	icon_state = "luciuspistol"
 	force = 10
 	/* one_hand_penalty = 0 */
-	move_delay = 1.5
 	accuracy = 0.4
 	charge_cost = 100
 	fire_delay = 2
@@ -516,7 +536,6 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	force = 15
 	one_hand_penalty = 2.2
 	accuracy = 1
-	move_delay = 5
 	origin_tech = list(TECH_COMBAT = 7, TECH_MAGNET = 7)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/pulse/ion
@@ -524,10 +543,19 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	ammoType = /obj/item/cell/ion
 	wielded_item_state = "ionriflet-wielded"
 	sales_price = 100
+	fire_delay = 14
 
 	firemodes = list(
-		list(mode_name="semi-automatic",       burst=1, fire_delay=8, burst_accuracy=null, dispersion=null, automatic = 0),
+		list(mode_name="semi-automatic",       burst=1, fire_delay=14, burst_accuracy=null, dispersion=null, automatic = 0),
 		)
+
+/obj/item/gun/energy/pulse/ionrifle/New()
+	..()
+	slowdown_per_slot[slot_back] = 0.2
+	slowdown_per_slot[slot_wear_suit] = 0.3
+	slowdown_per_slot[slot_belt] = 0.3
+	slowdown_per_slot[slot_r_hand] = 0.45
+	slowdown_per_slot[slot_l_hand] = 0.45
 
 /obj/item/gun/energy/pulse/pulsepistol
 	name = "pulse pistol"
@@ -538,7 +566,6 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	w_class = ITEM_SIZE_NORMAL
 	force = 8
 	accuracy = 0.5
-	move_delay = 2.5
 	origin_tech = list(TECH_COMBAT = 5, TECH_MAGNET = 5)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/pulse/pulsepistol
@@ -562,7 +589,6 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	force = 15
 	one_hand_penalty = 1.8
 	accuracy = 0.5
-	move_delay = 4
 	origin_tech = list(TECH_COMBAT = 6, TECH_MAGNET = 6)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/pulse/pulserifle
@@ -577,6 +603,14 @@ obj/item/gun/energy/las/hotshot/bloodpact
 		)
 
 
+/obj/item/gun/energy/pulse/pulserifle/New()
+	..()
+	slowdown_per_slot[slot_back] = 0.05
+	slowdown_per_slot[slot_wear_suit] = 0.15
+	slowdown_per_slot[slot_belt] = 0.15
+	slowdown_per_slot[slot_r_hand] = 0.3
+	slowdown_per_slot[slot_l_hand] = 0.3
+
 /obj/item/gun/energy/pulse/plasma
 	name = "plasma"
 	desc = "If you see this complain that staff used the wrong object"
@@ -589,8 +623,7 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	one_hand_penalty = 3 //heavy af fam
 	accuracy = 0
 	self_recharge = 1
-	recharge_time = 14 // With a fire delay of 19. You fire every 2.3 seconds. 1 recharge time is 1 second. Keep recharges to 1/6 and a bit per shot. We want people to NEED to reload in combat.
-	move_delay = 6 //dont want speedy bois
+	recharge_time = 14 // With a fire delay of 19. You fire every 2.3 seconds. 1 recharge time is 1 second. Keep recharges to 1/6 and a bit per shot. We want people to NEED to reload in combat. //dont want speedy bois
 	fire_delay = 15
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
@@ -636,8 +669,7 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	force = 12
 	one_hand_penalty = 2 //heavy af fam
 	accuracy = 0.6
-	fire_delay = 16
-	move_delay = 6 //dont want speedy bois
+	fire_delay = 16 //dont want speedy bois
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/pulse/plasmarifle
@@ -652,10 +684,11 @@ obj/item/gun/energy/las/hotshot/bloodpact
 
 /obj/item/gun/energy/pulse/plasma/rifle/New()
 	..()
-	slowdown_per_slot[slot_back] = 0.2
+	slowdown_per_slot[slot_back] = 0.1
 	slowdown_per_slot[slot_wear_suit] = 0.2
-	slowdown_per_slot[slot_r_hand] = 0.4
-	slowdown_per_slot[slot_l_hand] = 0.4
+	slowdown_per_slot[slot_belt] = 0.2
+	slowdown_per_slot[slot_r_hand] = 0.41
+	slowdown_per_slot[slot_l_hand] = 0.41
 
 /obj/item/gun/energy/pulse/plasma/pistol
 	name = "plasma pistol"
@@ -668,8 +701,7 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	force = 10
 	one_hand_penalty = 1.1
 	fire_delay = 18.5
-	accuracy = 0.1
-	move_delay = 4 //it a pistol, but giga cool plasma
+	accuracy = 0.1 //it a pistol, but giga cool plasma
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/pulse/plasmapistol
@@ -684,10 +716,11 @@ obj/item/gun/energy/las/hotshot/bloodpact
 
 /obj/item/gun/energy/pulse/plasma/pistol/New()
 	..()
-	slowdown_per_slot[slot_back] = 0.1
+	slowdown_per_slot[slot_back] = 0.05
 	slowdown_per_slot[slot_wear_suit] = 0.1
-	slowdown_per_slot[slot_r_hand] = 0.2
-	slowdown_per_slot[slot_l_hand] = 0.2
+	slowdown_per_slot[slot_belt] = 0.1
+	slowdown_per_slot[slot_r_hand] = 0.3
+	slowdown_per_slot[slot_l_hand] = 0.3
 
 /obj/item/gun/energy/pulse/plasma/pistol/astartes
 	name = "astartes plasma pistol"
@@ -701,8 +734,7 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	one_hand_penalty = 1
 	str_requirement = 20
 	fire_delay = 14.5
-	accuracy = 0.8
-	move_delay = 4 //it a pistol, but giga cool plasma
+	accuracy = 0.8 //it a pistol, but giga cool plasma
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/pulse/plasmapistol
@@ -724,8 +756,7 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	force = 12
 	one_hand_penalty = 1
 	fire_delay = 17.5
-	accuracy = 0.2
-	move_delay = 3.5 //it a pistol
+	accuracy = 0.2 //it a pistol
 	origin_tech = list(TECH_COMBAT = 4, TECH_MAGNET = 4)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/pulse/plasmapistol
@@ -748,8 +779,7 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	force = 10
 	one_hand_penalty = 0.8 //until plasma is better balanced, wield this fancy one.
 	accuracy = 0.3
-	fire_delay = 17
-	move_delay = 3.5
+	fire_delay = 17.5
 	recharge_time = 10
 	origin_tech = list(TECH_COMBAT = 4, TECH_MAGNET = 4)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
@@ -774,8 +804,7 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	force = 10
 	one_hand_penalty = 0.6 //change later?
 	accuracy = 0.6
-	fire_delay = 16
-	move_delay = 3 //it a pistol, but giga cool plasma
+	fire_delay = 16 //it a pistol, but giga cool plasma
 	origin_tech = list(TECH_COMBAT = 5, TECH_MAGNET = 5)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/pulse/plasmapistol
@@ -800,8 +829,7 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	force = 10
 	one_hand_penalty = 0.7 //change later?
 	accuracy = 0.5
-	fire_delay = 17
-	move_delay = 2 //it a pistol, but giga cool plasma
+	fire_delay = 17 //it a pistol, but giga cool plasma
 	self_recharge = 9 // very good
 	origin_tech = list(TECH_COMBAT = 5, TECH_MAGNET = 5)
 	projectile_type = /obj/item/projectile/energy/pulse/plasmapistol
@@ -829,7 +857,6 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	force = 12
 	one_hand_penalty = 1.5
 	accuracy = 0.5
-	move_delay = 2.5
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/las/lasgun
@@ -851,7 +878,6 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	armor_penetration = 15
 	force = 12
 	one_hand_penalty = 1.8
-	move_delay = 2.5
 	fire_delay = 3.5
 	charge_cost = 110
 	sales_price = 35
@@ -873,7 +899,6 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	armor_penetration = 8
 	one_hand_penalty = 1.5
 	accuracy = 0
-	move_delay = 2.5
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/las/lasgun
@@ -896,7 +921,6 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	one_hand_penalty = 1.2
 	charge_cost = 80
 	fire_delay = 2.3
-	move_delay = 2.5
 	sales_price = 35
 
 	firemodes = list(

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -12,16 +12,8 @@
 	multi_aim = 1
 	burst_delay = 3
 	burst = 3
-	move_delay = 4
 	accuracy = -1
 	wielded_item_state = "gun_wielded"
-
-/obj/item/gun/energy/pulse_rifle/New()
-	..()
-	slowdown_per_slot[slot_back] = 0.2
-	slowdown_per_slot[slot_wear_suit] = 0.2
-	slowdown_per_slot[slot_r_hand] = 0.3
-	slowdown_per_slot[slot_l_hand] = 0.3
 
 /obj/item/gun/energy/pulse_rifle/carbine
 	name = "pulse carbine"
@@ -35,14 +27,6 @@
 	w_class = ITEM_SIZE_LARGE
 	one_hand_penalty= 3
 	burst_delay = 2
-	move_delay = 2
-
-/obj/item/gun/energy/pulse_rifle/carbine/New()
-	..()
-	slowdown_per_slot[slot_back] = 0.1
-	slowdown_per_slot[slot_wear_suit] = 0.1
-	slowdown_per_slot[slot_r_hand] = 0.3
-	slowdown_per_slot[slot_l_hand] = 0.3
 
 /obj/item/gun/energy/pulse_rifle/pistol
 	name = "pulse pistol"
@@ -57,7 +41,6 @@
 	w_class = ITEM_SIZE_NORMAL
 	one_hand_penalty=1 //a bit heavy
 	burst_delay = 1
-	move_delay = 1
 	wielded_item_state = null
 
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -112,8 +112,7 @@ obj/item/gun/energy/staff/focus
 	str_requirement = 15 //kinda heavy due to it's giant cell.
 	max_shots = 5 //not lore accurate, but this is better.
 	w_class = ITEM_SIZE_NORMAL
-	burst_delay = 2
-	move_delay = 1 //its a small as fuck pistol, it may be poisonous but its small.
+	burst_delay = 2 //its a small as fuck pistol, it may be poisonous but its small.
 	fire_delay = 8
 	charge_cost = 300
 	cell_type = /obj/item/cell/plasma

--- a/code/modules/projectiles/guns/launcher.dm
+++ b/code/modules/projectiles/guns/launcher.dm
@@ -28,3 +28,11 @@
 	projectile.throw_at(target, throw_distance, release_force, user)
 	play_fire_sound(user,projectile)
 	return 1
+
+/obj/item/gun/launcher/New()
+	..()
+	slowdown_per_slot[slot_back] = 0.2
+	slowdown_per_slot[slot_wear_suit] = 0.2
+	slowdown_per_slot[slot_belt] = 0.2
+	slowdown_per_slot[slot_r_hand] = 0.5
+	slowdown_per_slot[slot_l_hand] = 0.5

--- a/code/modules/projectiles/guns/launcher/recoilless.dm
+++ b/code/modules/projectiles/guns/launcher/recoilless.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/launcher/rcl_rifle
+/obj/item/gun/launcher/rcl_rifle // SLOWDOWN IS APPLIED IN PARENT gun/launcher
         name = "Vraks pattern rocket launcher"
         desc = "A rocket launcher of Vraks pattern, being supplied to Krieg for combat against armoured targets."
         icon_state = "rcl_rifle-e"

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -27,6 +27,14 @@
 		)
 */
 
+/obj/item/gun/projectile/automatic/New()
+	..()
+	slowdown_per_slot[slot_back] = 0.1
+	slowdown_per_slot[slot_wear_suit] = 0.15
+	slowdown_per_slot[slot_belt] = 0.15
+	slowdown_per_slot[slot_r_hand] = 0.2
+	slowdown_per_slot[slot_l_hand] = 0.2
+
 /obj/item/gun/projectile/automatic/smg
 	name = "template smg"
 	desc = "This shouldnt exist and is bugged or not working. Ahelp immediately."
@@ -66,8 +74,7 @@
 	caliber = ".45"
 	slot_flags = SLOT_BACK|SLOT_S_STORE
 	w_class = ITEM_SIZE_HUGE
-	fire_sound = 'sound/weapons/gunshot/auto2.ogg'
-	move_delay = 2.5
+	fire_sound = 'sound/weapons/gunshot/auto2.ogg'.5
 	accuracy = 0
 	fire_delay = 3
 	sales_price = 40

--- a/code/modules/projectiles/guns/projectile/mattguns.dm
+++ b/code/modules/projectiles/guns/projectile/mattguns.dm
@@ -3,7 +3,7 @@
 // Accuracy Guide. Accuracy of -4 = Miss 1/3 shots on average. Accuracy of 0 = You never miss. Make sure weapon accuracy is never higher then -1 unless you want perfect accuracy.
 // Skills ONLY effect weapon spread. If the skill of a character is below 6 they'll have a hard time hitting anything.
 
-/obj/item/gun/projectile/shotgun/pump/boltaction
+/obj/item/gun/projectile/shotgun/pump/boltaction // BOLT ACTIONS USE THE PUMP SHOTGUN SLOWDOWN FROM THEIR PARENT. NO NEED TO ADD.
 	name = "\improper Boscelot Pattern Stub Rifle"
 	desc = "The stub rifle is a common weapon seen across the galaxy. Boscelot is a standard rifle pattern, firing large-bore rounds."
 	icon_state = "boltaction"
@@ -14,7 +14,6 @@
 	empty_icon = "boltaction-e"
 	fire_sound = 'sound/weapons/gunshot/auto5.ogg'
 	far_fire_sound = "sniper_fire"
-	move_delay = 8
 	one_hand_penalty = 2
 	accuracy = 1
 	fire_delay = 3
@@ -187,7 +186,6 @@
 /obj/item/gun/projectile/shotgun/pump/boltaction/shitty/tinkered
 	name = "\improper Triangong 4-46"
 	desc = "The stub rifle is a common sight across the galaxy, a hunting rifle firing large-bore rounds. This one is made of quality materials and has been laboured over extensively by expert hands."
-	move_delay = 2.5
 	one_hand_penalty = 1.5
 	accuracy = 1.2
 	fire_delay = 4
@@ -235,7 +233,6 @@
 	forwardsound = 'sound/weapons/guns/interact/la_forward.ogg'
 	empty_icon = "brushgun-e"
 	fire_delay = 3.5
-	move_delay = 2.5
 	gping = FALSE
 	sales_price = 10
 	accuracy = 0.8
@@ -363,11 +360,10 @@
 	str_requirement = 8
 	ammo_type = /obj/item/ammo_casing/shotgun
 	empty_icon = "voxlegisnew-e"
-	move_delay = 3
 	one_hand_penalty = 1.4
 	accuracy = 0.5
 	fire_delay= 3
-	sales_price = 10
+	sales_price = 10 // SHOTGUNS HAVE SLOWDOWN IN THEIR PARENT shotgun/pump -- DO NOT APPLY SLOWDOWN TO SHOTGUNS 
 
 /obj/item/gun/projectile/shotgun/pump/shitty/magrave
 	name = "\improper WTX Belle Magrave"
@@ -410,7 +406,6 @@
 	accuracy = 0
 	automatic = 1
 	fire_delay = 16
-	move_delay = 6
 	burst=1
 	magazine_type = /obj/item/ammo_magazine/flamer
 	allowed_magazines = /obj/item/ammo_magazine/flamer
@@ -426,6 +421,14 @@
 
 	gun_type = GUN_LMG //anyone can use this... just not anyone should.
 
+/obj/item/gun/projectile/automatic/flamer/New()
+	..()
+	slowdown_per_slot[slot_back] = 0.2
+	slowdown_per_slot[slot_wear_suit] = 0.3
+	slowdown_per_slot[slot_belt] = 0.3
+	slowdown_per_slot[slot_r_hand] = 0.4
+	slowdown_per_slot[slot_l_hand] = 0.4
+
 /obj/item/gun/projectile/automatic/flamer/update_icon()
     ..()
     if(ammo_magazine)
@@ -433,6 +436,7 @@
     else
         icon_state = "flamer-e"
 
+/*
 /obj/item/gun/projectile/automatic/flamer/pistol
 	name = "Handheld Scorcher"
 	desc = "The handheld, pistol varient of the flamer. It shoots slower than it's larger brother and is more difficult to hold in your single hand."
@@ -449,7 +453,6 @@
 	accuracy = 0
 	automatic = 1
 	fire_delay = 22
-	move_delay = 6
 	burst=1
 	magazine_type = /obj/item/ammo_magazine/flamer
 	allowed_magazines = /obj/item/ammo_magazine/flamer
@@ -464,7 +467,7 @@
 	sales_price = 30
 
 	gun_type = GUN_LMG //anyone can use this... just not anyone should.
-
+*/ // ABSOLUTELY NO PISTOL FLAMERS.
 
 /obj/item/gun/projectile/automatic/flamer/update_icon()
     ..()
@@ -473,7 +476,7 @@
     else
         icon_state = "flamerp-e"
 
-// Stubber //
+// Stubber // ALL AUTOMATIC WEAPONS HAVE SLOWDOWN APPLIED by 0.2 from their parent. Only add a slowdown if the weapon is heavier then a basic rifle.
 
 /obj/item/gun/projectile/automatic/m22/warmonger/m14/battlerifle
 	name = "Aegis Pattern Rifle"
@@ -487,7 +490,6 @@
 	cock_sound = 'sound/weapons/guns/interact/arm_cock.ogg'
 	fire_delay = 3.5
 	automatic = 0
-	move_delay = 4.2
 	one_hand_penalty = 1.6
 	accuracy = 1
 	sales_price = 16
@@ -528,8 +530,7 @@
 	reload_sound = 'sound/weapons/guns/interact/combatrifle_magin.ogg'
 	cock_sound = 'sound/weapons/guns/interact/combatrifle_cock.ogg'
 	fire_delay = 2.5
-	automatic = 0
-	move_delay = 4.2
+	automatic = 0.2
 	one_hand_penalty = 1.4
 	accuracy = 1.5
 	sales_price = 10
@@ -583,15 +584,16 @@
 
 	firemodes = list(
 		list(mode_name="semi-automatic", burst=1, fire_delay=1.6, burst_accuracy=null, dispersion=null, automatic = 0),
-		list(mode_name="4-round bursts", burst=4, fire_delay=3.2, burst_accuracy=list(0,-1,-1), dispersion=null, automatic = 0),
+		list(mode_name="4-round bursts", burst=4, fire_delay=4.5, burst_accuracy=list(0.5,-1,-1), dispersion=null, automatic = 0),
 		)
 
 /obj/item/gun/projectile/automatic/heavystubber/New()
 	..()
-	slowdown_per_slot[slot_back] = 0.1
+	slowdown_per_slot[slot_back] = 0.05
 	slowdown_per_slot[slot_wear_suit] = 0.1
-	slowdown_per_slot[slot_r_hand] = 0.3
-	slowdown_per_slot[slot_l_hand] = 0.3
+	slowdown_per_slot[slot_belt] = 0.1
+	slowdown_per_slot[slot_r_hand] = 0.32
+	slowdown_per_slot[slot_l_hand] = 0.32
 
 /obj/item/gun/projectile/automatic/heavystubber/update_icon()
     ..()
@@ -621,8 +623,8 @@
 	sales_price = 26
 
 	firemodes = list(
-		list(mode_name="semi-automatic",       burst=1, fire_delay=1.8, burst_accuracy=null, dispersion=null, automatic = 0),
-		list(mode_name="4-round bursts", burst=4, fire_delay=4.5, burst_accuracy=list(0,-1,-1), dispersion=null, automatic = 0),
+		list(mode_name="semi-automatic",       burst=1, fire_delay=1.6, burst_accuracy=null, dispersion=null, automatic = 0),
+		list(mode_name="5-round bursts", burst=5, fire_delay=4.3, burst_accuracy=list(1,-1,-1), dispersion=null, automatic = 0),
 		)
 
 /obj/item/gun/projectile/automatic/heavystubber/cognis/update_icon()
@@ -643,8 +645,8 @@
 	sales_price = 22
 
 	firemodes = list(
-		list(mode_name="semi-automatic", burst=1, fire_delay=1.8, burst_accuracy=null, dispersion=null, automatic = 0),
-		list(mode_name="2-round bursts", burst=2, fire_delay=3.6, burst_accuracy=list(0,-1,-1), dispersion=null, automatic = 0), // Villiers perform better in semi then burst
+		list(mode_name="semi-automatic", burst=1, fire_delay=1.6, burst_accuracy=null, dispersion=null, automatic = 0),
+		list(mode_name="2-round bursts", burst=2, fire_delay=3.5, burst_accuracy=list(1,1,1), dispersion=null, automatic = 0), // Villiers perform better in semi then burst
 		)
 
 // stub rifles, mag fed
@@ -656,7 +658,6 @@
 	wielded_item_state = "machinepistol-wielded"
 	slot_flags = SLOT_BACK|SLOT_S_STORE
 	w_class = ITEM_SIZE_HUGE
-	move_delay = 2.2
 	one_hand_penalty = 0.8
 	accuracy = 0.5
 	fire_delay = 1.7
@@ -681,12 +682,19 @@
 		list(mode_name="3-round bursts", burst=3, fire_delay=3.4, burst_accuracy=list(0,-1,-1), dispersion=null, automatic = 0),
 		)
 
+/obj/item/gun/projectile/automatic/machinepistol/New()
+	..()
+	slowdown_per_slot[slot_back] = 0.05
+	slowdown_per_slot[slot_wear_suit] = 0.1
+	slowdown_per_slot[slot_belt] = 0.1
+	slowdown_per_slot[slot_r_hand] = 0.15
+	slowdown_per_slot[slot_l_hand] = 0.15
+
 /obj/item/gun/projectile/automatic/machinepistol/a80
 	name = "Nachtwey A80 Autogun"
 	desc = "A specialty autogun made by frontier gunsmiths - an improved version of the Mk.22 Autogun with a more stable firing platform."
 	icon_state = "autorifle"
 	item_state = "autorifle"
-	move_delay = 2
 	one_hand_penalty = 0.6
 	accuracy = 0.7
 	fire_delay = 1.6
@@ -716,7 +724,6 @@
 	unloaded_icon = "auto_grim-e"
 	loaded_icon = "auto_grim"
 	fire_sound = 'sound/weapons/guns/fire/sfrifle_fire.ogg'
-	move_delay = 2.5
 	one_hand_penalty = 1
 	accuracy = 0.5
 	fire_delay = 1.6
@@ -751,7 +758,6 @@
 	unloaded_icon = "kriegstubber-e"
 	loaded_icon = "kriegstubber"
 	fire_sound = 'sound/weapons/guns/fire/sfrifle_fire.ogg'
-	move_delay = 2.5
 	one_hand_penalty = 1.2
 	accuracy = 0.7
 	fire_delay = 1.5
@@ -799,7 +805,6 @@
 	slot_flags = SLOT_BACK|SLOT_S_STORE
 	w_class = ITEM_SIZE_HUGE
 	fire_sound = 'sound/weapons/gunshot/auto2.ogg'
-	move_delay = 2.3
 	one_hand_penalty = 1.4
 	accuracy = 0.8
 	automatic = 0
@@ -839,7 +844,6 @@
 	slot_flags = SLOT_BACK|SLOT_S_STORE
 	w_class = ITEM_SIZE_HUGE
 	fire_sound = 'sound/weapons/gunshot/auto2.ogg'
-	move_delay = 7
 	one_hand_penalty = 1.3
 	accuracy = 0.4
 	automatic = 1
@@ -884,8 +888,8 @@
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 1, TECH_ILLEGAL = 2)
 	ammo_type = /obj/item/ammo_casing/bolter/astartes
 	load_method = MAGAZINE
-	magazine_type = /obj/item/ammo_magazine/bolt_rifle_magazine/astartes
-	allowed_magazines = list(/obj/item/ammo_magazine/bolt_rifle_magazine/astartes)
+	magazine_type = /obj/item/ammo_magazine/bolt_rifle_magazine_astartes
+	allowed_magazines = list(/obj/item/ammo_magazine/bolt_rifle_magazine_astartes)
 	fire_sound = 'sound/weapons/gunshot/loudbolt.ogg'
 	unload_sound 	= 'sound/weapons/guns/interact/ltrifle_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/ltrifle_magin.ogg'
@@ -899,7 +903,6 @@
 	wielded_unloaded_icon = "hbolter-e"
 	fire_delay = 2
 	burst = 1
-	move_delay = 3
 	one_hand_penalty = 2.2
 	firemodes = list()
 	gun_type = GUN_AUTOMATIC
@@ -913,8 +916,9 @@
 
 /obj/item/gun/projectile/boltrifle/New()
 	..()
-	slowdown_per_slot[slot_back] = 0.2
-	slowdown_per_slot[slot_wear_suit] = 0.2 // The slowdown is the same as the human bolter due to it being for Astartes. it's 21 STR requirement makes sure you still need that much strength to use it.
+	slowdown_per_slot[slot_back] = 0.1
+	slowdown_per_slot[slot_wear_suit] = 0.2
+	slowdown_per_slot[slot_belt] = 0.2
 	slowdown_per_slot[slot_r_hand] = 0.4
 	slowdown_per_slot[slot_l_hand] = 0.4
 
@@ -983,6 +987,8 @@
 	unload_sound 	= 'sound/weapons/guns/interact/ltrifle_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/ltrifle_magin.ogg'
 	cock_sound 		= 'sound/weapons/guns/interact/ltrifle_cock.ogg'
+	magazine_type = /obj/item/ammo_magazine/bolt_rifle_magazine
+	allowed_magazines = list(/obj/item/ammo_magazine/bolt_rifle_magazine)
 	loaded_icon = "lockebolter-30"
 	unloaded_icon = "lockebolter-e"
 	wielded_item_state = "autoshotty"
@@ -993,7 +999,6 @@
 	wielded_unloaded_icon = "autoshotty-wielded-e"
 	fire_delay = 2.45
 	burst = 1
-	move_delay = 3
 	firemodes = list()
 	gun_type = GUN_AUTOMATIC
 	accuracy = 0
@@ -1006,8 +1011,9 @@
 
 /obj/item/gun/projectile/boltrifle/lockebolter/New()
 	..()
-	slowdown_per_slot[slot_back] = 0.2
+	slowdown_per_slot[slot_back] = 0.1
 	slowdown_per_slot[slot_wear_suit] = 0.2
+	slowdown_per_slot[slot_belt] = 0.2
 	slowdown_per_slot[slot_r_hand] = 0.4
 	slowdown_per_slot[slot_l_hand] = 0.4
 
@@ -1021,6 +1027,8 @@
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 1, TECH_ILLEGAL = 2)
 	load_method = MAGAZINE
 	one_hand_penalty = 2.2 //its a bolter not a toy gun
+	magazine_type = /obj/item/ammo_magazine/bolt_rifle_magazine
+	allowed_magazines = list(/obj/item/ammo_magazine/bolt_rifle_magazine)
 	fire_sound = 'sound/weapons/gunshot/loudbolt.ogg'
 	loaded_icon = "lockebolter-30"
 	unloaded_icon = "lockebolter-e"
@@ -1032,7 +1040,6 @@
 	wielded_unloaded_icon = "autoshotty-wielded-e"
 	fire_delay = 2.15
 	burst = 1
-	move_delay = 3
 	firemodes = list()
 	gun_type = GUN_AUTOMATIC
 	accuracy = 0.5
@@ -1077,6 +1084,8 @@
 	max_shells = 30
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 1, TECH_ILLEGAL = 2)
 	one_hand_penalty = 2 //its still a bolter bro...
+	magazine_type = /obj/item/ammo_magazine/bolt_rifle_magazine
+	allowed_magazines = list(/obj/item/ammo_magazine/bolt_rifle_magazine)
 	fire_sound = 'sound/weapons/gunshot/loudbolt.ogg'
 	unload_sound 	= 'sound/weapons/guns/interact/ltrifle_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/ltrifle_magin.ogg'
@@ -1092,7 +1101,6 @@
 	wielded_unloaded_icon = "autoshotty-wielded-e"
 	fire_delay = 1.9
 	burst = 1
-	move_delay = 3
 	firemodes = list()
 	accuracy = 1.4 //only one gun per round so yeah
 	gun_type = GUN_AUTOMATIC
@@ -1112,8 +1120,9 @@
 
 /obj/item/gun/projectile/boltrifle/sisterbolter/New()
 	..()
-	slowdown_per_slot[slot_back] = 0.2
+	slowdown_per_slot[slot_back] = 0.1
 	slowdown_per_slot[slot_wear_suit] = 0.2
+	slowdown_per_slot[slot_belt] = 0.2
 	slowdown_per_slot[slot_r_hand] = 0.4
 	slowdown_per_slot[slot_l_hand] = 0.4
 
@@ -1136,7 +1145,6 @@
 	max_shells = 30
 	caliber = ".75"
 	can_jam = TRUE
-	move_delay = 5
 	one_hand_penalty = 1
 	accuracy = -1.5
 	ammo_type = /obj/item/ammo_casing/ork/shoota
@@ -1195,8 +1203,7 @@
 	unloaded_icon = "autoshotty-e"
 	unwielded_unloaded_icon = "autoshotty-e"
 	wielded_unloaded_icon = "autoshotty-wielded-e"
-	force = 20
-	move_delay = 1 // smg
+	force = 20 // smg
 	one_hand_penalty = 1
 	accuracy = -1
 	sales_price = 1
@@ -1228,7 +1235,6 @@
 	max_shells = 50
 	caliber = ".75"
 	can_jam = TRUE
-	move_delay = 10
 	one_hand_penalty = 2
 	accuracy = -2
 	gun_type = GUN_AUTOMATIC
@@ -1260,7 +1266,6 @@
 	unwielded_unloaded_icon = "autoshotty-e"
 	wielded_unloaded_icon = "autoshotty-wielded-e"
 	force = 15
-	move_delay = 8
 	one_hand_penalty = 2
 	accuracy = -0.5
 	gun_type = GUN_SNIPER

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -8,7 +8,6 @@
 	force = 10
 	accuracy = 0.5
 	one_hand_penalty = 0
-	move_delay = 5
 	fire_delay = 6
 	sales_price = 10
 
@@ -176,7 +175,6 @@
 	can_jam = TRUE //yes it can jam
 	accuracy = -0.5
 	force = 20
-	move_delay = 1.5
 	load_method = MAGAZINE
 
 /obj/item/gun/projectile/ork/slugga/update_icon()
@@ -198,7 +196,6 @@
 	caliber = ".75"
 	accuracy = 0
 	fire_delay = 1.8
-	move_delay = 1.5
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/bolt_pistol_magazine
 	allowed_magazines = /obj/item/ammo_magazine/bolt_pistol_magazine
@@ -220,8 +217,7 @@
 	force = 10
 	caliber = ".75"
 	accuracy = -0.4
-	fire_delay = 2
-	move_delay = 5.0 // make it shit and mostly ornamental
+	fire_delay = 2.0 // make it shit and mostly ornamental
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/bolt_pistol_magazine
 	allowed_magazines = /obj/item/ammo_magazine/bolt_pistol_magazine
@@ -243,7 +239,6 @@
 	caliber = ".75"
 	accuracy = 0.3 //VERY well maintained--maintened? eh, you get what i mean!
 	fire_delay = 1.5
-	move_delay = 1.3
 	sales_price = 58
 
 /obj/item/gun/projectile/bolter_pistol/inquis/update_icon()
@@ -262,8 +257,7 @@
 	force = 20 //i don't think that De'az bolt pistols can have bayonets attached to them, but, imma leave this in, oh also, the Mars Pattern Mark II Scourge is the one with a bayonet.
 	sharp = 1
 	accuracy = 0.6 //normally only 2 of those spawn on the map, one with the sisters, and one on a room in the caves, and they can't even be fabricated
-	fire_delay = 1.5 //fastaa!
-	move_delay = 1.5 //honestly this is kinda of useless
+	fire_delay = 1.5 //fastaa!.5 //honestly this is kinda of useless
 	attack_verb = list ("stabbed", "sliced")
 	hitsound = "stab_sound"
 	sales_price = 70

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -30,7 +30,7 @@
 	obj_flags =  OBJ_FLAG_CONDUCTIBLE
 	caliber = "shotgun"
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
-	ammo_type = /obj/item/ammo_casing/shotgun/beanbag
+	ammo_type = /obj/item/ammo_casing/shotgun
 	handle_casings = HOLD_CASINGS
 	var/recentpump = 0 // to prevent spammage
 	var/pumpsound = 'sound/weapons/guns/interact/newpump.ogg' //Support for other kinds of pump weapons.
@@ -49,7 +49,11 @@
 /obj/item/gun/projectile/shotgun/pump/New()
 	..()
 	pump(null, TRUE)//Chamber it when it's created.
-
+	slowdown_per_slot[slot_back] = 0.1
+	slowdown_per_slot[slot_wear_suit] = 0.1
+	slowdown_per_slot[slot_belt] = 0.1
+	slowdown_per_slot[slot_r_hand] = 0.2
+	slowdown_per_slot[slot_l_hand] = 0.2
 
 /obj/item/gun/projectile/shotgun/pump/consume_next_projectile()
 	if(check_for_jam())
@@ -240,20 +244,20 @@
 	one_hand_penalty = 8
 	block_chance = 15 //pretty big, could be used as a shield in theory considering how armored it is
 	gun_type = GUN_SHOTGUN
-	move_delay = 8
 	accuracy = -2
 	fire_delay= 20
 	sales_price = 50
-	burst = 30
+	burst = 16
 	
 	firemodes = list(
-		list(mode_name="OVERCHARGE", burst=25, fire_delay=40, burst_accuracy=null, dispersion=null, automatic = 0.7),
-		list(mode_name="STANDARD", burst=18, fire_delay=30, burst_accuracy=null, dispersion=null, automatic = 0.7),
+		list(mode_name="OVERCHARGE", burst=21, fire_delay=40, burst_accuracy=null, dispersion=null, automatic = 0.7),
+		list(mode_name="STANDARD", burst=16, fire_delay=30, burst_accuracy=null, dispersion=null, automatic = 0.7),
 	)
 
 /obj/item/gun/projectile/meltagun/New()
 	..()
-	slowdown_per_slot[slot_back] = 0.3
+	slowdown_per_slot[slot_back] = 0.2
 	slowdown_per_slot[slot_wear_suit] = 0.3
-	slowdown_per_slot[slot_r_hand] = 0.5
-	slowdown_per_slot[slot_l_hand] = 0.5
+	slowdown_per_slot[slot_belt] = 0.3
+	slowdown_per_slot[slot_r_hand] = 0.46
+	slowdown_per_slot[slot_l_hand] = 0.46

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -92,7 +92,6 @@
 	one_hand_penalty = 2.1
 	fire_delay = 8
 	accuracy = 1
-	move_delay = 4
 	origin_tech = list(TECH_COMBAT = 2, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 4000)
 	projectile_type = /obj/item/projectile/energy/las/lasgun/longlas
@@ -109,10 +108,11 @@
 
 /obj/item/gun/energy/las/lasgun/longlas/New()
 	..()
-	slowdown_per_slot[slot_back] = 0.1
+	slowdown_per_slot[slot_back] = 0.05
 	slowdown_per_slot[slot_wear_suit] = 0.1
-	slowdown_per_slot[slot_r_hand] = 0.3
-	slowdown_per_slot[slot_l_hand] = 0.3
+	slowdown_per_slot[slot_belt] = 0.1
+	slowdown_per_slot[slot_r_hand] = 0.25
+	slowdown_per_slot[slot_l_hand] = 0.25
 
 /obj/item/gun/energy/las/lasgun/longlas/verb/scope()
 	set category = "Object"
@@ -225,7 +225,6 @@
 	caliber = "galvanic"
 	max_shells = 7 //Fits seven rounds in the mag, with a revolving cylinder. No room for extra rounds.
 	str_requirement = 17
-	move_delay = 3
 	one_hand_penalty = 2.2
 	accuracy = 1 //extremely accurate
 	fire_delay = 4.9

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -111,7 +111,7 @@
 	icon_state = "shot" //TODO: would be nice to have it's own icon state
 	range = 10 	//These disappear after a short distance.
 	var/pellets = 4			//number of pellets
-	var/range_step = 2		//projectile will lose a fragment each time it travels this distance. Can be a non-integer.
+	var/range_step = 3		//projectile will lose a fragment each time it travels this distance. Can be a non-integer.
 	var/base_spread = 40	//lower means the pellets spread more across body parts. If zero then this is considered a shrapnel explosion instead of a shrapnel cone
 	var/spread_step = 10	//higher means the pellets spread more across body parts with distance
 	light_power = 9 //No tracers.
@@ -615,11 +615,11 @@
 	damage_type = BURN
 	penetration_modifier = 1
 	armor_penetration = 60
-	damage = 45
+	damage = 40
 	pellets = 1
-	range_step = 3 // stop fucking with my GOT DAMN CODE. DONT TOUCH IT IF YOU DONT KNOW WHAT IT DOES. Next mofucka who breaks mah game is getting perma'd from the Github.
+	range_step = 4 // stop fucking with my GOT DAMN CODE. DONT TOUCH IT IF YOU DONT KNOW WHAT IT DOES. Next mofucka who breaks mah game is getting perma'd from the Github.
 	spread_step = 2
-	range = 12
+	range = 16
 
 /obj/item/projectile/bullet/rifle/radcarbine
 	fire_sound = 'sound/weapons/guns/misc/laser_searwall.ogg'

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -72,7 +72,7 @@
 	fire_sound = 'sound/weapons/guns/fire/pain_fire.ogg'
 	mob_hit_sound = list('sound/weapons/tase.ogg')
 	nodamage = TRUE
-	agony = 100
+	agony = 200
 	damage_type = PAIN
 	//Damage will be handled on the MOB side, to prevent window shattering.
 
@@ -237,31 +237,31 @@
 	fire_sound='sound/weapons/lasgun.ogg'
 	wall_hitsound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "pulse1"
-	damage = 80
+	damage = 90
 	armor_penetration = 100
 
 	on_hit(var/atom/target, var/blocked = 0)
-		explosion(target, -1, 0, 1)
+		explosion(target, -1, -1, 0, 0, 0)
 
 /obj/item/projectile/energy/pulse/ion
 	name = "ION round"
 	fire_sound='sound/weapons/lasgun.ogg'
 	wall_hitsound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "pulse1"
-	damage = 80
+	damage = 90
 	armor_penetration = 100
 
 	on_hit(var/atom/target, var/blocked = 0)
-		explosion(target, -1, 0, 1)
+		explosion(target, -1, -1, 0, 0, 0)
 
 /obj/item/projectile/energy/pulse/plasmarifle
 	name = "plasma round"
 	fire_sound='sound/weapons/marauder.ogg'
 	wall_hitsound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "pulse1_bl"
-	damage = 100
+	damage = 90
 	weaken = 1
-	armor_penetration = 40
+	armor_penetration = 65
 	light_power = 4
 	light_color = "#2132cf"
 
@@ -273,7 +273,7 @@
 	icon_state = "pulse1_bl"
 	damage = 90
 	weaken = 1
-	armor_penetration = 35
+	armor_penetration = 50
 	light_power = 4
 	light_color = "#2132cf"
 
@@ -282,14 +282,14 @@
 	fire_sound='sound/weapons/marauder.ogg'
 	wall_hitsound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "pulse1_bl"
-	damage = 70
+	damage = 90
 	weaken = 1
-	armor_penetration = 45
+	armor_penetration = 50
 	light_power = 4
 	light_color = "#2132cf"
 
 	on_hit(var/atom/target, var/blocked = 0)
-		explosion(target, -1, 0, 1)
+		explosion(target, -1, -1, 0, 0, 0)
 
 /obj/item/projectile/warpboltcrappy
 	name = "Warp Bolt"

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -33,7 +33,7 @@
 	check_armour = "bullet"
 
 	on_hit(var/atom/target, var/blocked = 0)
-		explosion(target, -1, -1, 1)
+		explosion(target, -1, -1, -1, 0, 0)
 
 /obj/item/projectile/bullet/bpistol 
 	name =".50 bolt" //.50, human sized bolters and bolt pistols
@@ -62,7 +62,7 @@
 	armor_penetration = 25
 
 	on_hit(var/atom/target, var/blocked = 0)
-		explosion(target, -1, -1, 1)
+		explosion(target, -1, -1, -1, 0, 0)
 
 /obj/item/projectile/bullet/bolt/ms
 	fire_sound = 'sound/effects/explosion1.ogg'
@@ -70,7 +70,7 @@
 	armor_penetration = 30
 	
 	on_hit(var/atom/target, var/blocked = 0)
-		explosion(target, -1, -1, 0)
+		explosion(target, -1, -1, -1, 0, 0)
 
 /obj/item/projectile/meteor
 	name = "meteor"

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -2802,7 +2802,7 @@ CIRCUITS BELOW
 	id = "brmkp"
 	req_tech = list(TECH_MATERIAL = 5, TECH_ENGINEERING = 6, TECH_COMBAT = 5)
 	materials = list("diamond" = 6000, "phoron" = 600)
-	build_path = /obj/item/ammo_magazine/bolt_rifle_magazine/astartes
+	build_path = /obj/item/ammo_magazine/bolt_rifle_magazine_astartes
 	sort_string = "ZVBK"
 
 /datum/design/item/lasgunpowerpack


### PR DESCRIPTION
Weapon related movement slowdown is a bit more balanced. Added delay to a lot more weapons. You'll notice for now that melee weapons don't have slowdown and that's because I've yet to start adding slowdown to heavy melee weapons yet, though even if I do -- it's likely only going to effect very heavy weapons like the Daemonhammer or Chainsword.

Removed old useless move_delay code.

Backpacks in general have +4 added to space.

Disabled invisibility ring.

Holsters can now only contain small items such as knives, cutro blades, pistols -- etc. The seolite plasma pistol is uniquely the only plasma pistol that can be held within a holster, as it is canon considered a small sized plasma weapon.

Fixed up explosion code for a number of ranged weapons, along with fire_delay.

Astares ammo and boltgun related issues fixed.

Shotgun Pellets and Melta Pellet have greater range. Melta also just generally stronk but has a weaker burst.