### PR TITLE
Update ingotcrafting.dm

### DIFF
--- a/code/modules/mining/ingotcrafting.dm
+++ b/code/modules/mining/ingotcrafting.dm
@@ -403,7 +403,7 @@
 	if(isAutochisel(W)||isChisel(W))
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 
-		var/craftingchoices = list("Messina Pattern 'Pewter' stub pistol", "Boscelot Pattern Stub Rifle", "SMG magazine (9mm)", "Speed Loaders (.44)", "Loose Rifle Ammo (7.62)", ) //lists all possible crafting choices
+		var/craftingchoices = list("Messina Pattern 'Pewter' stub pistol", "Boscelot Pattern Stub Rifle", "SMG magazine (9mm)", "Speed Loaders (.44)", "Loose Rifle Ammo (7.62)", "Machine Steel", ) //lists all possible crafting choices
 
 
 		var/craftchoice = input("Choose what to craft", "Available crafts") as null|anything in craftingchoices
@@ -439,7 +439,12 @@
 				src.whatwemaking = 5
 				src.ismarked = 1
 				src.name = "Iron Ingot (Loose Rifle Ammo (7.62))"
-
+			if("Machine Steel")
+				visible_message("[user]'s auto-chisel moves in a blur over [src], marking it as a future unit of Steel.")
+				playsound(src, 'sound/effects/autochisel.ogg', 100, 1, 1)
+				src.whatwemaking = 6
+				src.ismarked = 1
+				src.name = "Iron Ingot (Steel)"
 
 
 	if(isLasercutter(W)||isHammer(W))
@@ -506,7 +511,17 @@
 					user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 					visible_message("[user] cuts away at the ingot, it will take a few more passes until we're done!")
 					playsound(src, 'sound/effects/lasercutter.ogg', 100, 1, 1)
-
+			if(6)
+				if(prob(25))
+					user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+					visible_message("[user] carefully carves the ingot into a blessed unit of Steel! Now take the ingot and dip it in the holy oil!")
+					src.rubtheoils = 1
+					src.name = "Iron Ingot (Carved Steel)"
+					playsound(src, 'sound/effects/lasercutter.ogg', 100, 1, 1)
+				else
+					user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+					visible_message("[user] cuts away at the ingot, it will take a few more passes until we're done!")
+					playsound(src, 'sound/effects/lasercutter.ogg', 100, 1, 1)
 
 
 	if(isHolyoils(W)||isLube(W))
@@ -549,7 +564,12 @@
 				new /obj/item/ammo_magazine/handful/brifle_handful(user.loc)
 				qdel(src)
 				return
-
+			if(6)
+				playsound(src, 'sound/voice/blessing.ogg', 100, 0, 1)
+				visible_message("As the carvings are lathered with the holy oil they begin to take their intended shape!")
+				new /obj/item/stack/material/iron(user.loc,10)
+				qdel(src)
+				return
 
 /*
    _____ _ _


### PR DESCRIPTION
Added a way to turn Iron Ingots into sheets of metal using the existing ingot crafting system.

This is a good thing for the game because it allows for a source of metal sheets for the AdMech (or anyone who gets their hands on the tools) to create more metal during a round without direct admin intervention. It should be producing 10 sheets of metal for 1 iron ingot - mostly because metal gets used at a MUCH higher rate than any other material, and 1-to-1 with Iron Ingots didn't seem like it'd be a good idea, but I'm not married to that conversion rate.

As of this pull request, it has not been tested, because I do not have VCS, but I basically just copy-pasted the existing formatting and changed the values necessary.