### PR TITLE
Removes Progena, replaces with Novitiate

### DIFF
--- a/code/game/jobs/job/adeptus_ministorum.dm
+++ b/code/game/jobs/job/adeptus_ministorum.dm
@@ -275,7 +275,7 @@
 	equip(var/mob/living/carbon/human/H)
 		var/current_name = H.real_name
 		..()
-		H.fully_replace_character_name("Sister-Superior [current_name]")
+		H.fully_replace_character_name("Sister [current_name]")
 		H.set_trait(new/datum/trait/death_tolerant)
 		H.set_quirk(new/datum/quirk/dead_inside) // the only thing the sisters of the orders millitant feel is the god emperor's light.
 		//"BUT THEY ARE DIVINE!!!" don't care, Sister superior is human, stop simping, im still giving them very GOOD stats.
@@ -394,7 +394,7 @@
 	equip(var/mob/living/carbon/human/H)
 		var/current_name = H.real_name
 		..()
-		H.fully_replace_character_name("Novitiate Sister [current_name]")
+		H.fully_replace_character_name("Novitae [current_name]")
 		H.set_trait(new/datum/trait/death_tolerant())
 		H.add_stats(rand(12,15), rand(12,15), rand(12,15), rand (12,15)) //Has not begun their training with the sisters yet.
 		H.add_skills(rand(5,7),rand(5,7),rand(5,7),rand(1,3),rand(5,7)) //melee, ranged, med, eng, surgery

--- a/code/game/jobs/job/adeptus_ministorum.dm
+++ b/code/game/jobs/job/adeptus_ministorum.dm
@@ -275,7 +275,7 @@
 	equip(var/mob/living/carbon/human/H)
 		var/current_name = H.real_name
 		..()
-		H.fully_replace_character_name("Sister [current_name]")
+		H.fully_replace_character_name("Sister-Superior [current_name]")
 		H.set_trait(new/datum/trait/death_tolerant)
 		H.set_quirk(new/datum/quirk/dead_inside) // the only thing the sisters of the orders millitant feel is the god emperor's light.
 		//"BUT THEY ARE DIVINE!!!" don't care, Sister superior is human, stop simping, im still giving them very GOOD stats.
@@ -307,7 +307,7 @@
 		H.vice = null
 		H.verbs += list(
 			/mob/living/carbon/human/proc/faithleaderclass)
-		to_chat(H, "<span class='notice'><b><font size=3>You are a Sister of Battle belonging to the Order of the Sacred Rose assigned to the Monastary, you serve both the Inquisition and Ecclesiarchy directly, though whom you truly serve is that of The Emperor who stands above all.</font></b></span>")
+		to_chat(H, "<span class='notice'><b><font size=3>You are a Sister of Battle assigned to the Monastary, you serve both the Inquisition and Ecclesiarchy directly, though whom you truly serve is that of The Emperor who stands above all.</font></b></span>")
 
 /datum/job/hospitaller
 	title = "Sister Hospitaller"
@@ -364,7 +364,7 @@
 
 //NOVICE - has not begun their training yet
 /datum/job/progena
-	title = "Progena"
+	title = "Novitiate"
 	department = list("Ministorum", "Medical")
 	department_flag = MED
 	minimal_player_age = 14
@@ -380,6 +380,9 @@
 	access = list(access_advchapel, access_medical, access_village)
 	minimal_access = list(access_advchapel, access_medical, access_village)
 	outfit_type = /decl/hierarchy/outfit/job/novice
+	alt_titles = list(
+	"Novitiate Hospitaller" = /decl/hierarchy/outfit/job/medical/doctor,
+		)
 	auto_rifle_skill = 7
 	semi_rifle_skill = 7
 	sniper_skill = 7
@@ -391,7 +394,7 @@
 	equip(var/mob/living/carbon/human/H)
 		var/current_name = H.real_name
 		..()
-		H.fully_replace_character_name("Progena [current_name]")
+		H.fully_replace_character_name("Novitiate Sister [current_name]")
 		H.set_trait(new/datum/trait/death_tolerant())
 		H.add_stats(rand(12,15), rand(12,15), rand(12,15), rand (12,15)) //Has not begun their training with the sisters yet.
 		H.add_skills(rand(5,7),rand(5,7),rand(5,7),rand(1,3),rand(5,7)) //melee, ranged, med, eng, surgery
@@ -401,12 +404,13 @@
 		H.adjustStaminaLoss(-INFINITY)
 		H.get_equipped_item(slot_s_store)
 		H.warfare_faction = IMPERIUM
+		H.gender = FEMALE
 		H.f_style = "shaved"
 		H.h_style = "Bob"
 		H.vice = null
 
 		to_chat(H, "<span class='notice'><b><font size=3>http://is12wiki.xyz/index.php/Guide_to_Medicine</font></b></span>")
-		to_chat(H, "<span class='notice'><b><font size=3>You are a recent arrival to the Monastery Scholam... soon you will begin your training with the sisters of the Ordos and the monks of the Ecclesiarchy, you stand at a crossroads where in which your failures and triumphs shall decide who you will become for the rest of your days. Do as you are instructed, learn from your masters and serve the God Emperor of Mankind.</font></b></span>")
+		to_chat(H, "<span class='notice'><b><font size=3>You are a recent graduate of the Scholam Progeneum, sent to Eipharius to serve alongside the redeemed Sister-Superior as she watched over the Reqliary of the local Monestary. Though you are no longer a Progena, you are not yet done learning. The Sisters and the Holy Deacon of the Adeptus Ministorum will act as your spiritual guides as you march ever further down the righteous path.</font></b></span>")
 
 /datum/job/preacher // DISABLED
 	title = "Preacher"
@@ -477,24 +481,24 @@
 				to_chat(U,"<span class='danger'><b><font size=4>THE HOLY DEACON</font></b></span>")
 				to_chat(U,"<span class='goodmood'><b><font size=3>A loyal servant to the imperium, as Deacon to the flock of the Eipharius colony you are responsible for the survival of faith, to keep the light of holy Terra and the God Emperor shining upon this dark world.</font></b></span>")
 				if(prob(4))
-					new /obj/item/device/radio/headset/headset_eng(src.loc) 
+					new /obj/item/device/radio/headset/headset_eng(src.loc)
 				if(prob(3))
-					new /obj/item/device/radio/headset/headset_sci(src.loc) 
+					new /obj/item/device/radio/headset/headset_sci(src.loc)
 			else
 				to_chat(U,"<span class='danger'><b><font size=4>THE DEACON OF WOUNDS</font></b></span>")
 				to_chat(U,"<span class='goodmood'><b><font size=3>The corruption has spread to your soul, deep within you a resonance -- a repeating vibration calls upon you to betray all that you have built. To reforge and stitch together a new world from the mangled corpses of the faithful. Lead them to the light, show them their new purpose. </font></b></span>")
 				U.add_stats(rand(14,18), rand(14,18), rand(17,21), rand(14,17))
 				if(prob(50))
-					new /obj/item/device/radio/headset/blue_team/all(src.loc) 
-				new /obj/item/reagent_containers/hypospray/autoinjector/tau(src.loc) 
+					new /obj/item/device/radio/headset/blue_team/all(src.loc)
+				new /obj/item/reagent_containers/hypospray/autoinjector/tau(src.loc)
 				var/datum/heretic_deity/deity = GOD(U.client.prefs.cult)
 					deity.add_cultist(U)
 				if(prob(8))
-					new /obj/item/device/radio/headset/headset_eng(src.loc) 
+					new /obj/item/device/radio/headset/headset_eng(src.loc)
 				if(prob(2))
-					new /obj/item/device/radio/headset/inquisition(src.loc) 
+					new /obj/item/device/radio/headset/inquisition(src.loc)
 				if(prob(6))
-					new /obj/item/device/radio/headset/headset_sci(src.loc) 
+					new /obj/item/device/radio/headset/headset_sci(src.loc)
 
 /mob/living/carbon/human/proc/faithleaderclass()
 	set name = "Select your faith"
@@ -522,11 +526,11 @@
 			if(prob(80))
 				to_chat(U,"<span class='danger'><b><font size=4>THE SWORD</font></b></span>")
 				to_chat(U,"<span class='goodmood'><b><font size=3>You are the sword that guards against the warp and seeks out it's destruction. Be wary, for those who battle against the great enemy are cursed to either die... or succumb to it.</font></b></span>")
-				new /obj/item/melee/sword/combat_knife/glaive/holy(src.loc) 
+				new /obj/item/melee/sword/combat_knife/glaive/holy(src.loc)
 			else if(prob(50))
 				to_chat(U,"<span class='danger'><b><font size=4>THE SHIELD</font></b></span>")
 				to_chat(U,"<span class='goodmood'><b><font size=3>You are the shield that protects the weak and guards the flame of his Divine Emperor.</font></b></span>")
-				new /obj/item/storage/firstaid/combat(src.loc) 
+				new /obj/item/storage/firstaid/combat(src.loc)
 			else
 				to_chat(U,"<span class='danger'><b><font size=4>THE CORRUPTED</font></b></span>")
 				to_chat(U,"<span class='goodmood'><b><font size=3>You are a traitor to the Imperium and for reasons known only to you now, shall bring corruption to it's fiefdoms. Praise the hivemind/cult/cogitae! </font></b></span>")
@@ -559,11 +563,11 @@
 			if(prob(65))
 				to_chat(U,"<span class='danger'><b><font size=4>THE SWORD</font></b></span>")
 				to_chat(U,"<span class='goodmood'><b><font size=3>You are the sword that guards against the warp and seeks out it's destruction. Be wary, for those who battle against the great enemy are cursed to either die... or succumb to it.</font></b></span>")
-				new /obj/item/melee/sword/combat_knife/glaive/holy(src.loc) 
+				new /obj/item/melee/sword/combat_knife/glaive/holy(src.loc)
 			else if(prob(25))
 				to_chat(U,"<span class='danger'><b><font size=4>THE SHIELD</font></b></span>")
 				to_chat(U,"<span class='goodmood'><b><font size=3>You are the shield that protects the weak and guards the flame of his Divine Emperor.</font></b></span>")
-				new /obj/item/storage/firstaid/combat(src.loc) 
+				new /obj/item/storage/firstaid/combat(src.loc)
 			else
 				to_chat(U,"<span class='danger'><b><font size=4>THE CORRUPTED</font></b></span>")
 				to_chat(U,"<span class='goodmood'><b><font size=3>You are a traitor to the Imperium and for reasons known only to you now, shall bring corruption to it's fiefdoms. Praise the hivemind/cult/cogitae! </font></b></span>")
@@ -700,17 +704,20 @@
 
 
 /decl/hierarchy/outfit/job/novice
-	name = OUTFIT_JOB_NAME("Progena")
-	uniform = /obj/item/clothing/under/rank/medical
-	l_ear  = /obj/item/device/radio/headset/headset_sci
+	name = OUTFIT_JOB_NAME("Novitiate")
+	l_ear = /obj/item/device/radio/headset/headset_sci
+	uniform = /obj/item/clothing/under/guard/uniform/sisterofbattle
 	neck = /obj/item/reagent_containers/food/drinks/canteen
+	suit = /obj/item/clothing/suit/sisterofbattle/training
+	belt = /obj/item/melee/sword/longsword
 	back = /obj/item/storage/backpack/satchel/warfare
 	shoes = /obj/item/clothing/shoes/jackboots
-	glasses = /obj/item/clothing/glasses/hud/health
+	id_type = /obj/item/card/id/dog_tag
+	l_pocket = /obj/item/storage/box/ifak
 	r_pocket = /obj/item/storage/box/coin
-	l_pocket = /obj/item/device/flashlight/lantern
-	id_type = /obj/item/card/id/medical
+	r_hand = /obj/item/gun/projectile/bolter_pistol/sisterofbattle
 	backpack_contents = list(
-		/obj/item/reagent_containers/food/snacks/warfare/rat = 1,
-		/obj/item/stack/thrones2 = 1,
-		/obj/item/stack/thrones3/five = 1,)
+	/obj/item/ammo_magazine/bolt_pistol_magazine = 2,
+	/obj/item/reagent_containers/food/snacks/warfare = 1,
+	/obj/item/device/flashlight/lantern = 1,
+		)

--- a/code/game/jobs/job/inquisition.dm
+++ b/code/game/jobs/job/inquisition.dm
@@ -226,7 +226,6 @@
 			new /obj/item/gun/energy/las/hotshot(src.loc)
 			new /obj/item/clothing/suit/armor/scion/trooper(src.loc)
 			new /obj/item/storage/backpack/satchel/warfare/scion(src.loc)
-			new /obj/item/clothing/head/helmet/tscion/trooper(src.loc)
 			new /obj/item/clothing/rosette(src.loc)
 
 /mob/living/carbon/human/proc/eqclass()

--- a/code/game/jobs/job/warhammer_jobs.dm
+++ b/code/game/jobs/job/warhammer_jobs.dm
@@ -31,11 +31,11 @@
 //	/datum/job/cmo,
 	/datum/job/sistersuperior,
 	/datum/job/hospitaller,
+	/datum/job/progena,
 	/datum/job/marshal,
 	/datum/job/investigator,
 	/datum/job/kasrkin,
-	/datum/job/scavenger,
-	/datum/job/progena,/*
+	/datum/job/scavenger,/*
 	/datum/job/preacher, turn preacher into pilgrim fate */
 	/datum/job/innkeeper,
 	/datum/job/underboss,

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -115,6 +115,21 @@
 	icon = 'icons/obj/weapons/melee/misc.dmi'
 	w_class = ITEM_SIZE_NORMAL
 
+/obj/item/melee/sword/longsword
+	name = "longsword"
+	desc = "A long, well-balanced blade. Good for keeping enemies at bay."
+	icon = 'icons/obj/weapons/melee/misc.dmi'
+	icon_state = "longsword"
+	item_state = "longsword"
+	attack_verb = list("slashed")
+	force = 30
+	force_wielded = 35
+	armor_penetration = 15
+	block_chance = 35
+	weapon_speed_delay = 7
+	w_class = ITEM_SIZE_NORMAL
+
+
 
 
 //////////////
@@ -140,7 +155,7 @@
 	sales_price = 0
 	weapon_speed_delay = 8
 	armor = list(melee = 15, bullet = 20, laser = 20, energy = 10, bomb = 10, bio = 0, rad = 0)
-	
+
 
 /obj/item/melee/sword/commissword/sabre
 	name = "Sabre"
@@ -409,7 +424,7 @@
 	force = 30
 	force_wielded = 41
 	armor_penetration = 15
-	block_chance = 25 
+	block_chance = 25
 	weapon_speed_delay = 8
 	sales_price = 0
 
@@ -589,7 +604,7 @@
 	throwforce = 22
 	block_chance = 24
 	weapon_speed_delay = 8
-	w_class = ITEM_SIZE_LARGE 
+	w_class = ITEM_SIZE_LARGE
 	armor = list(melee = 10, bullet = 20, laser = 20, energy = 10, bomb = 10, bio = 0, rad = 0)
 
 /obj/item/melee/trench_axe/bspear
@@ -605,7 +620,7 @@
 	block_chance = 22
 	weapon_speed_delay = 8
 	edge = 0
-	w_class = ITEM_SIZE_LARGE 
+	w_class = ITEM_SIZE_LARGE
 	armor = list(melee = 10, bullet = 15, laser = 15, energy = 10, bomb = 10, bio = 0, rad = 0)
 
 /obj/item/melee/trench_axe/bspear/hunter
@@ -630,7 +645,7 @@
 	block_chance = 24
 	weapon_speed_delay = 10
 	edge = 0
-	w_class = ITEM_SIZE_LARGE 
+	w_class = ITEM_SIZE_LARGE
 
 /obj/item/melee/trench_axe/lance/adamantine
 	name = "adamantine fuscina"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -1223,11 +1223,11 @@ obj/item/clothing/suit/armor
 	species_restricted = list(SPECIES_HUMAN)
 
 /obj/item/clothing/suit/sisterofbattle/training
-	name = "Novice Power Armor"
-	desc = "The Ancient and Deconsecrated Power Armour adorned by Novice Militants during their training in Eipharius' Monastarium. Stripped of almost all iconography and with damaged plating, and has scriptures across it's surface speaking of The Beatie and her crusade across the Sabbat worlds."
+	name = "Novice Armor"
+	desc = "The Ancient and Deconsecrated Carapace Armour adorned by Novice Militants during their training in Eipharius' Monastarium. Stripped of almost all iconography and with damaged plating. It has scriptures across it's surface, recounting the triumph and martyrdom of Saint Katherine."
 	icon_state = "ooml"
 	item_state = "ooml"
-	armor = list(melee = 54, bullet = 60, laser = 60, energy = 50, bomb = 60, bio = 80, rad = 70)
+	armor = list(melee = 44, bullet = 44, laser = 44, energy = 20, bomb = 40, bio = 50, rad = 50)
 	sales_price = 20
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET
 	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
@@ -1235,6 +1235,7 @@ obj/item/clothing/suit/armor
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	flags_inv = HIDEJUMPSUIT
 	species_restricted = list(SPECIES_HUMAN)
+
 /obj/item/clothing/suit/sisterofbattle/training/New()
 	..()
 	slowdown_per_slot[slot_wear_suit] = 0.3

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -1223,11 +1223,11 @@ obj/item/clothing/suit/armor
 	species_restricted = list(SPECIES_HUMAN)
 
 /obj/item/clothing/suit/sisterofbattle/training
-	name = "Novice Armor"
+	name = "Novitae Power Armor"
 	desc = "The Ancient and Deconsecrated Carapace Armour adorned by Novice Militants during their training in Eipharius' Monastarium. Stripped of almost all iconography and with damaged plating. It has scriptures across it's surface, recounting the triumph and martyrdom of Saint Katherine."
 	icon_state = "ooml"
 	item_state = "ooml"
-	armor = list(melee = 44, bullet = 44, laser = 44, energy = 20, bomb = 40, bio = 50, rad = 50)
+	armor = list(melee = 54, bullet = 51, laser = 48, energy = 20, bomb = 40, bio = 50, rad = 50)
 	sales_price = 20
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET
 	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS

--- a/maps/delta/warhammer-2.dmm
+++ b/maps/delta/warhammer-2.dmm
@@ -7223,6 +7223,13 @@
 	icon_state = "wood_1tileendtable";
 	dir = 4
 	},
+/obj/item/fluff_items/skull{
+	pixel_y = 4
+	},
+/obj/item/flame/candle/church{
+	pixel_y = 7;
+	pixel_x = 8
+	},
 /turf/simulated/floor/fancyfloor/carpet/blue{
 	dir = 8
 	},
@@ -21873,6 +21880,12 @@
 	},
 /turf/simulated/floor/factory_floor,
 /area/cadiaoutpost/oa/service/chapel/chapeldorm)
+"ueA" = (
+/obj/effect/landmark/start/ministorum/novice{
+	name = "Novitiate"
+	},
+/turf/unsimulated/miningtime,
+/area/cadiaoutpost/new_hive/caves)
 "ueY" = (
 /obj/structure/grille/metal_bars/cell,
 /turf/simulated/floor/factory_floor,
@@ -23913,7 +23926,7 @@
 	icon_state = "migbed"
 	},
 /obj/effect/landmark/start/ministorum/novice{
-	name = "Progena"
+	name = "Novitiate"
 	},
 /turf/simulated/floor/fancyfloor/coralg,
 /area/cadiaoutpost/oa/service/chapel/chapeldorm)
@@ -40401,7 +40414,7 @@ tOB
 tOB
 tOB
 tOB
-tOB
+ueA
 tOB
 tOB
 tOB


### PR DESCRIPTION
Since nobody was playing progena, I've replaced them with novitiate sisters. Players can pick to be either militant or hospitaller novitiates 

This has been done to both fit more with the newer lore and also to increase church player count. People don't really play ministorum roles unless they're Adepta Sororitas roles, and absolutely nobody was playing progena. 

Should not hurt game balance. Novitiate armor stats are pretty abysmal. They do not have proper power armor and have stats similar to guardsmen if they are militants.

Map changes are purely spawn changes to make sure novitiates spawn in their room as well as adding a skull and a candle to the deacon's office because it looks rad.

There was an inquisition helmet causing an error which has now been removed.
