### PR TITLE
Ork Balance

### DIFF
--- a/code/modules/mob/living/carbon/human/species/races/orks/ork_species.dm
+++ b/code/modules/mob/living/carbon/human/species/races/orks/ork_species.dm
@@ -7,15 +7,15 @@
 	deform = 'icons/mob/human_races/r_def_ork.dmi'
 	min_age = 1
 	max_age = 600
-	total_health = 150
+	total_health = 80
 	var/pain_power = 120
 	gluttonous = GLUT_ITEM_NORMAL
 	mob_size = MOB_LARGE
 	strength = STR_HIGH
 //	sexybits_location = BP_GROIN
 	species_flags = SPECIES_FLAG_NO_EMBED|SPECIES_FLAG_NO_SLIP
-	brute_mod = 0.75
-	burn_mod = 0.75 
+	brute_mod = 0.72
+	burn_mod = 0.76
 	base_auras = list(
 		/obj/aura/regenerating/human/ork
 		)


### PR DESCRIPTION
Ork Brain Health lowered even more so they die ever faster now.

Their brute modifier is 0.72 from 0.75

Laser modifier is 0.76 from 0.75

What this means is burns hurt them more then bullets which is just ork physiology. You can shoot them with regular bullets and it mostly just stings, but bolter rounds, lasguns and flamers are the only real threats to an Ork outside of a bullet to the brain.