### PR TITLE
Hotfixes

### DIFF
--- a/code/game/objects/auras/aura.dm
+++ b/code/game/objects/auras/aura.dm
@@ -164,42 +164,42 @@ They should also be used for when you want to effect the ENTIRE mob, like having
 	brute_mult = 15 // Value of 10 = 1 per second. Bleeding slows this down a lot, so a minimum of 15-20 is needed to stop bleeding.
 	fire_mult = 15
 	tox_mult = 7 // We don't want toxin to heal as quickly as we want death to still be possible -- only slowed down. Not stopped.
-	organheal = 0.4 // Leave this as is. Any higher and you become god.
+	organheal = 0.3 // Leave this as is. Any higher and you become god.
 
 /obj/aura/regenerating/human/ork
 	can_regenerate_organs = TRUE
-	brute_mult = 12
-	fire_mult = 12
+	brute_mult = 9
+	fire_mult = 9
 	tox_mult = 6
-	organheal = 0.4
+	organheal = 0.3
 
 /obj/aura/regenerating/human/ogryn
 	can_regenerate_organs = TRUE
-	brute_mult = 12
-	fire_mult = 12
-	tox_mult = 6
+	brute_mult = 7
+	fire_mult = 7
+	tox_mult = 4
 	organheal = 0.3
 
 /obj/aura/regenerating/human/khornate
 	can_regenerate_organs = TRUE
-	brute_mult = 3
-	fire_mult = 3
-	tox_mult = 2
-	organheal = 0.2
+	brute_mult = 5
+	fire_mult = 5
+	tox_mult = 3
+	organheal = 0.3
 
 /obj/aura/regenerating/human/skinless
 	can_regenerate_organs = TRUE
 	brute_mult = 20
 	fire_mult = 20
 	tox_mult = 15
-	organheal = 0.4
+	organheal = 0.3
 
 /obj/aura/regenerating/human/nid
 	can_regenerate_organs = TRUE
-	brute_mult = 16
-	fire_mult = 16
-	tox_mult = 16
-	organheal = 0.4
+	brute_mult = 15
+	fire_mult = 15
+	tox_mult = 10
+	organheal = 0.3
 
 /obj/aura/regenerating/human/rat
 	can_regenerate_organs = TRUE
@@ -214,8 +214,8 @@ They should also be used for when you want to effect the ENTIRE mob, like having
 	can_regenerate_organs = TRUE
 	brute_mult = 45
 	fire_mult = 45
-	tox_mult = 8
-	organheal = 0.7
+	tox_mult = 25
+	organheal = 0.3
 
 
 /*/obj/aura/regenerating/human/astartes/life_tick()

--- a/code/game/objects/items/weapons/grenades/explosive.dm
+++ b/code/game/objects/items/weapons/grenades/explosive.dm
@@ -1,5 +1,5 @@
 /obj/item/projectile/bullet/pellet/fragment
-	damage = 55
+	damage = 45
 	range_step = 3 //controls damage falloff with distance. projectiles lose a "pellet" each time they travel this distance. Can be a non-integer.
 
 	base_spread = 0 //causes it to be treated as a shrapnel explosion instead of cone
@@ -12,12 +12,12 @@
 	do_not_pass_trench = TRUE
 
 /obj/item/projectile/bullet/pellet/fragment/strong
-	damage = 70
+	damage = 60
 	range_step = 1 //controls damage falloff with distance. projectiles lose a "pellet" each time they travel this distance. Can be a non-integer.
 	range = 5
 
 /obj/item/projectile/bullet/pellet/fragment/weak
-	damage = 50
+	damage = 40
 	range_step = 3
 
 /obj/item/grenade/frag

--- a/code/modules/mob/living/simple_animal/hostile/smalldemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/smalldemon.dm
@@ -130,8 +130,8 @@
 	icon_state = "floater"
 	icon_living = "floater"
 	icon_dead = "floater2"
-	maxHealth = 680
-	health = 680
+	maxHealth = 430
+	health = 430
 	speak_emote = list("harks")
 	emote_hear = list("growls")
 	response_help  = "gnashes"

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -177,7 +177,7 @@
 	force = 13
 	one_hand_penalty = 1
 	fire_delay = 3
-	accuracy = 0.5
+	accuracy = 0
 	origin_tech = list(TECH_COMBAT = 2, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/las/lasgun
@@ -211,7 +211,7 @@
 	force = 13
 	one_hand_penalty = 1
 	fire_delay = 3
-	accuracy = 0.5
+	accuracy = 0
 	origin_tech = list(TECH_COMBAT = 2, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/las/lasgun
@@ -239,7 +239,7 @@
 	force = 12
 	one_hand_penalty = 1.5
 	fire_delay = 5
-	accuracy = 0.5
+	accuracy = 0
 	charge_cost = 130
 	wielded_item_state = "semir"
 	charge_meter = FALSE
@@ -257,7 +257,7 @@
 	force = 15
 	one_hand_penalty = 1.2
 	fire_delay = 4
-	accuracy = 0.5
+	accuracy = 0
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/las/lasgun/lucius
@@ -283,7 +283,7 @@
 	force = 14
 	one_hand_penalty = 0.5
 	fire_delay = 2.5
-	accuracy = 0.3
+	accuracy = -0.3
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/las/lasgun
@@ -317,7 +317,7 @@
 	force = 12
 	one_hand_penalty = 0.7
 	fire_delay = 1.5
-	accuracy = 0.6
+	accuracy = 0.1
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/las/lasgun/pistol
@@ -344,7 +344,7 @@
 	force = 15
 	one_hand_penalty = 1.5
 	fire_delay = 3.1
-	accuracy = 0.6
+	accuracy = 0.1
 	self_recharge = 1
 	origin_tech = list(TECH_COMBAT = 4, TECH_MAGNET = 4)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
@@ -379,7 +379,7 @@
 	force = 15
 	one_hand_penalty = 1.7
 	fire_delay = 3.7
-	accuracy = 0.7
+	accuracy = 0.2
 	self_recharge = 3
 	recharge_time = 9
 	origin_tech = list(TECH_COMBAT = 4, TECH_MAGNET = 4)
@@ -421,7 +421,7 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	slot_flags = SLOT_BELT|SLOT_S_STORE
 	w_class = ITEM_SIZE_NORMAL
 	force = 11
-	accuracy = 0
+	accuracy = -0.5
 	fire_delay = 1.85
 	origin_tech = list(TECH_COMBAT = 2, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
@@ -449,7 +449,7 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	slot_flags = SLOT_BELT|SLOT_S_STORE
 	w_class = ITEM_SIZE_NORMAL
 	force = 10
-	accuracy = 0
+	accuracy = -0.5
 	fire_delay = 1.2
 	charge_cost = 80
 	cell_type = /obj/item/cell/lasgun
@@ -462,7 +462,7 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	desc = "It is magnificant in handling and detail. Larger in size than most las pistols, yet more lightweight and extremely efficient in energy usage. All the luxurious makings of a weapon from Terra itself."
 	icon_state = "lordlaspistol"
 	charge_meter = FALSE //must have, due to having only 1 item state.
-	accuracy = 1
+	accuracy = 0.5
 	fire_delay = 1.5
 	charge_cost = 70
 	firemodes = list(
@@ -487,7 +487,7 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	name = "Kantrael MG Laspistol"
 	desc = "Kantrael MG is a Heavy Cadian Laspistol used by their shock regiments' NCOs. It is slow firing but pacts a punch for a laspistol. It is also possible to overcharge."
 	icon_state = "laspistol"
-	accuracy = 0.4
+	accuracy = 0
 	charge_cost = 80
 	fire_delay = 1.6
 	cell_type = /obj/item/cell/lasgun
@@ -512,7 +512,7 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	icon_state = "luciuspistol"
 	force = 10
 	/* one_hand_penalty = 0 */
-	accuracy = 0.4
+	accuracy = 0
 	charge_cost = 100
 	fire_delay = 2
 	cell_type = /obj/item/cell/lasgun
@@ -535,7 +535,7 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	w_class = ITEM_SIZE_LARGE
 	force = 15
 	one_hand_penalty = 2.2
-	accuracy = 1
+	accuracy = 0.5
 	origin_tech = list(TECH_COMBAT = 7, TECH_MAGNET = 7)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/pulse/ion
@@ -621,7 +621,7 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	w_class = ITEM_SIZE_LARGE
 	force = 15
 	one_hand_penalty = 3 //heavy af fam
-	accuracy = 0
+	accuracy = -0.5
 	self_recharge = 1
 	recharge_time = 14 // With a fire delay of 19. You fire every 2.3 seconds. 1 recharge time is 1 second. Keep recharges to 1/6 and a bit per shot. We want people to NEED to reload in combat. //dont want speedy bois
 	fire_delay = 15
@@ -668,7 +668,7 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	w_class = ITEM_SIZE_HUGE
 	force = 12
 	one_hand_penalty = 2 //heavy af fam
-	accuracy = 0.6
+	accuracy = 0.1
 	fire_delay = 16 //dont want speedy bois
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
@@ -701,7 +701,7 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	force = 10
 	one_hand_penalty = 1.1
 	fire_delay = 18.5
-	accuracy = 0.1 //it a pistol, but giga cool plasma
+	accuracy = -0.5 //it a pistol, but giga cool plasma
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/pulse/plasmapistol
@@ -734,7 +734,7 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	one_hand_penalty = 1
 	str_requirement = 20
 	fire_delay = 14.5
-	accuracy = 0.8 //it a pistol, but giga cool plasma
+	accuracy = 0.3 //it a pistol, but giga cool plasma
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/pulse/plasmapistol
@@ -756,7 +756,7 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	force = 12
 	one_hand_penalty = 1
 	fire_delay = 17.5
-	accuracy = 0.2 //it a pistol
+	accuracy = -0.2 //it a pistol
 	origin_tech = list(TECH_COMBAT = 4, TECH_MAGNET = 4)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/energy/pulse/plasmapistol
@@ -778,7 +778,7 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	item_state = "pulse_pistol"
 	force = 10
 	one_hand_penalty = 0.8 //until plasma is better balanced, wield this fancy one.
-	accuracy = 0.3
+	accuracy = 0
 	fire_delay = 17.5
 	recharge_time = 10
 	origin_tech = list(TECH_COMBAT = 4, TECH_MAGNET = 4)
@@ -803,7 +803,7 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	w_class = ITEM_SIZE_NORMAL
 	force = 10
 	one_hand_penalty = 0.6 //change later?
-	accuracy = 0.6
+	accuracy = 0.1
 	fire_delay = 16 //it a pistol, but giga cool plasma
 	origin_tech = list(TECH_COMBAT = 5, TECH_MAGNET = 5)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
@@ -828,7 +828,7 @@ obj/item/gun/energy/las/hotshot/bloodpact
 	w_class = ITEM_SIZE_NORMAL
 	force = 10
 	one_hand_penalty = 0.7 //change later?
-	accuracy = 0.5
+	accuracy = 0
 	fire_delay = 17 //it a pistol, but giga cool plasma
 	self_recharge = 9 // very good
 	origin_tech = list(TECH_COMBAT = 5, TECH_MAGNET = 5)

--- a/code/modules/projectiles/guns/projectile/mattguns.dm
+++ b/code/modules/projectiles/guns/projectile/mattguns.dm
@@ -15,7 +15,7 @@
 	fire_sound = 'sound/weapons/gunshot/auto5.ogg'
 	far_fire_sound = "sniper_fire"
 	one_hand_penalty = 2
-	accuracy = 1
+	accuracy = 0.5
 	fire_delay = 3
 	force = 15
 	sales_price = 4
@@ -88,7 +88,7 @@
 	unloaded_icon = "boltactionsharp-e"
 	unwielded_unloaded_icon = "boltactionsharp"
 	wielded_unloaded_icon = "boltaction-wielded"
-	accuracy = 1
+	accuracy = 0.5
 	sales_price = 10
 
 /*
@@ -187,7 +187,7 @@
 	name = "\improper Triangong 4-46"
 	desc = "The stub rifle is a common sight across the galaxy, a hunting rifle firing large-bore rounds. This one is made of quality materials and has been laboured over extensively by expert hands."
 	one_hand_penalty = 1.5
-	accuracy = 1.2
+	accuracy = 1
 	fire_delay = 4
 	sales_price = 23
 	icon_state = "boltactionsharp"
@@ -235,7 +235,7 @@
 	fire_delay = 3.5
 	gping = FALSE
 	sales_price = 10
-	accuracy = 0.8
+	accuracy = 0.3
 
 /obj/item/gun/projectile/shotgun/pump/boltaction/shitty/glory
 	name = "\improper Crucible Pattern Stub Rifle"
@@ -243,7 +243,7 @@
 	icon_state = "oldglory"
 	item_state = "boltactionsharp"
 	empty_icon = "oldglory-e"
-	accuracy = 1.4
+	accuracy = 1
 	sales_price = 16
 
 //Paryying.
@@ -270,7 +270,7 @@
 	fire_delay = 6
 	move_delay= 2.5
 	one_hand_penalty = 1.7
-	accuracy = 1.1
+	accuracy = 0.6
 	force = 30
 	sharp = 1
 	screen_shake = 0.5
@@ -361,7 +361,7 @@
 	ammo_type = /obj/item/ammo_casing/shotgun
 	empty_icon = "voxlegisnew-e"
 	one_hand_penalty = 1.4
-	accuracy = 0.5
+	accuracy = 0
 	fire_delay= 3
 	sales_price = 10 // SHOTGUNS HAVE SLOWDOWN IN THEIR PARENT shotgun/pump -- DO NOT APPLY SLOWDOWN TO SHOTGUNS 
 
@@ -370,7 +370,7 @@
 	desc = "A rare specialty Magrave shotgun long out of production - this retired veteran has been well maintained over the years by it's previous owners."
 	move_delay= 2.5
 	one_hand_penalty = 1
-	accuracy = 0.8
+	accuracy = 0.3
 	fire_delay = 2
 	sales_price = 15
 
@@ -386,7 +386,7 @@
 	empty_icon = "hunting-sawn"
 	one_hand_penalty = 0.4
 	fire_delay = 2
-	accuracy = 0
+	accuracy = -0.5
 	armor_penetration = 0
 	sales_price = 5
 
@@ -491,7 +491,7 @@
 	fire_delay = 3.5
 	automatic = 0
 	one_hand_penalty = 1.6
-	accuracy = 1
+	accuracy = 0.5
 	sales_price = 16
 	caliber = "a762"
 	ammo_type = /obj/item/ammo_casing/a762
@@ -532,7 +532,7 @@
 	fire_delay = 2.5
 	automatic = 0.2
 	one_hand_penalty = 1.4
-	accuracy = 1.5
+	accuracy = 1
 	sales_price = 10
 
 	loaded_icon = "commando"
@@ -578,7 +578,7 @@
 	gun_type = GUN_LMG
 	move_delay= 5
 	one_hand_penalty = 2.2 //it is a HMG, but its also not a bolter, this is probably enough penalty
-	accuracy = 0.5
+	accuracy = 0
 	fire_delay = 1.6
 	sales_price = 21
 
@@ -640,7 +640,7 @@
 	desc = "A rugged belt-fed stubber that is long out of service. This one seems to have been diligently maintained over the years."
 	move_delay= 4.5
 	one_hand_penalty = 2
-	accuracy = 1
+	accuracy = 0.5
 	fire_delay = 1.5
 	sales_price = 22
 
@@ -659,7 +659,7 @@
 	slot_flags = SLOT_BACK|SLOT_S_STORE
 	w_class = ITEM_SIZE_HUGE
 	one_hand_penalty = 0.8
-	accuracy = 0.5
+	accuracy = 0
 	fire_delay = 1.7
 	sales_price = 8
 
@@ -696,7 +696,7 @@
 	icon_state = "autorifle"
 	item_state = "autorifle"
 	one_hand_penalty = 0.6
-	accuracy = 0.7
+	accuracy = 0.2
 	fire_delay = 1.6
 	sales_price = 18
 
@@ -725,7 +725,7 @@
 	loaded_icon = "auto_grim"
 	fire_sound = 'sound/weapons/guns/fire/sfrifle_fire.ogg'
 	one_hand_penalty = 1
-	accuracy = 0.5
+	accuracy = 0
 	fire_delay = 1.6
 	sales_price = 21
 
@@ -759,7 +759,7 @@
 	loaded_icon = "kriegstubber"
 	fire_sound = 'sound/weapons/guns/fire/sfrifle_fire.ogg'
 	one_hand_penalty = 1.2
-	accuracy = 0.7
+	accuracy = 0.2
 	fire_delay = 1.5
 	sales_price = 20
 
@@ -806,7 +806,7 @@
 	w_class = ITEM_SIZE_HUGE
 	fire_sound = 'sound/weapons/gunshot/auto2.ogg'
 	one_hand_penalty = 1.4
-	accuracy = 0.8
+	accuracy = 0.3
 	automatic = 0
 	fire_delay = 4
 	sales_price = 20
@@ -845,7 +845,7 @@
 	w_class = ITEM_SIZE_HUGE
 	fire_sound = 'sound/weapons/gunshot/auto2.ogg'
 	one_hand_penalty = 1.3
-	accuracy = 0.4
+	accuracy = 0
 	automatic = 1
 	fire_delay = 1.5
 	sales_price = 15
@@ -906,7 +906,7 @@
 	one_hand_penalty = 2.2
 	firemodes = list()
 	gun_type = GUN_AUTOMATIC
-	accuracy = 1
+	accuracy = 0.5
 	sales_price = 60
 
 	firemodes = list(
@@ -1003,7 +1003,7 @@
 	burst = 1
 	firemodes = list()
 	gun_type = GUN_AUTOMATIC
-	accuracy = 0
+	accuracy = -0.5
 	sales_price = 70
 
 	firemodes = list(
@@ -1046,7 +1046,7 @@
 	burst = 1
 	firemodes = list()
 	gun_type = GUN_AUTOMATIC
-	accuracy = 0.5
+	accuracy = 0
 	sales_price = 85
 
 	firemodes = list(
@@ -1067,7 +1067,7 @@
 	icon_state = "1kbolter"
 	loaded_icon = "1kbolter-30"
 	unloaded_icon = "1kbolter-e"
-	accuracy = 1.2
+	accuracy = 0.5
 /obj/item/gun/projectile/lockebolter/infernobolter/update_icon()
 	..()
 	if(ammo_magazine)
@@ -1108,7 +1108,7 @@
 	fire_delay = 1.9
 	burst = 1
 	firemodes = list()
-	accuracy = 1.4 //only one gun per round so yeah
+	accuracy = 0.6 //only one gun per round so yeah
 	gun_type = GUN_AUTOMATIC
 	sales_price = 120
 
@@ -1152,7 +1152,7 @@
 	caliber = ".75"
 	can_jam = TRUE
 	one_hand_penalty = 1
-	accuracy = -1.5
+	accuracy = -2
 	ammo_type = /obj/item/ammo_casing/ork/shoota
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/ork/shoota
@@ -1211,7 +1211,7 @@
 	wielded_unloaded_icon = "autoshotty-wielded-e"
 	force = 20 // smg
 	one_hand_penalty = 1
-	accuracy = -1
+	accuracy = -1.5
 	sales_price = 1
 
 	firemodes = list(
@@ -1242,7 +1242,7 @@
 	caliber = ".75"
 	can_jam = TRUE
 	one_hand_penalty = 2
-	accuracy = -2
+	accuracy = -2.5
 	gun_type = GUN_AUTOMATIC
 	fire_delay = 4
 	burst = 5
@@ -1281,7 +1281,7 @@
 	wielded_unloaded_icon = "autoshotty-wielded-e"
 	force = 15
 	one_hand_penalty = 2
-	accuracy = -0.5
+	accuracy = -1
 	gun_type = GUN_SNIPER
 	sales_price = 1
 
@@ -1332,7 +1332,7 @@
 		list(mode_name="automatic",   	 burst=5, fire_delay=1.5, one_hand_penalty=2, burst_accuracy=list(0,1,1), dispersion=null, automatic = 2)
 		)
 	gun_type = GUN_AUTOMATIC
-	accuracy = 1
+	accuracy = 0.5
 
 /obj/item/gun/projectile/eldar/scatapult/update_icon()
 	..()
@@ -1362,7 +1362,7 @@
 	str_requirement = 11
 	move_delay= 4
 	one_hand_penalty = 4
-	accuracy = 0.5 //Good gun, well maintained by the Mechanicus
+	accuracy = 0.1 //Good gun, well maintained by the Mechanicus
 	fire_delay = 3.5
 	slot_flags = SLOT_BACK|SLOT_S_STORE
 	magazine_type = /obj/item/ammo_magazine/radcarbine
@@ -1397,7 +1397,7 @@
 	str_requirement = 11
 	move_delay= 2
 	one_hand_penalty = 1
-	accuracy = 0.6 //Good gun, well maintained by the Mechanicus
+	accuracy = 0.1 //Good gun, well maintained by the Mechanicus
 	fire_delay = 2.5
 	slot_flags = SLOT_BELT|SLOT_S_STORE
 	magazine_type = /obj/item/ammo_magazine/radcarbine/radpistol

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -251,7 +251,7 @@
 	fire_sound='sound/weapons/lasgun.ogg'
 	wall_hitsound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "pulse1"
-	damage = 4
+	damage = 7
 	armor_penetration = 70
 
 /obj/item/projectile/energy/pulse/pulserail

--- a/maps/delta/warhammer-2.dmm
+++ b/maps/delta/warhammer-2.dmm
@@ -4600,9 +4600,6 @@
 	pixel_y = 6
 	},
 /obj/item/gun/energy/las/lasgun/lucius,
-/obj/item/gun/energy/las/lasgun/lucius{
-	pixel_y = -6
-	},
 /obj/effect/floor_decal/industrial/mark,
 /turf/simulated/floor/tiled{
 	color = "grey"
@@ -6344,11 +6341,17 @@
 /area/cadiaoutpost/oa/service/chapel/chapelsurgery)
 "fEF" = (
 /obj/structure/table/rack,
-/obj/item/gun/energy/las/lasgun/accatran,
 /obj/effect/floor_decal/industrial/mark,
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "tube1"
+	},
+/obj/item/gun/energy/las/lasgun/longlas{
+	pixel_y = 8
+	},
+/obj/item/gun/energy/las/lasgun/accatran,
+/obj/item/gun/energy/las/hotshot{
+	pixel_y = -8
 	},
 /turf/simulated/floor/tiled{
 	color = "grey"
@@ -17606,11 +17609,14 @@
 /turf/simulated/floor/trench,
 /area/cadiaoutpost/new_hive/caves)
 "oUP" = (
-/obj/machinery/door/airlock/cone{
-	req_one_access = list(63,331,10);
-	name = "Close Quarters Training Room"
+/obj/effect/floor_decal/newcorner/shaft/corner{
+	dir = 1
 	},
-/turf/simulated/floor/factory_floor,
+/obj/effect/gibspawner/human,
+/turf/simulated/floor/tiled{
+	color = "grey";
+	icon_state = "dark1"
+	},
 /area/cadiaoutpost/oa/security/barracks)
 "oUR" = (
 /obj/effect/shuttle_landmark/ferry/cargo_start,
@@ -19141,6 +19147,17 @@
 	},
 /turf/simulated/floor/factory_floor,
 /area/cadiaoutpost/oa/magistratumpost)
+"qmJ" = (
+/obj/structure/table/graf/reinf_table{
+	icon_state = "table_horizontal2"
+	},
+/obj/item/rcd,
+/obj/item/stack/barbwire,
+/obj/item/defensive_barrier,
+/turf/simulated/floor/tiled{
+	color = "grey"
+	},
+/area/cadiaoutpost/oa/security/barracks)
 "qng" = (
 /obj/structure/bed/chair{
 	dir = 8;
@@ -19676,6 +19693,13 @@
 	icon_state = "white1"
 	},
 /area/cadiaoutpost/oa/service/inn)
+"qKN" = (
+/obj/structure/railing,
+/obj/effect/gibspawner/human,
+/turf/simulated/floor/tiled{
+	color = "grey"
+	},
+/area/cadiaoutpost/oa/security/barracks)
 "qLb" = (
 /obj/effect/floor_decal/newcorner/white/solid,
 /obj/effect/wingrille_spawn/reinforced{
@@ -28109,7 +28133,6 @@
 	},
 /obj/effect/floor_decal/newcorner/green/solid,
 /obj/item/device/binoculars,
-/obj/item/rcd,
 /turf/simulated/floor/tiled/dark{
 	color = "grey"
 	},
@@ -72314,7 +72337,7 @@ gCd
 fGN
 noi
 gZP
-lnX
+oUP
 wYk
 wYk
 wYk
@@ -73069,7 +73092,7 @@ fGN
 fGN
 fGN
 fGN
-oUP
+bpK
 fGN
 fGN
 fGN
@@ -74325,10 +74348,10 @@ tOB
 tOB
 slE
 fGN
-pVJ
+qmJ
 sey
 bMd
-wgM
+qKN
 lqV
 jPo
 srD
@@ -74834,7 +74857,7 @@ gms
 sey
 sey
 sey
-sey
+gms
 fGN
 fGN
 uyG
@@ -75840,7 +75863,7 @@ wcj
 wcj
 sey
 sey
-sey
+bpK
 sey
 wcj
 fGN


### PR DESCRIPTION
Regen Aura's effectiveness reduced overall..

Frag Explosives deal less damage.

Plasma Explosions deal more damage.

Two handed guns have less accuracy -- an average of reduction by 0.5. Also includes one handed plasma pistols since they use the same projectile as a plasma rifle.

Small edits to the guard armory, gave them a free longlas + hotshot and put some building supplies in the Tunnel Breach.