### PR TITLE
Fixes admin role add/remove function (admins can now add/remove roles!)

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1468,3 +1468,35 @@ datum/admins/var/obj/item/paper/admin/faxreply // var to hold fax replies in
 		qdel(P)
 		faxreply = null
 	return
+
+/datum/admins/proc/manage_free_slots()
+	if(!check_rights())
+		return
+	var/datum/browser/browser = new(usr, "jobmanagement", "Manage Free Slots", 520)
+	var/list/dat = list()
+	var/count = 0
+
+
+	for(var/j in SSjobs.occupations)
+		var/datum/job/job = j
+		count++
+		var/J_title = html_encode(job.title)
+		var/J_opPos = html_encode(job.total_positions - (job.total_positions - job.current_positions))
+		var/J_totPos = html_encode(job.total_positions)
+		dat += "<tr><td>[J_title]:</td> <td>[J_opPos]/[job.total_positions < 0 ? " (unlimited)" : J_totPos]"
+
+		dat += "</td>"
+		dat += "<td>"
+		if(job.total_positions >= 0)
+			dat += "addjobslot=[job.title]'>Add 1</A> | "
+			if(job.total_positions > job.current_positions)
+				dat += "removejobslot=[job.title]'>Remove</A> | "
+			else
+				dat += "Remove | "
+			dat += "unlimitjobslot=[job.title]'>Unlimit</A></td>"
+		else
+			dat += "limitjobslot=[job.title]'>Limit</A></td>"
+
+	browser.height = min(100 + count * 20, 650)
+	browser.set_content(dat.Join())
+	browser.open()

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -109,6 +109,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/vice_edit,
 	/client/proc/vicetype_edit,
 	/client/proc/happiness_edit,
+	/client/proc/cmd_admin_list_manage_jobs,
 
 )
 var/list/admin_verbs_ban = list(

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -874,3 +874,9 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		src << browse(msg, "window=Player_class_check")
 	else
 		to_chat(src, "No matches for that class found.")
+
+/client/proc/cmd_admin_list_manage_jobs()
+	set category = "Admin"
+	set name = "Manage Job Slots"
+	set desc="manage the roles, add/remove them"
+	holder.manage_free_slots()


### PR DESCRIPTION
## About The Pull Request

Adds a function to then remove roles from in-round. Contrary to popular belief, admins before could NOT remove roles, only add. (That wont go poorly right?)

## Why It's Good For The Game

Allows for admins to run faction focused events (Disabling roles to balance it out) also allowing them to test things based on role count (removing/adding roles to test). This will also allow for roles to be removed if one is added by accident. 

So far it seems to work, also fixed my issue with localhosting so I was able to test it and it appeared to run well.

Oprime has indeed helped with making this and keeping it functional so that's epic, thank the big man for the help to let this go faster B)

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
