### PR TITLE
Fixes nurgle ritual again (real)

### DIFF
--- a/code/modules/cultist/runes/nurgle.dm
+++ b/code/modules/cultist/runes/nurgle.dm
@@ -19,7 +19,7 @@
 	ingredients = list(/obj/item/organ/internal/brain)
 	special = TRUE
 
-/datum/rune_recipe/nurgle/offer_gem/do_special(var/mob/living/carbon/user, var/obj/effect/cleanable/heretic_rune/rune)
+/datum/rune_recipe/nurgle/offer_brain/do_special(var/mob/living/carbon/user, var/obj/effect/cleanable/heretic_rune/rune)
 	SEND_SIGNAL(user, COMSIG_CULT_ADD_FAVOR, 15)
 
 /datum/rune_recipe/nurgle/offer_gem

--- a/code/modules/cultist/runes/nurgle.dm
+++ b/code/modules/cultist/runes/nurgle.dm
@@ -19,8 +19,8 @@
 	ingredients = list(/obj/item/organ/internal/brain)
 	special = TRUE
 
-/datum/rune_recipe/khorne/offer_brain/do_special(var/mob/living/carbon/user, var/obj/effect/cleanable/heretic_rune/rune)
-	SEND_SIGNAL(user, COMSIG_CULT_ADD_FAVOR, 10)
+/datum/rune_recipe/nurgle/offer_gem/do_special(var/mob/living/carbon/user, var/obj/effect/cleanable/heretic_rune/rune)
+	SEND_SIGNAL(user, COMSIG_CULT_ADD_FAVOR, 15)
 
 /datum/rune_recipe/nurgle/offer_gem
 	ingredients = list(/obj/item/stack/thrones)


### PR DESCRIPTION
Someone made the offer_brain ritual send to Khorne instead of Nurgle. Brains will now give favor as intended. Also buffs favor slightly, to put it on level with Khorne.