### PR TITLE
Temp Big Update

### DIFF
--- a/code/datums/outfits/jobs/medical.dm
+++ b/code/datums/outfits/jobs/medical.dm
@@ -56,6 +56,7 @@
 	/obj/item/stack/thrones2/five = 1,
 	/obj/item/stack/thrones3/ten = 1,
 	/obj/item/clothing/rosarius = 1,
+	/obj/item/book/manual/ecc = 1,
 	/obj/item/clothing/accessory/holster/waist = 1,
 	/obj/item/ammo_magazine/c50/ms = 2,
 	/obj/item/gun/projectile/revolver/mateba = 1

--- a/code/game/jobs/job/adeptus_ministorum.dm
+++ b/code/game/jobs/job/adeptus_ministorum.dm
@@ -676,7 +676,8 @@
 		/obj/item/gun/projectile/bolter_pistol/sisterofbattle = 1,
 		/obj/item/ammo_magazine/bolt_pistol_magazine = 2,
 		/obj/item/clothing/accessory/holster/waist = 1,
-		/obj/item/device/flashlight/lantern = 1
+		/obj/item/device/flashlight/lantern = 1,
+		/obj/item/book/manual/ecc = 1
 		)
 
 /decl/hierarchy/outfit/job/sisterofbattle
@@ -702,6 +703,7 @@
 	/obj/item/reagent_containers/food/snacks/warfare = 1,
 	/obj/item/clothing/mask/gas/explorer = 1,
 	/obj/item/device/flashlight/lantern = 1,
+	/obj/item/book/manual/ecc = 1,
 	/obj/item/stack/thrones2/ten = 1
 	)
 

--- a/code/game/jobs/job/inquisition.dm
+++ b/code/game/jobs/job/inquisition.dm
@@ -329,6 +329,7 @@
 	/obj/item/stack/thrones/five = 1,
 	/obj/item/stack/thrones2/ten = 1,
 	/obj/item/stack/thrones3/twenty = 1,
+	/obj/item/book/manual/inq = 1,
 	/obj/item/card/id/syndicate = 1
 	)
 
@@ -357,6 +358,7 @@
 	/obj/item/device/flashlight/lantern = 1,
 	/obj/item/stack/thrones/five = 1,
 	/obj/item/stack/thrones2/ten = 1,
+	/obj/item/book/manual/inq = 1,
 	/obj/item/card/id/syndicate = 1
 	)
 

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -311,6 +311,7 @@ Template:
 				/obj/item/clothing/accessory/armguards/riot = 6,
 				/obj/item/clothing/glasses/cadiangoggles/elite = 2,
 				/obj/item/clothing/head/helmet/guardhelmet/carapace = 1,
+				/obj/item/storage/backpack/satchel/heavy = 1,
 				/obj/item/clothing/accessory/legguards/riot = 6)
 
 /obj/random/loot/lightmelee
@@ -541,7 +542,8 @@ Template:
 		/obj/item/gun/projectile/automatic/autogrim/krieg = 1,
 		/obj/item/gun/projectile/automatic/agripinaaii = 1,
 		/obj/item/gun/projectile/automatic/messina = 1,
-		/obj/item/gun/projectile/thrower = 4
+		/obj/item/gun/projectile/thrower = 4,
+		/obj/item/storage/backpack/satchel/heavy = 1
 	)
 
 
@@ -641,6 +643,7 @@ Template:
 				/obj/item/storage/pill_bottle/happy = 1,
 				/obj/item/stack/material/silver/ten = 1,
 				/obj/item/stack/material/glass/fifty = 1,
+				/obj/item/clothing/under/rank/victorian = 1,
 				/obj/item/stack/material/steel/fifty = 2)
 
 /obj/random/loot/randomitemcaves // make this a grenade spawn?
@@ -662,6 +665,8 @@ Template:
 				/obj/item/stack/thrones2/ten = 1,
 				/obj/item/grenade/frag/high_yield/homemade = 1,
 				/obj/item/grenade/frag = 1,
+				/obj/item/storage/backpack/satchel/heavy = 1,
+				/obj/item/clothing/under/rank/victorian = 1,
 				/obj/item/grenade/frag/high_yield/krak = 1)
 
 /obj/random/loot/randomitemtown
@@ -678,11 +683,13 @@ Template:
 				/obj/item/clothing/suit/armor/militia = 2,
 				/obj/item/melee/sword/combat_knife = 1,
 				/obj/item/stack/thrones2/ten = 2,
+				/obj/item/storage/backpack/satchel/heavy = 1,
 				/obj/item/clothing/accessory/holster/waist = 3,
 				/obj/item/clothing/accessory/storage/webbing = 5,
 				/obj/item/storage/belt/utility/full = 2,
 				/obj/item/clothing/accessory/legguards = 2,
 				/obj/item/clothing/accessory/armguards/ballistic = 2,
+				/obj/item/clothing/under/rank/victorian = 1,
 				/obj/item/grenade/frag/high_yield/homemade = 1)
 
 

--- a/code/game/objects/items/devices/mechanicustoys.dm
+++ b/code/game/objects/items/devices/mechanicustoys.dm
@@ -157,7 +157,7 @@
 	block_chance = 20 //20 block chance, same block chance, force and pen as brutal chainsword but harder to get
 	force = 50
 	force_wielded = 60
-	armor_penetration = 55 //high penetration due to it being a power axe, weaker than power sword due to moderate block chance.
+	armor_penetration = 21 //high penetration due to it being a power axe, weaker than power sword due to moderate block chance.
 	sharp = TRUE
 	edge = TRUE
 //	obj_flags = OBJ_FLAG_CONDUCTIBLE //me on my way to get shocked after flinging a power axe at a power wire cause it somehow is conductible
@@ -266,9 +266,9 @@ obj/item/device/neuraladapter/attack(mob/living/carbon/human/skitarii/C, mob/liv
 	wielded_icon = "pcsword"
 	slot_flags = SLOT_BELT|SLOT_BACK|SLOT_S_STORE
 	str_requirement = 20
-	force = 50
+	force = 42
 	force_wielded = 60
-	armor_penetration = 50
+	armor_penetration = 21
 	block_chance = 45 //apothecary nartheciums can be used for blocking better, due to being essentially a extension of the apothecaries body and being insanely armored.
 
 /obj/item/melee/chain/pcsword/narthecium/apot/dropped() //since nodrop is fucked this will deal with it for now.

--- a/code/game/objects/items/weapons/baton.dm
+++ b/code/game/objects/items/weapons/baton.dm
@@ -43,6 +43,7 @@
 	item_state = "WU-club"
 	force = 25 //These things pack a punch.
 	block_chance = 25
+	armor_penetration = 20
 
 /obj/item/melee/classic_baton/trench_club/New()
 	..()
@@ -107,7 +108,7 @@
 	icon_state = "crozius"
 	item_state = "crozius"
 	force = 30 //in conjunction with ass tardes str this thing is insane
-	armor_penetration = 60
+	armor_penetration = 22
 	throwforce = 1
 	throw_speed = 1
 	throw_range = 1

--- a/code/game/objects/items/weapons/cane.dm
+++ b/code/game/objects/items/weapons/cane.dm
@@ -67,7 +67,7 @@
 	block_chance = 40
 	force = 31
 	force_wielded = 35
-	armor_penetration = 15
+	armor_penetration = 19
 	weapon_speed_delay = 7
 	sharp = 1
 	w_class = ITEM_SIZE_NORMAL

--- a/code/game/objects/items/weapons/material/swords.dm
+++ b/code/game/objects/items/weapons/material/swords.dm
@@ -13,7 +13,7 @@
 	force = 30
 	force_wielded = 40
 	block_chance = 35
-	armor_penetration = 25
+	armor_penetration = 16
 	// force_divisor = 0.8 // Do not turn this back on.
 	// thrown_force_divisor = 0.2 //
 	sharp = 1 //sharp or blunt, blunt causes broken bones, sharp causes organ damage and extra bleeding.
@@ -148,7 +148,7 @@
 	force = 22
 	force_wielded = 26
 	block_chance = 25
-	armor_penetration = 20
+	armor_penetration = 16
 	weapon_speed_delay = 7
 	sharp = 1
 	throw_speed = 1
@@ -172,5 +172,5 @@
 	slot_flags = SLOT_BELT
 	sales_price = 0
 	weapon_speed_delay = 7
-	armor_penetration = 31
+	armor_penetration = 19
 

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/weapons/melee/energy.dmi'
 	sharp = 0
 	edge = 0
-	armor_penetration = 50
+	armor_penetration = 20
 	atom_flags = ATOM_FLAG_NO_BLOOD
 
 /obj/item/melee/energy/proc/activate(mob/living/user)
@@ -211,7 +211,7 @@
 	desc = "A concentrated beam of energy in the shape of a blade. Very stylish... and lethal."
 	icon_state = "blade"
 	force = 40 //Normal attacks deal very high damage - about the same as wielded fire axe
-	armor_penetration = 50
+	armor_penetration = 21
 	sharp = 1
 	edge = 1
 	anchored = 1    // Never spawned outside of inventory, should be fine.
@@ -289,7 +289,7 @@
 	active_throwforce = 18
 	icon = 'icons/obj/guardpower_gear_32xOBJ.dmi'
 	force = 34
-	armor_penetration = 60
+	armor_penetration = 25
 	throwforce = 15
 	throw_speed = 1
 	throw_range = 4
@@ -359,7 +359,7 @@
 	throw_speed = 1
 	throw_range = 1
 	weapon_speed_delay = 8
-	armor_penetration = 55
+	armor_penetration = 23
 	edge = 1
 	sharp = 1
 	block_chance = 15
@@ -413,7 +413,7 @@
 	str_requirement = 18 //this shouldn't even be here but just in case of someone abusing bugs to get the apothecary's power armor
 	force = 30 //sharp enough to penetrate ceramite and adamantium alike
 	block_chance = 10 //apothecaries are based
-	armor_penetration = 50 //VERY fucking sharp
+	armor_penetration = 20 //VERY fucking sharp
 	sharp = TRUE
 	hitsound = 'sound/weapons/chainsword.ogg'
 	drop_sound = 'sound/items/handle/axe_drop.ogg'

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -61,11 +61,12 @@
 	name = "scrap mace"
 	desc = "A mace normally used by the ork meks, made of scrap."
 	str_requirement = 13
-	armor_penetration = 35 //Crushing damage
+	armor_penetration = 20 //Crushing damage
 	force = 35
 	icon = 'icons/obj/weapons/melee/misc.dmi'
 	icon_state = "mekmace"
 	item_state = "mekmace"
+	str_requirement = 22
 
 /obj/item/material/mekmace/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 
@@ -89,7 +90,7 @@
 	hitsound = 'sound/weapons/whip.ogg'
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	slot_flags = SLOT_BELT
-	armor_penetration = 45
+	armor_penetration = 20
 	force = 12
 	block_chance = 35
 	throwforce = 7
@@ -137,7 +138,7 @@
 	item_state = "tzbook"
 	slot_flags = SLOT_BELT
 	force = 30
-	armor_penetration = 35
+	armor_penetration = 21
 	throwforce = 100 //In warp books hit you
 	w_class = ITEM_SIZE_NORMAL
 	attack_verb = list("bashed", "bonked", "smashed")
@@ -151,7 +152,7 @@
 			H.say("CHAR BELOK TEZANIUM!")
 			C.add_event("Tzbook", /datum/happiness_event/Tzbook/Ext)
 			C.happiness -= 1
-			C.hallucination(100, 999)
+			C.hallucination(100, 200)
 			C.confused = 50
 			C.apply_effects( stun = 30, agony = 100,)
 		else
@@ -170,5 +171,5 @@
 		H.apply_effects(stun = 120, agony = 220)
 		to_chat(user, "<span class='phobia'>The words jump off of the page and burrow into your skull!</span>")
 		H.add_event("Tzbook", /datum/happiness_event/Tzbook/Ext)
-		H.hallucination(1000, 999)
-		H.confused = 240
+		H.hallucination(100, 250)
+		H.confused = 20

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -218,9 +218,29 @@
 	name = "satchel"
 	desc = "A trendy looking satchel."
 	icon_state = "satchel-norm"
+	max_storage_space = DEFAULT_BOX_STORAGE +2
+	slot_flags = SLOT_BACK|SLOT_S_STORE//In your back or your second back slot. Backpacks can only go in the main one though.
+	is_satchel = TRUE
+
+/obj/item/storage/backpack/satchel/New()
+	..()
+	slowdown_per_slot[slot_back] = 0.04
+	slowdown_per_slot[slot_r_hand] = 0.04
+	slowdown_per_slot[slot_l_hand] = 0.04
+
+/obj/item/storage/backpack/satchel/heavy
+	name = "heavy rucksack"
+	desc = "A heavy rucksack."
+	icon_state = "warfare_satchel"
 	max_storage_space = DEFAULT_BOX_STORAGE +4
 	slot_flags = SLOT_BACK|SLOT_S_STORE//In your back or your second back slot. Backpacks can only go in the main one though.
 	is_satchel = TRUE
+
+/obj/item/storage/backpack/satchel/New()
+	..()
+	slowdown_per_slot[slot_back] = 0.08
+	slowdown_per_slot[slot_r_hand] = 0.08
+	slowdown_per_slot[slot_l_hand] = 0.08
 
 /obj/item/storage/backpack/satchel/warfare
 	desc = "Fit for war, and not much else."

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -24,7 +24,7 @@
 	sales_price = 1
 	weapon_speed_delay = 6
 	status = 1
-	armor_penetration = 15 //Blunt force transfers through a lot of equipment.
+	armor_penetration = 17 //Blunt force transfers through a lot of equipment.
 
 /obj/item/melee/baton/handle_shield(mob/living/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
 	if(default_sword_parry(user, damage, damage_source, attacker, def_zone, attack_text))
@@ -280,7 +280,7 @@
 	atom_flags = ATOM_FLAG_NO_BLOOD
 	origin_tech = list(TECH_MAGNET = 2, TECH_COMBAT = 2)
 	attack_verb = list("beaten", "smashed")
-	armor_penetration = 45 //Power maul
+	armor_penetration = 19 //Power maul
 
 /obj/item/melee/powermaul/apply_hit_effect(mob/living/target, mob/living/user, var/hit_zone)
 	if(isrobot(target))
@@ -339,7 +339,7 @@
 	atom_flags = ATOM_FLAG_NO_BLOOD
 	origin_tech = list(TECH_MAGNET = 2, TECH_COMBAT = 2)
 	attack_verb = list("violated", "penetrated", "infested")
-	armor_penetration = 70 //Genestealer magic.
+	armor_penetration = 19 //Genestealer magic.
 no
 /obj/item/melee/baton/nidstun/dropped() //since nodrop is fucked this will deal with it for now.
 	..()

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -17,7 +17,7 @@
 	force = 30
 	force_wielded = 40
 	block_chance = 35
-	armor_penetration = 18
+	armor_penetration = 16
 	sharp = 1 //sharp or blunt, blunt causes broken bones, sharp causes organ damage and extra bleeding.
 	edge = 1 //edge or not edged, edged has a higher chance of cutting limbs off, no edge has more chance of breaking limb
 	attack_verb = list("slashed", "sliced")
@@ -109,7 +109,7 @@
 	item_state = "spatha"
 	force = 30
 	force_wielded = 35
-	armor_penetration = 18
+	armor_penetration = 16
 	block_chance = 35 //It's short length does it no favors in this regard
 	weapon_speed_delay = 7
 	icon = 'icons/obj/weapons/melee/misc.dmi'
@@ -124,7 +124,7 @@
 	attack_verb = list("slashed")
 	force = 30
 	force_wielded = 35
-	armor_penetration = 20
+	armor_penetration = 16
 	block_chance = 35
 	weapon_speed_delay = 7
 	w_class = ITEM_SIZE_NORMAL
@@ -165,7 +165,7 @@
 	item_state = "sabre"
 	block_chance = 65
 	sales_price = 0
-	armor_penetration = 15
+	armor_penetration = 16
 
 /obj/item/melee/sword/choppa
 	name = "choppa"
@@ -176,7 +176,7 @@
 	item_state = "choppa"
 	attack_verb = list("stabbed", "chopped", "cut", "sliced")
 	force = 33
-	armor_penetration = 25
+	armor_penetration = 20
 	block_chance = 35
 	sharp = 1
 	hitsound = "slash_sound"
@@ -185,6 +185,7 @@
 	slot_flags = SLOT_BELT
 	sales_price = 0
 	weapon_speed_delay = 9
+	str_requirement = 22
 
 ///////////////
 //CHAINSWORDS//
@@ -199,7 +200,7 @@
 	str_requirement = 12
 	force = 32
 	force_wielded = 37
-	armor_penetration = 40
+	armor_penetration = 20
 	block_chance = 15
 	sharp = 1
 	edge = 1
@@ -224,7 +225,7 @@
 	force = 33
 	force_wielded = 38
 	str_requirement = 13
-	armor_penetration = 42
+	armor_penetration = 21
 	block_chance = 20
 
 /obj/item/melee/chain/gold
@@ -237,7 +238,7 @@
 	force = 29
 	force_wielded = 35
 	str_requirement = 13
-	armor_penetration = 42
+	armor_penetration = 19
 
 /obj/item/melee/chain/mercycs
 	name = "Locke Pattern Double-Edged Chainsword"
@@ -250,7 +251,7 @@
 	str_requirement = 13
 	force = 37
 	force_wielded = 42
-	armor_penetration = 42
+	armor_penetration = 22
 	block_chance = 12
 	weapon_speed_delay = 10
 	sharp = 1
@@ -274,7 +275,7 @@
 	str_requirement = 12
 	force_wielded = 38
 	force = 33
-	armor_penetration = 46
+	armor_penetration = 21
 	weapon_speed_delay = 8
 	block_chance = 20
 	sharp = 1
@@ -298,7 +299,7 @@
 	str_requirement = 18
 	force = 38
 	force_wielded = 44
-	armor_penetration = 52
+	armor_penetration = 22
 	sharp = 1
 	edge = 1
 	hitsound = 'sound/weapons/chainsword.ogg'
@@ -321,7 +322,7 @@
 	str_requirement = 14 // It's downsides of size are represented in it's one handed damage.
 	force = 28 // Physically impossible to wield effectively one handed unless Astartes/Ork.
 	force_wielded = 45
-	armor_penetration = 42
+	armor_penetration = 21
 	block_chance = 25
 	sharp = 1
 	edge = 1
@@ -346,7 +347,7 @@
 	str_requirement = 16
 	force = 36
 	force_wielded = 43
-	armor_penetration = 50
+	armor_penetration = 21
 	block_chance = 10
 	sharp = 1
 	edge = 1
@@ -387,7 +388,7 @@
 	item_state = "spatha"
 	force = 27
 	force_wielded = 29
-	armor_penetration = 25
+	armor_penetration = 17
 	block_chance = 35
 	weapon_speed_delay = 6
 	icon = 'icons/obj/weapons/melee/misc.dmi'
@@ -399,7 +400,7 @@
 	color = "#848484"
 	force = 29
 	force_wielded = 31
-	armor_penetration = 30
+	armor_penetration = 18
 	block_chance = 37
 	weapon_speed_delay = 6
 	sales_price = 0
@@ -411,7 +412,7 @@
 	item_state = "claymore"
 	force = 28
 	force_wielded = 38
-	armor_penetration = 20
+	armor_penetration = 17
 	block_chance = 20
 	weapon_speed_delay = 8
 	icon = 'icons/obj/weapons/melee/misc.dmi'
@@ -423,7 +424,7 @@
 	color = "#848484"
 	force = 30
 	force_wielded = 41
-	armor_penetration = 25
+	armor_penetration = 18
 	block_chance = 25
 	weapon_speed_delay = 8
 	sales_price = 0
@@ -440,6 +441,7 @@
 	force_wielded = 29
 	block_chance = 31 //quicker
 	weapon_speed_delay = 6
+	armor_penetration = 15
 
 /obj/item/melee/sword/machete/chopper
 	name = "iron chopper"
@@ -451,7 +453,7 @@
 	slot_flags = SLOT_BELT
 	force = 25
 	force_wielded = 32
-	armor_penetration = 20
+	armor_penetration = 15
 	block_chance = 30
 	weapon_speed_delay = 7
 
@@ -462,7 +464,7 @@
 	slot_flags = null
 	force = 35
 	force_wielded = 10
-	armor_penetration = 40
+	armor_penetration = 18
 	block_chance = 0
 	weapon_speed_delay = 10
 
@@ -476,7 +478,7 @@
 	slot_flags = SLOT_BELT
 	force = 27
 	force_wielded = 34
-	armor_penetration = 20
+	armor_penetration = 16
 	block_chance = 25
 	weapon_speed_delay = 8
 
@@ -492,7 +494,7 @@
 	slot_flags = SLOT_BELT
 	force = 31
 	force_wielded = 37
-	armor_penetration = 25
+	armor_penetration = 17
 	block_chance = 30
 	weapon_speed_delay = 8
 
@@ -507,7 +509,7 @@
 	str_requirement = 18
 	force = 32
 	force_wielded = 39
-	armor_penetration = 25
+	armor_penetration = 17
 	block_chance = 35
 	weapon_speed_delay = 8
 
@@ -522,7 +524,7 @@
 	str_requirement = 14
 	force = 36
 	force_wielded = 44 //warpsword
-	armor_penetration = 55
+	armor_penetration = 21
 	block_chance = 30
 	sharpness = TRUE
 	grab_sound_is_loud = TRUE
@@ -541,7 +543,7 @@
 	slot_flags = SLOT_BELT|SLOT_BACK|SLOT_S_STORE
 	force = 25
 	force_wielded = 36
-	armor_penetration = 22
+	armor_penetration = 17
 	throwforce = 18
 	block_chance = 25
 	sharp = 1
@@ -565,7 +567,7 @@
 	wielded_icon = "spear-w"
 	force = 25
 	force_wielded = 39
-	armor_penetration = 45
+	armor_penetration = 19
 	throwforce = 40
 	block_chance = 35
 	weapon_speed_delay = 10
@@ -578,7 +580,7 @@
 	color = "#848484"
 	force = 27
 	force_wielded = 41
-	armor_penetration = 50
+	armor_penetration = 20
 	sales_price = 0
 
 /obj/item/melee/trench_axe/bardiche
@@ -589,7 +591,7 @@
 	wielded_icon = "savaxe"
 	force = 27
 	force_wielded = 41
-	armor_penetration = 25
+	armor_penetration = 18
 	throwforce = 15
 	block_chance = 20
 	weapon_speed_delay = 9
@@ -600,7 +602,7 @@
 	desc = "A gigantic, powerful, two handed, sharp polearm used for singular felling blows against armored opponents."
 	force = 30
 	force_wielded = 44
-	armor_penetration = 25
+	armor_penetration = 19
 	throwforce = 22
 	block_chance = 24
 	weapon_speed_delay = 8
@@ -615,7 +617,7 @@
 	wielded_icon = "bone_spear-w"
 	force = 27
 	force_wielded = 31
-	armor_penetration = 30
+	armor_penetration = 17
 	throwforce = 25
 	block_chance = 22
 	weapon_speed_delay = 8
@@ -628,7 +630,7 @@
 	desc = "An incredibly lightweight and nimble spear used by hunters against large game animals."
 	force = 29
 	force_wielded = 33
-	armor_penetration = 32
+	armor_penetration = 18
 	throwforce = 27
 	block_chance = 25
 	weapon_speed_delay = 7
@@ -641,7 +643,7 @@
 	wielded_icon = "lance-w"
 	force = 24
 	force_wielded = 37
-	armor_penetration = 30
+	armor_penetration = 19
 	block_chance = 24
 	weapon_speed_delay = 10
 	edge = 0
@@ -653,7 +655,7 @@
 	color = "#848484"
 	force = 26
 	force_wielded = 39
-	armor_penetration = 35
+	armor_penetration = 20
 	sales_price = 0
 
 /obj/item/melee/sword/choppa
@@ -666,7 +668,8 @@
 	attack_verb = list("stabbed", "chopped", "cut", "sliced")
 	force = 35
 	force_wielded = 39
-	armor_penetration = 30
+	armor_penetration = 20
+	str_requirement = 22
 	block_chance = 25
 	sharp = 1
 	edge = 1
@@ -690,7 +693,7 @@
 	str_requirement = 13
 	force_wielded = 32
 	force = 45
-	armor_penetration = 30
+	armor_penetration = 24
 	block_chance = 40
 	grab_sound_is_loud = TRUE
 	weapon_speed_delay = 8
@@ -721,7 +724,7 @@
 	weapon_speed_delay = 6
 	drop_sound = 'sound/items/knife_drop.ogg'
 	swing_sound = "blunt_swing"
-	armor_penetration = 21
+	armor_penetration = 18
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HEAD
 	armor = list(melee = 5, bullet = 5, laser = 5, energy = 10, bomb = 10, bio = 0, rad = 0)
 
@@ -789,7 +792,7 @@
 	attack_verb = list("slashed")
 	force = 25
 	force_wielded = 28
-	armor_penetration = 27
+	armor_penetration = 20
 	block_chance = 35
 	str_requirement = 12 //i don't want to hear it, anyone below 12 str is supposed to be a child or a old man.
 	weapon_speed_delay = 7
@@ -803,7 +806,7 @@
 	force = 30
 	force_wielded = 35
 	edge = 1
-	str_requirement = 18 //you really shouldn't be using it if you are below 18
+	str_requirement = 20 //you really shouldn't be using it if you are below 18
 
 
 /obj/item/material/scythe
@@ -815,7 +818,7 @@
 	force = 15
 	force_wielded = 22
 	block_chance = 25
-	armor_penetration = 20
+	armor_penetration = 16
 	weapon_speed_delay = 7
 	sharp = 1
 	throw_speed = 1
@@ -844,7 +847,7 @@
 	force = 15
 	force_wielded = 22
 	block_chance = 25
-	armor_penetration = 20
+	armor_penetration = 16
 	weapon_speed_delay = 7
 	sharp = 1
 	throw_speed = 1

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -10,7 +10,7 @@
 	throw_range = 4
 	throwforce = 10
 	w_class = ITEM_SIZE_SMALL
-	armor_penetration = 100 //Magic
+	armor_penetration = 20 //Magic
 
 /obj/item/nullrod/attack(mob/M as mob, mob/living/user as mob) //Paste from old-code to decult with a null rod.
 	admin_attack_log(user, M, "Attacked using \a [src]", "Was attacked with \a [src]", "used \a [src] to attack")

--- a/code/game/objects/newmap/dungeon_code.dm
+++ b/code/game/objects/newmap/dungeon_code.dm
@@ -373,7 +373,7 @@ This file contains most of the code for the dungeons to work, structures, some i
 	check_armour = "energy"
 	animate_movement = 1
 	penetrating = 55
-	armor_penetration = 55
+	armor_penetration = 21
 
 /obj/machinery/door/unpowered/necron_door1
 	icon = 'icons/obj/doors/necron_door.dmi'

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -1207,7 +1207,7 @@ obj/item/clothing/suit/armor
 	item_state = "sister"
 	armor = list(melee = 21, bullet = 42, laser = 42, energy = 30, bomb = 60, bio = 60, rad = 90) //its essentially light powerarmor, a bit weaker than assfartez.
 	sales_price = 30
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
@@ -1239,7 +1239,7 @@ obj/item/clothing/suit/armor
 	item_state = "mlsister"
 	armor = list(melee = 21, bullet = 42, laser = 42, energy = 30, bomb = 60, bio = 60, rad = 90) //its essentially light powerarmor, a bit weaker than assfartez.
 	sales_price = 30
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
@@ -1253,7 +1253,7 @@ obj/item/clothing/suit/armor
 	item_state = "brsister"
 	armor = list(melee = 21, bullet = 42, laser = 42, energy = 30, bomb = 60, bio = 60, rad = 90) //its essentially light powerarmor, a bit weaker than assfartez.
 	sales_price = 30
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE

--- a/code/modules/clothing/suits/astartes.dm
+++ b/code/modules/clothing/suits/astartes.dm
@@ -7,7 +7,7 @@
 	str_requirement = 24 // they can get gibbed and their armor stays. helmet has it, so why not armor too
 	canremove = 1
 	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
-	armor = list(melee = 22, bullet = 44, laser = 44, energy = 80, bomb = 60, bio = 100, rad = 80)
+	armor = list(melee = 25, bullet = 48, laser = 48, energy = 80, bomb = 60, bio = 100, rad = 80)
 	sales_price = 120
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS

--- a/code/modules/cultist/components/hereticitem.dm
+++ b/code/modules/cultist/components/hereticitem.dm
@@ -104,7 +104,7 @@
 	attack_verb = list("slashed")
 	force = 20
 	force_wielded = 21
-	armor_penetration = 25
+	armor_penetration = 20
 	block_chance = 20
 	sales_price = 39
 	weapon_speed_delay = 5
@@ -144,7 +144,7 @@
 	attack_verb = list("slashed")
 	force = 20
 	force_wielded = 23
-	armor_penetration = 30
+	armor_penetration = 21
 	block_chance = 10
 	sales_price = 39
 	weapon_speed_delay = 8
@@ -175,7 +175,7 @@
 	str_requirement = 13
 	force = 32 // blood for the blood god. its strong,  but the shit block chance makes it balanced
 	force_wielded = 40
-	armor_penetration = 30
+	armor_penetration = 22
 	block_chance = 10
 	sharp = TRUE
 	w_class = ITEM_SIZE_HUGE
@@ -201,7 +201,7 @@
 	str_requirement = 17
 	force = 30
 	force_wielded = 40 //warpsword
-	armor_penetration = 60
+	armor_penetration = 21
 	block_chance = 50 //may the warp guide your hand
 	sharpness = TRUE
 	grab_sound_is_loud = TRUE
@@ -299,7 +299,7 @@
 	attack_verb = list("slashed")
 	force = 21
 	force_wielded = 22
-	armor_penetration = 25
+	armor_penetration = 20
 	block_chance = 20
 	sales_price = 39
 	weapon_speed_delay = 5

--- a/code/modules/cultist/deities.dm
+++ b/code/modules/cultist/deities.dm
@@ -88,6 +88,7 @@
 	faction = "Chaos"
 	rune_recipes = list(/datum/rune_recipe/tzeentch/conversion,
 						/datum/rune_recipe/tzeentch/fool,
+						/datum/rune_recipe/tzeentch/cloth,
 						/datum/rune_recipe/tzeentch/illusion,
 						/datum/rune_recipe/tzeentch/omniscience,
 						/datum/rune_recipe/tzeentch/skinless,

--- a/code/modules/cultist/runes/tzeentch.dm
+++ b/code/modules/cultist/runes/tzeentch.dm
@@ -15,6 +15,31 @@
 	ingredients = list(/obj/item/organ/internal/eyes/bioprinted, /obj/item/clothing)
 	special = TRUE
 
+/datum/rune_recipe/tzeentch/cloth
+	name = "Clothing Rite"
+	ingredients = list(/obj/item/newore/gems/emerald)
+	product_path = (/obj/item/clothing/suit/armor/heretcoat/tzeecult)
+
+/datum/rune_recipe/tzeentch/cloth
+	name = "Helmet1 Rite"
+	ingredients = list(/obj/item/newore/gems/ruby)
+	product_path = (/obj/item/clothing/head/helmet/guardhelmet/enforcer/arbitrator/tzeecult1)
+
+/datum/rune_recipe/tzeentch/cloth
+	name = "Helmet2 Rite"
+	ingredients = list(/obj/item/newore/gems/sapphire)
+	product_path = (/obj/item/clothing/head/helmet/guardhelmet/enforcer/arbitrator/tzeecult2)
+
+/datum/rune_recipe/tzeentch/cloth
+	name = "Helmet3 Rite"
+	ingredients = list(/obj/item/newore/gems/quartz)
+	product_path = (/obj/item/clothing/head/helmet/guardhelmet/enforcer/arbitrator/tzeecult3)
+
+/datum/rune_recipe/tzeentch/cloth
+	name = "Helmet4 Rite"
+	ingredients = list(/obj/item/newore/gems/topaz)
+	product_path = (/obj/item/clothing/head/helmet/guardhelmet/enforcer/arbitrator/tzeecult4)
+
 
 //Stolen from chamelon projectors
 /datum/rune_recipe/tzeentch/illusion
@@ -81,7 +106,7 @@
 
 /datum/rune_recipe/tzeentch/coppercoin
 	name = "Copper to Coin"
-	ingredients = list(/obj/item/stack/thrones)
+	ingredients = list(/obj/item/stack/thrones3)
 	product_path = list(/obj/item/reagent_containers/food/snacks/poo)
 
 /datum/rune_recipe/tzeentch/lens

--- a/code/modules/library/manuals/manuals.dm
+++ b/code/modules/library/manuals/manuals.dm
@@ -423,6 +423,13 @@
 				<h3>A discreet yet powerful magic weapon, perfect for self defense.</h3>
 				Lasgun powercell offered on a rune of Tzeentch.
 
+				<h2>Clothing Rite:</h2>
+				<h3>Summon the garb of Tzeentch, either magical armor(emerald), or one of four masks(ruby, sapphire, quartz or topaz) offered onto the rune.</h3>
+
+				<h2>Coin Rite:</h2>
+				<h3>Convert common gold ore to thrones.</h3>
+				Place a gold ore on rune of Tzeentch.
+
 				</body>
 			</html>
 			"}
@@ -484,11 +491,11 @@
 
 
 
-/*	/obj/item/book/manual/guard
+/obj/item/book/manual/guard
 	name = "Imperial Infantrymans Uplifting Primer"
 	icon = 'icons/obj/items/books.dmi'
 	icon_state = "IIUP"
-	author = "Lord General Militant Huxlow"
+	author = "Warmaster Slado"
 	title = "Imperial Infantrymans Uplifting Primer"
 	desc = "A pocket guide to Policy, Equipment, and Danger. Everything an Imperial Guard could wish for"
 	var/list/iiupfact = list(
@@ -561,16 +568,30 @@
 /obj/item/book/manual/guard/attack_self(mob/user as mob)
     to_chat(user, "<span class='notice'>You flip past your blank death certificate, reading the following passage</span>")
     playsound(user, 'sound/effects/pageturn1.ogg', 10, 1)
-    to_chat(user, "<span class='notice'>[pick(iiupfact)]</span>"
+    icon_state = "IIUP1"
 
 
 /obj/item/book/manual/inq
 	name = "Inquisitorial Rituals"
 	icon = 'icons/obj/items/books.dmi'
 	icon_state = "IRIT"
-	author = "Inquisitor Gideon Ravenor"
+	author = "Inquisitor Amberly Vail"
 	title = "Inquisitorial Rituals"
 	desc = "A tiny handbook containing the descriptions of essential rituals"
+	var/list/IRIT = list(
+	"Page 1. Litany of his imperial preservation. Emperor I consecrate this place today anew and without reserve to your righteous fury. (Dear readers should note that this originally thought to be entirely Sanguinary ritual of a now long excommunicated monk from the world of Marketh does in fact hold power on imperial worlds tainted by Chaos. My research suggests that this is due to the fact... it may be entirely heretical in nature.)",
+	"Page 2. Litany of his imperial preservation. Emperor keep us. Emperor preserve us.(The translation isn't entirely accurate. Either you say.... keep us or preserve us. One of those, or perhaps both. Along with further changing by the ritual leader, with his or her flock until they all explode... or they sanctify the grounds.)",
+	"Page 3. Litany of her martyred exorcism. Holy emperor you have given us your saints to purge wickedness across the stars I call upon them now to reveal the truth.(This one I tested personally on a whim while drunk among the company of one Ciaphas Cain, uniquely... it did work. We tied up the poor heretic in a basement while splashing gin and holy water into their sobbing pleading face while yelling the names of saints. What happened to his eyeballs... was quite messy.)",
+	"Page 4. Litany of her martyred exorcism. Saint Sabbat defend us! Saint Beatie defend us! Saint ephrael and her martyed lady defend us!",
+	"Page 5. There is a drawing of holy water being expeled onto the face of a heretic during the litany of her martyred exorcism.",
+	"Page 6. Stories of Vessorine Blade lore have been uncovered by inquisitorial research, suggesting that the use of the Saintie, Fuscina, Cutro and Power Sword are the most favourable weapons used when combating the arch enemies of man. Vessorine blademasters often employ light arms loaded with manstopper rounds, using both blade and gun together in combating Daemons.",
+	"Page 7. The tales of Interrogator Harland Nale have revealed detailed analytics on the use of conventional weapons against imperial archenemies, including that of Chaos Space Marines and rogue Inquisitorial agents often bearing incredible armor. A shotgun, aegis stub rifle or mateba loaded with armor penetrating rounds... and in a pinch the catachan fang are all proven weapons capable of defeating any armor-systems when used by a stout operative. These tools should always be kept in mind for the traveller in need of sufficient fire-power in a pinch. Personally I prefer the use of a power-blade myself..."
+	) 
+
+/obj/item/book/manual/guard/attack_self(mob/user as mob)
+    to_chat(user, "<span class='notice'>You flip past your blank death certificate, reading the following passage</span>")
+    playsound(user, 'sound/effects/pageturn1.ogg', 10, 1)
+    icon_state = "IRIT1"
 
 /obj/item/book/manual/ecc
 	name = "Ecceliarchy Rituals"
@@ -579,8 +600,21 @@
 	author = "Goge Vandire"
 	title = "Ecceliarchy Rituals"
 	desc = "A tiny handbook containing the descriptions of essential rituals"
+	var/list/ERIT = list(
+	"Page 1. Litany of his imperial preservation. Emperor I consecrate this place today anew and without reserve to your righteous fury.",
+	"Page 2. Litany of his imperial preservation. Emperor keep us. Emperor preserve us.",
+	"Page 3. Litany of her martyred exorcism. Holy emperor you have given us your saints to purge wickedness across the stars I call upon them now to reveal the truth.",
+	"Page 4. Litany of her martyred exorcism. Saint Sabbat defend us! Saint Beatie defend us! Saint ephrael and her martyed lady defend us!",
+	"Page 5. There is a drawing of holy water being expeled onto the face of a heretic during the litany of her martyred exorcism."
+	) 
+
+/obj/item/book/manual/guard/attack_self(mob/user as mob)
+    to_chat(user, "<span class='notice'>You flip past your blank death certificate, reading the following passage</span>")
+    playsound(user, 'sound/effects/pageturn1.ogg', 10, 1)
+    icon_state = "ERIT1"
 
 
+/*
 /obj/item/book/manual/law
 	name = "Lex Imperialis"
 	icon = 'icons/obj/items/books.dmi'
@@ -588,4 +622,16 @@
 	author = "God Emperor of Mankind"
 	title = "Lex Imperialis"
 	desc = "An old handbook containing some of the Imperiums most important laws."
+	var/list/ERIT = list(
+	"Page 1. Litany of his imperial preservation. Emperor I consecrate this place today anew and without reserve to your righteous fury.",
+	"Page 2. Litany of his imperial preservation. Emperor keep us. Emperor preserve us.",
+	"Page 3. Litany of her martyred exorcism. Holy emperor you have given us your saints to purge wickedness across the stars I call upon them now to reveal the truth.",
+	"Page 4. Litany of her martyred exorcism. Saint Sabbat defend us! Saint Beatie defend us! Saint ephrael and her martyed lady defend us!",
+	"Page 5. There is a drawing of holy water being expeled onto the face of a heretic during the litany of her martyred exorcism."
+	) 
+
+/obj/item/book/manual/guard/attack_self(mob/user as mob)
+    to_chat(user, "<span class='notice'>You flip past your blank death certificate, reading the following passage</span>")
+    playsound(user, 'sound/effects/pageturn1.ogg', 10, 1)
+    icon_state = "ERIT1"
 */

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -132,7 +132,7 @@ var/global/list/sparring_attack_cache = list()
 	attack_verb = list("bit")
 	attack_sound = 'sound/weapons/bite.ogg'
 	shredding = 1
-	damage = 28
+	damage = 31
 	sharp = 1
 
 /datum/unarmed_attack/punch
@@ -140,7 +140,7 @@ var/global/list/sparring_attack_cache = list()
 	attack_noun = list("fist")
 	eye_attack_text = "fingers"
 	eye_attack_text_victim = "digits"
-	damage = 21
+	damage = 28
 
 /datum/unarmed_attack/punch/show_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone, var/attack_damage)
 	var/obj/item/organ/external/affecting = target.get_organ(zone)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -91,14 +91,14 @@ proc/getsensorlevel(A)
 var/list/global/base_miss_chance = list(
 	BP_HEAD = 30,
 	BP_THROAT = 35,
-	BP_CHEST = 8,
+	BP_CHEST = 10,
 	BP_GROIN = 10,
 	BP_L_LEG = 12,
 	BP_R_LEG = 12,
 	BP_L_ARM = 12,
 	BP_R_ARM = 12,
-	BP_L_HAND = 15,
-	BP_R_HAND = 15,
+	BP_L_HAND = 35,
+	BP_R_HAND = 35,
 	BP_L_FOOT = 22,
 	BP_R_FOOT = 22,
 )

--- a/code/modules/projectiles/guns/projectile/mattguns.dm
+++ b/code/modules/projectiles/guns/projectile/mattguns.dm
@@ -305,31 +305,31 @@
 
 /obj/item/projectile/bullet/rifle/a762/brifle
 	fire_sound = 'sound/weapons/gunshot/auto5.ogg'
-	damage = 65
-	armor_penetration = 15
+	damage = 50
+	armor_penetration = 30
 
 /obj/item/projectile/bullet/rifle/a762/brifle/ap
 	fire_sound = 'sound/weapons/gunshot/auto5.ogg'
-	damage = 68
-	armor_penetration = 25
+	damage = 50
+	armor_penetration = 40
 	penetrating = 1
 
 /obj/item/projectile/bullet/rifle/a762/brifle/kp
 	fire_sound = 'sound/weapons/gunshot/auto5.ogg'
-	damage = 68
-	armor_penetration = 40
+	damage = 50
+	armor_penetration = 45
 	penetrating = 2
 
 /obj/item/projectile/bullet/rifle/a762/brifle/ms
 	fire_sound = 'sound/weapons/gunshot/auto5.ogg'
-	damage = 75
-	armor_penetration = 0
+	damage = 65
+	armor_penetration = 30
 
 /obj/item/projectile/bullet/rifle/kroot
 	fire_sound = 'sound/weapons/gunshot/auto5.ogg'
 	penetrating = TRUE // fuck that shit penetrative rounds
-	damage = 70
-	armor_penetration = 25
+	damage = 50
+	armor_penetration = 45
 
 /obj/item/ammo_magazine/brifle
 	name = "Rifle Box"

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -327,21 +327,21 @@
 	projectile_type = /obj/item/projectile/bullet/rifle/lp338/needler
 /obj/item/projectile/bullet/rifle/lp338
 	fire_sound = 'sound/weapons/gunshot/loudbolt.ogg'
-	damage = 145
-	armor_penetration = 70
+	damage = 115
+	armor_penetration = 45
 	penetration_modifier = 1.5
 	penetrating = TRUE
 
 /obj/item/projectile/bullet/rifle/lp338/jhp
 	name = "JHP bullet"
 	fire_sound = 'sound/weapons/gunshot/loudbolt.ogg'
-	damage = 170
-	armor_penetration = 30
+	damage = 130
+	armor_penetration = 25
 
 /obj/item/projectile/bullet/rifle/lp338/needler
 	name = "needler bullet"
 	fire_sound = 'sound/weapons/gunshot/needler.ogg'
-	damage = 110
+	damage = 100
 	damage_type = TOX
 	penetration_modifier = 2
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -40,7 +40,7 @@
 	icon_state = "heavylaser"
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 	damage = 60
-	armor_penetration = 30
+	armor_penetration = 40
 
 	muzzle_type = /obj/effect/projectile/laser/heavy/muzzle
 	tracer_type = /obj/effect/projectile/laser/heavy/tracer
@@ -51,7 +51,7 @@
 	icon_state = "heavylaser"
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 	damage = 200
-	armor_penetration = 30
+	armor_penetration = 40
 
 	muzzle_type = /obj/effect/projectile/laser/heavy/muzzle
 	tracer_type = /obj/effect/projectile/laser/heavy/tracer
@@ -137,7 +137,7 @@
 	icon_state = "xray"
 	fire_sound = 'sound/weapons/marauder.ogg'
 	damage = 50
-	armor_penetration = 10
+	armor_penetration = 40
 	stun = 3
 	weaken = 3
 	stutter = 3

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -174,96 +174,96 @@
 /obj/item/projectile/bullet/pistol
 	damage = 30 //9mm
 	fire_sound = 'sound/weapons/gunshot/auto1.ogg'
-	armor_penetration = 10
+	armor_penetration = 24
 
 /obj/item/projectile/bullet/pistol/medium
 	damage = 35 //.45
-	armor_penetration = 15
+	armor_penetration = 26
 	fire_sound = 'sound/weapons/gunshot/auto1.ogg'
 
 /obj/item/projectile/bullet/pistol/medium/ap
-	damage = 40 //.45
-	armor_penetration = 25
+	damage = 35 //.45
+	armor_penetration = 34
 
 /obj/item/projectile/bullet/pistol/medium/ms
-	damage = 55 //.45
-	armor_penetration = 0
+	damage = 45 //.45
+	armor_penetration = 24
 
 /obj/item/projectile/bullet/pistol/medium/kp
-	damage = 40 //.45
-	armor_penetration = 35
+	damage = 35 //.45
+	armor_penetration = 38
 	penetrating = 1
 
 /obj/item/projectile/bullet/pistol/strong //matebas
 	fire_sound = 'sound/weapons/gunshot/gunshot_strong.ogg'
-	damage = 50 //.50AE
-	armor_penetration = 25
+	damage = 45 //.50AE
+	armor_penetration = 28
 
 /obj/item/projectile/bullet/pistol/strong/ap
 	damage = 54 //.50AE
-	armor_penetration = 35
+	armor_penetration = 36
 
 /obj/item/projectile/bullet/pistol/strong/kp
 	damage = 54 //.50AE
-	armor_penetration = 45
+	armor_penetration = 40
 	penetrating = 1
 
 /obj/item/projectile/bullet/pistol/strong/ms
-	damage = 64 //.50AE
-	armor_penetration = 10
+	damage = 55 //.50AE
+	armor_penetration = 28
 
 /obj/item/projectile/bullet/pistol/revolver
 	fire_sound = 'sound/weapons/gunshot/auto5.ogg'
-	damage = 54 // .357
-	armor_penetration = 25
+	damage = 40 // .357
+	armor_penetration = 28
 
 /obj/item/projectile/bullet/pistol/revolver/ap
-	damage = 58
-	armor_penetration = 35
+	damage = 49
+	armor_penetration = 36
 
 /obj/item/projectile/bullet/pistol/revolver/kp
-	damage = 58
-	armor_penetration = 45
+	damage = 49
+	armor_penetration = 40
 	penetrating = 1
 
 /obj/item/projectile/bullet/pistol/revolver/ms
-	damage = 68
-	armor_penetration = 5
+	damage = 50
+	armor_penetration = 28
 
 /obj/item/projectile/bullet/pistol/medium/revolver
 	fire_sound = 'sound/weapons/gunshot/gunshot_strong.ogg'
-	damage = 54 //.44 magnum or something
-	armor_penetration = 20
+	damage = 40 //.44 magnum or something
+	armor_penetration = 28
 
 /obj/item/projectile/bullet/pistol/medium/revolver/ap
-	damage = 58
-	armor_penetration = 30
+	damage = 40
+	armor_penetration = 36
 
 /obj/item/projectile/bullet/pistol/medium/revolver/kp
-	damage = 58
+	damage = 40
 	armor_penetration = 40
 	penetrating = 1
 
 /obj/item/projectile/bullet/pistol/medium/revolver/ms
-	damage = 68
-	armor_penetration = 10
+	damage = 50
+	armor_penetration = 28
 
 /obj/item/projectile/bullet/pistol/strong/revolver
-	damage = 58
-	armor_penetration = 20
+	damage = 40
+	armor_penetration = 28
 
 /obj/item/projectile/bullet/pistol/strong/revolver/ap
-	damage = 62
-	armor_penetration = 30
+	damage = 40
+	armor_penetration = 36
 
 /obj/item/projectile/bullet/pistol/strong/revolver/kp
-	damage = 62
+	damage = 40
 	armor_penetration = 40
 	penetrating = 1
 
 /obj/item/projectile/bullet/pistol/strong/revolver/ms
-	damage = 72
-	armor_penetration = 5
+	damage = 50
+	armor_penetration = 28
 
 /obj/item/projectile/bullet/pistol/rubber //"rubber" bullets
 	name = "rubber bullet"
@@ -279,27 +279,27 @@
 /obj/item/projectile/bullet/shotgun
 	name = "slug"
 	fire_sound = 'sound/weapons/gunshot/shotgun3.ogg'
-	damage = 70
-	armor_penetration = 25
+	damage = 65
+	armor_penetration = 35
 
 /obj/item/projectile/bullet/shotgun/kp
 	name = "KP slug"
 	fire_sound = 'sound/weapons/gunshot/shotgun3.ogg'
-	damage = 75
-	armor_penetration = 35
+	damage = 65
+	armor_penetration = 45
 	penetrating = 1
 
 /obj/item/projectile/bullet/shotgun/ms
 	name = "MS slug"
 	fire_sound = 'sound/weapons/gunshot/shotgun3.ogg'
-	damage = 85
-	armor_penetration = 5
+	damage = 75
+	armor_penetration = 35
 
 /obj/item/projectile/bullet/shotgun/beanbag		//because beanbags are not bullets
 	name = "beanbag"
 	check_armour = "melee"
 	damage = 10
-	armor_penetration = 10
+	armor_penetration = 28
 	agony = 70
 	embed = 0
 	sharp = 0
@@ -310,7 +310,7 @@
 	name = "buckshot"
 	fire_sound = 'sound/weapons/gunshot/shotgun3.ogg'
 	damage = 25
-	armor_penetration = 10
+	armor_penetration = 27
 	pellets = 10
 	range_step = 3
 	spread_step = 8
@@ -321,68 +321,68 @@
 /obj/item/projectile/bullet/rifle/kroot
 	fire_sound = 'sound/weapons/gunshot/auto5.ogg'
 	penetrating = TRUE // fuck that shit penetrative rounds
-	damage = 65
-	armor_penetration = 30
+	damage = 50
+	armor_penetration = 45
 
 /obj/item/projectile/bullet/rifle
-	damage = 55
-	armor_penetration = 15
+	damage = 40
+	armor_penetration = 28
 	penetrating = TRUE
 
 /obj/item/projectile/bullet/rifle/a556
 	fire_sound = 'sound/weapons/gunshot/gunshot3.ogg'
-	damage = 43
-	armor_penetration = 15
+	damage = 40
+	armor_penetration = 28
 
 /obj/item/projectile/bullet/rifle/a556/ap
 	fire_sound = 'sound/weapons/gunshot/gunshot3.ogg'
-	damage = 47
-	armor_penetration = 25
+	damage = 40
+	armor_penetration = 36
 
 /obj/item/projectile/bullet/rifle/a556/ms
 	fire_sound = 'sound/weapons/gunshot/gunshot3.ogg'
-	damage = 52
-	armor_penetration = 5
+	damage = 50
+	armor_penetration = 28
 
 /obj/item/projectile/bullet/rifle/a556/kp
 	fire_sound = 'sound/weapons/gunshot/gunshot3.ogg'
-	damage = 47
-	armor_penetration = 35
+	damage = 40
+	armor_penetration = 40
 	penetrating = 1
 
 /obj/item/projectile/bullet/rifle/a762
 	fire_sound = 'sound/weapons/gunshot/gunshot2.ogg'
-	damage = 49
+	damage = 50
 	armor_penetration = 30
 
 /obj/item/projectile/bullet/rifle/a762/ap
 	fire_sound = 'sound/weapons/gunshot/gunshot2.ogg'
-	damage = 49
+	damage = 50
 	armor_penetration = 40
 
 /obj/item/projectile/bullet/rifle/a762/kp
 	fire_sound = 'sound/weapons/gunshot/gunshot2.ogg'
-	damage = 49
-	armor_penetration = 50
+	damage = 50
+	armor_penetration = 45
 	penetrating = 1
 
 /obj/item/projectile/bullet/rifle/a762/ms
 	fire_sound = 'sound/weapons/gunshot/gunshot2.ogg'
-	damage = 64
-	armor_penetration = 10
+	damage = 60
+	armor_penetration = 40
 
 
 /obj/item/projectile/bullet/rifle/a145
 	fire_sound = 'sound/weapons/gunshot/loudbolt.ogg'
-	damage = 130
-	armor_penetration = 55
+	damage = 110
+	armor_penetration = 50
 	//hitscan = 1 //so the PTR isn't useless as a sniper weapon
 	penetration_modifier = 1
 	penetrating = 2
 
 /obj/item/projectile/bullet/rifle/a145/apds
-	damage = 120
-	armor_penetration = 75
+	damage = 110
+	armor_penetration = 65
 	penetration_modifier = 1
 	penetrating = 3
 
@@ -391,19 +391,19 @@
 /obj/item/projectile/bullet/suffocationbullet//How does this even work?
 	name = "CO2 bullet"
 	damage = 65
-	armor_penetration = 10
+	armor_penetration = 35
 	damage_type = OXY
 
 /obj/item/projectile/bullet/cyanideround
 	name = "poison bullet"
 	damage = 65
-	armor_penetration = 10
+	armor_penetration = 35
 	damage_type = TOX
 
 /obj/item/projectile/bullet/burstbullet
 	name = "exploding bullet"
 	damage = 100
-	armor_penetration = 10
+	armor_penetration = 40
 	embed = 0
 	edge = 1
 
@@ -485,7 +485,7 @@
 	fire_sound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	damage = 90
 	damage_type = BURN
-	armor_penetration = 60
+	armor_penetration = 46
 	penetration_modifier = 1.4
 	penetrating = TRUE
 
@@ -494,7 +494,7 @@
 	fire_sound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	damage = 80
 	damage_type = BURN
-	armor_penetration = 55
+	armor_penetration = 44
 	penetration_modifier = 1.2
 
 
@@ -503,7 +503,7 @@
 	fire_sound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	damage = 51
 	damage_type = BURN
-	armor_penetration = 40
+	armor_penetration = 44
 	penetration_modifier = 1.4
 
 
@@ -520,35 +520,35 @@
 /obj/item/projectile/bullet/rifle/shuriken/catapult
 	fire_sound = 'sound/weapons/gunshot/needler.ogg'
 	icon_state = "ion"
-	damage = 25
+	damage = 21
 	damage_type = BRUTE
-	armor_penetration = 25
+	armor_penetration = 44
 	penetration_modifier = 1
 
 /obj/item/projectile/bullet/rifle/shuriken/pistol
 	fire_sound = 'sound/weapons/gunshot/needler.ogg'
 	icon_state = "ion"
-	damage = 25
+	damage = 21
 	damage_type = BRUTE
-	armor_penetration = 30
+	armor_penetration = 44
 	penetration_modifier = 1
 	
 // XENOS
 /obj/item/projectile/bullet/rifle/pmag
 	fire_sound = 'sound/weapons/gunshot/needler.ogg'
 	icon_state = "pulse"
-	damage = 51
+	damage = 50
 	damage_type = BRUTE
-	armor_penetration = 40
+	armor_penetration = 44
 	penetration_modifier = 1
 	
 //MECHANICUS
 /obj/item/projectile/bullet/rifle/galvanic
 	fire_sound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "ion"
-	damage = 63
+	damage = 55
 	damage_type = BRUTE
-	armor_penetration = 40
+	armor_penetration = 44
 	penetration_modifier = 2
 	var/heavy_effect_range = 1
 	var/light_effect_range = 1
@@ -558,7 +558,7 @@
 	icon_state = "ion"
 	damage = 35
 	damage_type = BRUTE
-	armor_penetration = 35
+	armor_penetration = 38
 	penetration_modifier = 2
 	
 /obj/item/projectile/bullet/rifle/galvanic/fire/on_hit(var/atom/target, var/blocked = 0)
@@ -577,7 +577,7 @@
 	icon_state = "ion"
 	damage = 15
 	damage_type = BURN
-	armor_penetration = 15
+	armor_penetration = 38
 	penetration_modifier = 1
 	on_impact(var/atom/A)
 		empulse(A, 1, 2)
@@ -588,7 +588,7 @@
 	icon_state = "ion"
 	damage = 40
 	damage_type = BRUTE
-	armor_penetration = 35
+	armor_penetration = 38
 
 /obj/item/projectile/bullet/rifle/galvanic/airburst/on_hit(var/atom/target)
 	if(ishuman(target))
@@ -612,7 +612,7 @@
 	icon_state = "ion"
 	damage = 5
 	damage_type = BURN
-	armor_penetration = 30
+	armor_penetration = 40
 	agony = 150 //Might need reworking
 	taser_effect = 1
 
@@ -622,8 +622,8 @@
 	icon_state = "lasbolt"
 	damage_type = BURN
 	penetration_modifier = 1
-	armor_penetration = 60
-	damage = 40
+	armor_penetration = 48
+	damage = 35
 	pellets = 1
 	range_step = 4 // do not touch
 	spread_step = 2
@@ -632,9 +632,9 @@
 /obj/item/projectile/bullet/rifle/radcarbine
 	fire_sound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "shot"
-	damage = 45
+	damage = 40
 	damage_type = BRUTE //Initial poisoning effect
-	armor_penetration = 40 
+	armor_penetration = 44 
 	penetration_modifier = 2
 
 /obj/item/projectile/bullet/rifle/radcarbine/on_hit(var/atom/target, var/blocked = 0)
@@ -647,7 +647,7 @@
 	icon_state = "shot"
 	damage = 35
 	damage_type = BRUTE //Initial poisoning effect
-	armor_penetration = 35
+	armor_penetration = 44
 	penetration_modifier = 2
 
 /obj/item/projectile/bullet/rifle/radcarbine/radpistol/on_hit(var/atom/target, var/blocked = 0)
@@ -667,16 +667,16 @@
 
 /obj/item/projectile/bullet/rifle/plasma/cannon/orkish //three colors of green!
 	fire_sound = 'sound/weapons/guns/misc/laser_searwall.ogg'
-	damage = 120
+	damage = 100
 	damage_type = BURN
-	armor_penetration = 40
+	armor_penetration = 44
 	penetration_modifier = 3
 	
 /obj/item/projectile/bullet/rifle/lascannon/melta/inferno
 	fire_sound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "lasbolt"
 	damage = 25 //weaker than melta caus its a pistol
-	armor_penetration = 40
+	armor_penetration = 44
 
 
 /* ORKY BULLETS */
@@ -684,8 +684,8 @@
 /obj/item/projectile/bullet/ork
 	name = "scrap"
 	fire_sound = 'sound/weapons/gunshot/loudbolt.ogg'
-	damage = 41
-	armor_penetration = 20
+	damage = 38
+	armor_penetration = 44
 
 /*
 
@@ -724,17 +724,17 @@
 /obj/item/projectile/bullet/rifle/lascannon
 	fire_sound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "lasbolt"
-	damage = 90
+	damage = 85
 	damage_type = BURN
-	armor_penetration = 35
+	armor_penetration = 44
 	penetration_modifier = 2
 	penetrating = TRUE
 
 /obj/item/projectile/bullet/rifle/plasma/cannon //D E A T H
 	fire_sound = 'sound/weapons/guns/misc/laser_searwall.ogg'
-	damage = 160
+	damage = 120
 	damage_type = BURN
-	armor_penetration = 70
+	armor_penetration = 48
 	penetration_modifier = 3
 	
 /obj/item/projectile/bullet/rifle/exitus
@@ -743,7 +743,7 @@
 	damage = 140
 	damage_type = BRUTE
 	check_armour = "bullet"
-	armor_penetration = 70
+	armor_penetration = 50
 	embed = 1
 	sharp = 1
 	light_power = 0

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -95,7 +95,7 @@
 	damage = 15
 	agony = 90
 	damage_type = BURN
-	armor_penetration = 20
+	armor_penetration = 30
 
 /obj/item/projectile/energy/dart
 	name = "dart"
@@ -148,7 +148,7 @@
 	wall_hitsound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "lasbolt"
 	damage = 44
-	armor_penetration = 20
+	armor_penetration = 30
 
 /obj/item/projectile/energy/las/lasgun/pistol // just use rifle lasgun for over charges for pistol
 	name = "lasbolt"
@@ -156,31 +156,31 @@
 	wall_hitsound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "lasbolt"
 	damage = 35
-	armor_penetration = 25
+	armor_penetration = 29
 
 /obj/item/projectile/energy/las/lasgun/pistol/overcharge // just use rifle lasgun for over charges for pistol
 	name = "lasbolt"
 	fire_sound='sound/weapons/gunshot/lasgun2.ogg'
 	wall_hitsound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "lasbolt"
-	damage = 45
-	armor_penetration = 45
+	damage = 40
+	armor_penetration = 38
 
 /obj/item/projectile/energy/las/lasgun/overcharge
 	name = "lasbolt"
 	fire_sound='sound/weapons/gunshot/lasgun2.ogg'
 	wall_hitsound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "lasbolt"
-	damage = 64
-	armor_penetration = 20
+	damage = 54
+	armor_penetration = 38
 
 /obj/item/projectile/energy/las/lasgun/undercharge
 	name = "lasbolt"
 	fire_sound='sound/weapons/gunshot/lasgun2.ogg'
 	wall_hitsound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "lasbolt"
-	damage = 24
-	armor_penetration = 15
+	damage = 30
+	armor_penetration = 25
 
 /obj/item/projectile/energy/las/lasgun/execution
 	name = "lasbolt"
@@ -188,31 +188,31 @@
 	wall_hitsound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "lasbolt"
 	damage = 90
-	armor_penetration = 30
+	armor_penetration = 45
 
 /obj/item/projectile/energy/las/lasgun/lucius
 	name = "lasbolt"
 	fire_sound='sound/weapons/gunshot/lasgun2.ogg'
 	wall_hitsound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "lasbolt"
-	damage = 52
-	armor_penetration = 20
+	damage = 48
+	armor_penetration = 35
 
 /obj/item/projectile/energy/las/lasgun/lucius/overcharge
 	name = "lasbolt"
 	fire_sound='sound/weapons/gunshot/lasgun3.ogg'
 	wall_hitsound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "lasbolt"
-	damage = 66
-	armor_penetration = 30
+	damage = 62
+	armor_penetration = 43
 
 /obj/item/projectile/energy/las/lasgun/longlas
 	name = "lasbolt"
 	fire_sound='sound/weapons/gunshot/lasgun3.ogg'
 	wall_hitsound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "lasbolt"
-	damage = 85
-	armor_penetration = 56
+	damage = 75
+	armor_penetration = 43
 	accuracy = 2
 
 /obj/item/projectile/energy/las/lasgun/longlas/overcharge
@@ -220,40 +220,40 @@
 	fire_sound='sound/weapons/gunshot/lasgun4.ogg'
 	wall_hitsound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "lasbolt"
-	damage = 106
-	armor_penetration = 75
+	damage = 90
+	armor_penetration = 50
 
 /obj/item/projectile/energy/las/lasgun/hotshot
 	name = "lasbolt"
 	fire_sound='sound/weapons/gunshot/lasgun3.ogg'
 	wall_hitsound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "lasbolt"
-	damage = 58
-	armor_penetration = 30
+	damage = 55
+	armor_penetration = 43
 
 /obj/item/projectile/energy/las/lasgun/hotshot/krieg
 	name = "lasbolt"
 	fire_sound='sound/weapons/gunshot/lasgun3.ogg'
 	wall_hitsound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "lasbolt"
-	damage = 68
-	armor_penetration = 30
+	damage = 58
+	armor_penetration = 44
 
 /obj/item/projectile/energy/pulse/pulserifle
 	name = "pulse round"
 	fire_sound='sound/weapons/lasgun.ogg'
 	wall_hitsound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "pulse1"
-	damage = 54
-	armor_penetration = 38
+	damage = 55
+	armor_penetration = 43
 
 /obj/item/projectile/energy/pulse/pulsepistol
 	name = "pulse round"
 	fire_sound='sound/weapons/lasgun.ogg'
 	wall_hitsound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "pulse1"
-	damage = 54
-	armor_penetration = 48
+	damage = 55
+	armor_penetration = 43
 
 /obj/item/projectile/energy/pulse/fragment // fragmentation for pulse explosions
 	name = "pulse round"
@@ -261,7 +261,7 @@
 	wall_hitsound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "pulse1"
 	damage = 7
-	armor_penetration = 70
+	armor_penetration = 40
 
 /obj/item/projectile/energy/pulse/pulserail
 	name = "pulse round"
@@ -269,7 +269,7 @@
 	wall_hitsound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "pulse1"
 	damage = 32
-	armor_penetration = 60
+	armor_penetration = 50
 
 	on_hit(var/atom/target, var/blocked = 0)
 		fragmentates(target, 8)
@@ -280,7 +280,7 @@
 	wall_hitsound = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	icon_state = "pulse1"
 	damage = 35
-	armor_penetration = 66
+	armor_penetration = 50
 
 	on_hit(var/atom/target, var/blocked = 0)
 		fragmentates(target, 8)
@@ -292,7 +292,7 @@
 	icon_state = "pulse1_bl"
 	damage = 90
 	weaken = 1
-	armor_penetration = 55
+	armor_penetration = 50
 	light_power = 4
 	light_color = "#2132cf"
 
@@ -304,7 +304,7 @@
 	icon_state = "pulse1_bl"
 	damage = 80
 	weaken = 1
-	armor_penetration = 55
+	armor_penetration = 48
 	light_power = 4
 	light_color = "#2132cf"
 
@@ -315,7 +315,7 @@
 	icon_state = "pulse1_bl"
 	damage = 28
 	weaken = 1
-	armor_penetration = 50
+	armor_penetration = 52
 	light_power = 4
 	light_color = "#2132cf"
 
@@ -326,7 +326,7 @@
 	name = "Warp Bolt"
 	icon_state = "warpboltcrappy"
 	damage = 20
-	armor_penetration = 55
+	armor_penetration = 50
 	agony = 15 //Its warp magic it hurts more than it really is damaging.
 	eyeblur = 10 //the warp magic disrupts your eyes for a moment.
 	light_power = 4 //It glows because warp idk.

--- a/code/modules/projectiles/projectile/magnetic.dm
+++ b/code/modules/projectiles/projectile/magnetic.dm
@@ -6,7 +6,7 @@
 	stun = 1
 	weaken = 1
 	penetrating = 5
-	armor_penetration = 70
+	armor_penetration = 50
 	penetration_modifier = 1.1
 	fire_sound = 'sound/weapons/railgun.ogg'
 
@@ -14,11 +14,11 @@
 	name = "slug"
 	icon_state = "gauss_silenced"
 	damage = 75
-	armor_penetration = 90
+	armor_penetration = 44
 
 /obj/item/projectile/bullet/magnetic/flechette
 	name = "flechette"
 	icon_state = "flechette"
 	damage = 20
-	armor_penetration = 100
+	armor_penetration = 48
 	fire_sound = 'sound/weapons/rapidslice.ogg'

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -22,14 +22,14 @@
 	name =".75 bolt" //.75, astartes sized bolters or boltpistols
 	icon_state= "bolter"
 	damage = 75
-	armor_penetration = 40 //this is totally not cause its a .75
+	armor_penetration = 44 //this is totally not cause its a .75
 	check_armour = "bullet"
 
 /obj/item/projectile/bullet/bolterrifle/astartes
 	name =".95 bolt"  // Will make kraken penetrator variants later.
 	icon_state= "bolter"
 	damage = 89
-	armor_penetration = 45 
+	armor_penetration = 48
 	check_armour = "bullet"
 
 /obj/item/projectile/bullet/bpistol 
@@ -37,31 +37,31 @@
 	icon_state= "bolter"
 	damage = 68
 	check_armour = "bullet"
-	armor_penetration = 35
+	armor_penetration = 44
 
 // SPECIAL BOLT ROUNDS
 
 /obj/item/projectile/bullet/bpistol/kp
 	fire_sound = 'sound/effects/explosion1.ogg'
 	damage = 73
-	armor_penetration = 45
+	armor_penetration = 48
 	penetrating = 2
 
 /obj/item/projectile/bullet/bolt/kp
 	fire_sound = 'sound/effects/explosion1.ogg'
 	damage = 83
-	armor_penetration = 60
+	armor_penetration = 48
 	penetrating = 2
 
 /obj/item/projectile/bullet/bpistol/ms // This is .75 Bolt Pistol Round
 	fire_sound = 'sound/effects/explosion1.ogg'
 	damage = 79
-	armor_penetration = 35
+	armor_penetration = 44
 
 /obj/item/projectile/bullet/bolt/ms
 	fire_sound = 'sound/effects/explosion1.ogg'
 	damage = 89
-	armor_penetration = 35
+	armor_penetration = 44
 
 /obj/item/projectile/meteor
 	name = "meteor"
@@ -328,9 +328,9 @@
 	name = "phosphor splash"
 	icon_state = "pulse1"
 	fire_sound = 'sound/weapons/gunshot/gunshot_pistol.ogg'
-	damage = 65 //phosphor blasters are incredibly powerful weapons, almost never used
+	damage = 35 //phosphor blasters are incredibly powerful weapons, almost never used
 	check_armour = "energy"
-	armor_penetration = 100 //phosphor blasters are incredibly good at penetrating heavy armor
+	armor_penetration = 40 //phosphor blasters are incredibly good at penetrating heavy armor
 	range =  6 //extremely close ranged, normal vision is 8 but technically 7 if you don't count your own tile.
 	
 
@@ -340,7 +340,7 @@
 		if(!istype(H.wear_suit, /obj/item/clothing/suit/armor/seolsuit))
 			H.adjust_fire_stacks(5) //i know this aint lore accurate, but if you want to buff this, nerf pain.
 			H.IgniteMob()
-		new /obj/flamer_fire(H.loc, 120, 500, "red", 1)
+		new /obj/flamer_fire(H.loc, 12, 10, "red", 1)
 		if(H.isChild())
 			var/mob/living/carbon/human/F = firer
 			F.unlock_achievement(new/datum/achievement/child_fire())
@@ -350,7 +350,7 @@
 	name = "Gauss "
 	icon_state = "emitter"
 	fire_sound = 'sound/effects/meteorimpact.ogg' //Bass-y sound of firing
-	damage = 250
+	damage = 100
 	damage_type = BURN
 	agony = 200
 	check_armour = "energy"
@@ -359,7 +359,7 @@
 	dispersion = 0.0
 	animate_movement = 1
 	penetrating = 10
-	armor_penetration = 100
+	armor_penetration = 44
 
 /obj/item/projectile/energy/meltagun
 	name = "Meltagun beam"
@@ -371,7 +371,7 @@
 	range =  5
 	incinerate = 1
 	penetrating = 10
-	armor_penetration = 120
+	armor_penetration = 47
 	var/flash_range = 1
 	var/brightness = 10
 	var/light_colour = "#ffffff"


### PR DESCRIPTION
Will add changelog later.

TL;DR

Inquisitorial/Primer/Ecclesiarchy books kind of in(not working). Looks cool though.

Added new satchel code that creates slowdown, with a lightweight and heavy satchel. Magos/Priest and Power Packs immune.

Fixed melee code to now penetrate armor, with various 'tiers' on what melee weapons penetrate what armor. Emphasizing their strengths and weaknesses. 

Fixed astartes power armor and sisters, also gave Astartes better protection against damage so you need specialized weapons like sniper rifles, or kraken penetrator shotgun slugs to hurt them. 

Re-did AP on all ranged weapons too. I worked off 40k logic, being that some not all autoguns penetrate imperial flak armor. For example pistols will do fuck all to imperial flak, but revolvers have a chance to penetrate with RNG. AP rounds and heavier autoguns, like bolt action rifles and shotguns will break flak in half.

Most autoguns will have a chance of penetrating basic pilgrim armors, though may struggle to penetrate Carapace or be completely unable to. Like the Kasrkin Carapace will just eat 5.56 FMJ for breakfast. In that case you want to aim for hands/feet or limbs if their armor doesn't cover it. A boot knife in any case will always be capable of penetrating any armor(knife in gaps of armor) outside of  really good ones like plate or power.

Las Pistols will generally penetrate flak, Lasguns will have RNG chance of penetrating carapace. Overcharged lasguns depending on pattern and RNG may penetrate power armor, though only Lucius has a chance at hurting an Astartes while overcharged.

The new system I setup is unique in that previously people, including myself, just guessed when we assigned damage/Ap or armor to any item.

This new system has all guns and armor balanced off each other. Where an autogun's AP actually matches the armor of guns it's rated to penetrate and what it struggles to beat. 

There's also a generally strong rebalance of how AP, KP and Manstopper rounds work -- so there's more incentive to use Manstoppers now over KP. Since a lot of armors have pretty similar armor values, if you are using something like 7.62 you don't really have any logical reason to get kraken penetrator. Generally a 7.62 bolt rifle is going to fuck almost any armor you come across, and as a Pilgrim you shouldn't expect to be fighting people in high quality carapace. Getting KP? Waste of thrones. Get standard ammo or  Manstoppers instead for that bolt rifle.

It's also easy to rebalance in future, numbers are pretty simple and it's relatively easy to keep in mind a simple rule.

If the weapon is meant to penetrate flak, it should generally have an AP of 28-30 minimum.

If it's meant  to penetrate carapace or heavy flak, it should be AP 32-38.

If it is rated for a Sister of Battle or Astartes chestpiece. It's AP needs to be in the 40-50 area.

Relatively simple. This rule doesn't apply to melee though. Since melee code is different, those weapons should never have an AP above 30 -- ever. Since the highest melee protection in game is 25. A melee weapon shouldn't ever go above 30 even if it's made of angel dust. For this reason Power Swords AP is 25 which matches exactly the rating of an Astartes Chestpiece.

-
A pending note is it would be a good idea to develop armors that are rated to actually resist the strongest weapons in the game partially -- but only enough to have RNG chance of being penetrated. Like archeotech astartes helmets or sister power armor. As long as they aren't a rating of 5 higher -- then the highest penetrating weapons they're good.

This meta also redefines what it means for a weapon to be strong/powerful. Since no matter how much damage a weapon deals now, it's AP is it's only stat that defines if it can break armor. In a way, AP is the new damage for the game which sort of resembles IRL ballistics since super powerful rifle rounds don't translate to much damage.