### PR TITLE
"Fixes" force eject

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1080,7 +1080,7 @@
 	return
 
 
-/obj/mecha/verb/force_eject()
+/* /obj/mecha/verb/force_eject()
 	if(exitable == 1)
 		set category = "Object"
 		set name = "Force Eject"
@@ -1089,7 +1089,7 @@
 		src.go_out()
 		return
 	else
-		to_chat(usr, "You can't exit the exosuit.")
+		to_chat(usr, "You can't exit the exosuit.") */
 
 
 


### PR DESCRIPTION
## About The Pull Request

This was "fixed" because of a mixture of complaints, copium and also hearing tales of people using this to abuse the tau mechs. It's a simple "fix" that takes 2 seconds to do. Seemed to work when I tried it on local. So.... I hope this doesn't cause issues B)

## Why It's Good For The Game

Literally just stops being being able to force eject people from mechs without being inside them. Force eject is supposed to be internal only from what I can see, that or an external ejection but it takes time. Yada Yada funny moment.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
