### PR TITLE
Guard Return + QOL

### DIFF
--- a/code/game/jobs/job/astra_militarum.dm
+++ b/code/game/jobs/job/astra_militarum.dm
@@ -54,6 +54,7 @@
 
 /datum/job/ig/guardsman
 	title = "Imperial Guardsman"
+	supervisors = "The Captain or Commissar"
 	total_positions = 0
 	spawn_positions = 0
 	social_class = SOCIAL_CLASS_MED //Guards are at least pretty respected in imperial society
@@ -113,8 +114,8 @@
 
 /datum/job/ig/whiteshield
 	title = "PDF Trooper"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 1
+	spawn_positions = 1
 	open_when_dead = FALSE
 	social_class = SOCIAL_CLASS_MED //Guards are at least pretty respected in imperial society
 	outfit_type = /decl/hierarchy/outfit/job/whiteshield
@@ -149,6 +150,7 @@
 	title = "Imperial Guard Specialist"
 	total_positions = 0
 	spawn_positions = 0
+	supervisors = "The Captain or Commissar"
 	open_when_dead = FALSE
 	outfit_type = /decl/hierarchy/outfit/job/sharpshooter
 	auto_rifle_skill = 10
@@ -210,8 +212,8 @@ datum/job/ig/bullgryn
 	title = "Bullgryn"
 	social_class = SOCIAL_CLASS_MED //is it lore accurate? no, does it make sense to have a bullgryn here? also no
 	selection_color = "#33813A"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	supervisors = "Da Emprah. Da Commesar, and da little on's!"
 	outfit_type = /decl/hierarchy/outfit/job/bullgryn
 	latejoin_at_spawnpoints = TRUE
@@ -296,8 +298,8 @@ datum/job/ig/bullgryn
 /datum/job/ig/sergeant
 	title = "Sergeant"
 	supervisors = "The Captain or Commissar"
-	total_positions = 0
-	spawn_positions = 0
+	total_positions = 1
+	spawn_positions = 1
 	open_when_dead = FALSE
 	selection_color = "#23742a"
 	department_flag = SEC
@@ -367,6 +369,7 @@ datum/job/ig/bullgryn
 /datum/job/ig/medicae
 	title = "Combat Medicae"
 	department = "Medical"
+	supervisors = "The Captain or Commissar"
 	department_flag = SEC
 	social_class = SOCIAL_CLASS_MED
 	can_be_in_squad = TRUE

--- a/code/game/jobs/job/pilgrims.dm
+++ b/code/game/jobs/job/pilgrims.dm
@@ -143,13 +143,13 @@ Pilgrim Fate System
 			U.add_skills(rand(5,8),rand(4,6),rand(3,6),rand(2,6),rand(2,6)) //melee, ranged, med, eng, surgery
 			equip_to_slot_or_store_or_drop(new /obj/item/clothing/under/rank/victorian, slot_w_uniform)
 			new /obj/item/glass_jar(src.loc)
-			new /obj/item/storage/backpack/satchel/warfare(src.loc)
+			equip_to_slot_or_store_or_drop(new /obj/item/storage/backpack/satchel/warfare, slot_back)
 			new /obj/item/device/radio/headset/headset_service(src.loc)
 			new /obj/item/device/flashlight/lantern(src.loc)
 			new /obj/item/paper/administratum(src.loc)
 			new /obj/item/pen(src.loc)
 			equip_to_slot_or_store_or_drop(new /obj/item/card/id/pilgrim/penitent, slot_wear_id)
-			new /obj/item/clothing/shoes/jackboots/pilgrim_boots(src.loc)
+			equip_to_slot_or_store_or_drop(new /obj/item/clothing/shoes/jackboots/pilgrim_boots, slot_shoes)
 			U.verbs -= list(/mob/living/carbon/human/proc/penitentclass,) //removes verb
 			U.stat = CONSCIOUS
 			U.sleeping = 0
@@ -159,7 +159,7 @@ Pilgrim Fate System
 				to_chat(U,"<span class='goodmood'><b><font size=3>You have had glimpses of the future, in these waking dreams you see yourself fighting against a terrible foe. A dark and hideous creature, this day will come soon. Train and prepare yourself for this fight, track down the great beasts of the land. You are not hunted. You are the hunter. </font></b></span>")
 				U.add_stats(rand(18,19), rand(14,16), rand(12,18), rand (12,14))
 				new /obj/item/stack/thrones3/twenty(src.loc) 
-				new /obj/item/clothing/suit/armor/exile(src.loc)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/armor/exile, slot_wear_suit)
 				new /obj/item/melee/sword/machete/chopper/heavy/slayer(src.loc) 
 				
 			else if(prob(15))
@@ -168,7 +168,7 @@ Pilgrim Fate System
 				U.add_stats(rand(16,19), rand(16,19), rand(19,21), rand (14,16)) 
 				U.add_skills(rand(5,8),rand(5,6),rand(5,6),rand(2,6),rand(5,6))
 				new /obj/item/stack/thrones3/twenty(src.loc)
-				new /obj/item/clothing/suit/armor/scum2(src.loc)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/armor/scum2, slot_wear_suit)
 				new /obj/item/reagent_containers/food/snacks/threebread(src.loc)
 				var/datum/heretic_deity/deity = GOD(U.client.prefs.cult)
 					deity.add_cultist(U)
@@ -192,7 +192,7 @@ Pilgrim Fate System
 					new /obj/item/storage/box/sniperammo/apds/bos(src.loc)
 				new /obj/item/ammo_magazine/handful/brifle_handful/ms(src.loc)
 				new /obj/item/ammo_magazine/handful/brifle_handful(src.loc)
-				new /obj/item/clothing/suit/sherpa(src.loc)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/sherpa, slot_wear_suit)
 				new /obj/item/reagent_containers/food/snacks/threebread(src.loc)
 			else // Add a fate that is high chance, you are a target of a bounty and give them clothing that cannot be removed which is a criminal marker. Criminal Barcode. Penitent Markings. Penitent Tattoo.
 				to_chat(U,"<span class='danger'><b><font size=4>THE TRIBAL</font></b></span>")
@@ -200,20 +200,20 @@ Pilgrim Fate System
 				new /obj/item/stack/thrones3/twenty(src.loc) 
 				new /obj/item/stack/thrones3/twenty(src.loc) 
 				new /obj/item/melee/trench_axe/bspear/hunter(src.loc) 
-				new /obj/item/clothing/suit/armor/leather(src.loc)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/armor/leather, slot_wear_suit)
 				to_chat(U,"<span class='goodmood'><b><font size=3>You are a local hunter and tribal from one of the many wandering tribes of Messina, you've only recently learned of Low Gothic and are adjusting to imperial rule.. </font></b></span>")
 		if("Nomad")
 			U.add_skills(rand(5,8),rand(7,9),rand(5,7),rand(1,3),rand(1,6)) //melee, ranged, med, eng, surgery
 			equip_to_slot_or_store_or_drop(new /obj/item/clothing/under/rank/victorian, slot_w_uniform)
-			new /obj/item/clothing/shoes/jackboots/pilgrim_boots(src.loc)
+			equip_to_slot_or_store_or_drop(new /obj/item/clothing/shoes/jackboots/pilgrim_boots, slot_shoes)
 			new /obj/item/clothing/head/ushanka2(src.loc)
 			new /obj/item/device/radio/headset/headset_service(src.loc)
-			new /obj/item/storage/backpack/satchel/warfare(src.loc)
+			equip_to_slot_or_store_or_drop(new /obj/item/storage/backpack/satchel/warfare, slot_back)
 			new /obj/item/device/flashlight/lantern(src.loc) 
 			equip_to_slot_or_store_or_drop(new /obj/item/card/id/pilgrim/penitent, slot_wear_id)
 			new /obj/item/storage/belt/stalker(src.loc) 
-			new /obj/item/clothing/head/pillbox(src.loc) 
-			new /obj/item/clothing/suit/chokha(src.loc) 
+			//new /obj/item/clothing/head/pillbox(src.loc) 
+			//new /obj/item/clothing/suit/chokha(src.loc) 
 			U.verbs -= list(/mob/living/carbon/human/proc/penitentclass,)
 			U.stat = CONSCIOUS
 			U.sleeping = 0
@@ -225,8 +225,8 @@ Pilgrim Fate System
 				new /obj/item/melee/trench_axe/bardiche/beast(src.loc)
 				new /obj/item/reagent_containers/food/snacks/threebread(src.loc)
 				new /obj/item/melee/sword/combat_knife/bowie(src.loc)
-				new /obj/item/clothing/suit/armor/bonearmor(src.loc)
-				new /obj/item/clothing/head/helmet/dragon(src.loc)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/armor/bonearmor, slot_wear_suit)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/head/helmet/dragon, slot_head)
 			else
 				to_chat(U,"<span class='danger'><b><font size=4>THE EXPLORER</font></b></span>")
 				to_chat(U,"<span class='goodmood'>A skilled explorer of frontier worlds, you've plied your trade aiding the most unsensible of imperials and even xenos survive otherwise suicidal treks into alien worlds. Here you are once again, upon a xenos tainted world likely a few steps from your grave.</font></b></span>")
@@ -239,18 +239,18 @@ Pilgrim Fate System
 					new /obj/item/gun/energy/pulse/plasma/pistol/glock(src.loc)
 				else
 					new /obj/item/gun/energy/las/triplex(src.loc)
-				new /obj/item/clothing/suit/armor/ranger2(src.loc)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/armor/ranger2, slot_wear_suit)
 				new /obj/item/paper/administratum/weapon4(src.loc)
 				new /obj/item/pen(src.loc)
 				new /obj/item/paper/administratum/theta(src.loc)
 		if("Scum") // Pariah story. The magical 357
 			 //ex criminal, not fed very well, but random stats
 			U.add_skills(rand(5,10),rand(5,10),rand(5,10),rand(5,10),rand(5,10)) //melee, ranged, med, eng, surgery
-			new /obj/item/clothing/shoes/jackboots/pilgrim_boots(src.loc)
+			equip_to_slot_or_store_or_drop(new /obj/item/clothing/shoes/jackboots/pilgrim_boots, slot_shoes)
 			new /obj/item/device/radio/headset/headset_sci(src.loc)
 			equip_to_slot_or_store_or_drop(new /obj/item/card/id/pilgrim/penitent, slot_wear_id)
 			new /obj/item/torch/self_lit(src.loc)
-			new /obj/item/storage/backpack/satchel/warfare(src.loc)
+			equip_to_slot_or_store_or_drop(new /obj/item/storage/backpack/satchel/warfare, slot_back)
 			U.verbs -= list(/mob/living/carbon/human/proc/penitentclass,)
 			U.stat = CONSCIOUS
 			U.sleeping = 0
@@ -262,11 +262,11 @@ Pilgrim Fate System
 				if(prob(50))
 					equip_to_slot_or_store_or_drop(new /obj/item/clothing/under/rank/victorian, slot_w_uniform)
 				else if(prob(50))
-					new /obj/item/clothing/under/rank/victorian/blred(src.loc)
+					equip_to_slot_or_store_or_drop(new /obj/item/clothing/under/rank/victorian/blred, slot_w_uniform)
 				else
-					new /obj/item/clothing/under/rank/victorian/redbl(src.loc)
-				new /obj/item/clothing/suit/scum(src.loc)
-				new /obj/item/clothing/head/scum(src.loc)
+					equip_to_slot_or_store_or_drop(new /obj/item/clothing/under/rank/victorian/redbl, slot_w_uniform)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/scum, slot_wear_suit)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/head/scum, slot_head)
 				new /obj/item/storage/fancy/cigarettes/dromedaryco(src.loc)
 				new /obj/item/storage/fancy/cigarettes/dromedaryco(src.loc)
 				new /obj/item/storage/pill_bottle/happy(src.loc) 
@@ -285,22 +285,22 @@ Pilgrim Fate System
 				to_chat(U,"<span class='danger'><b><font size=4>THE PENITENT</font></b></span>")
 				to_chat(U,"<span class='goodmood'>You are a penitent, after committing several horrible crimes to the imperium, you were arrested and imprisoned for years before being released by the church. As per your punishment you are marked and must take upon the burdens of others to ease your own...</font></b></span>")
 				U.add_stats(rand(16,17), rand(16,17), rand(12,16), rand (10,15))
-				new /obj/item/clothing/under/rank/penitent(src.loc)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/under/rank/penitent, slot_w_uniform)
 				new /obj/item/gun/projectile/slugrevolver/penitent(src.loc)
 				new /obj/item/ammo_magazine/c44(src.loc)
 				new /obj/item/ammo_magazine/c44(src.loc)
-				new /obj/item/clothing/suit/raggedrobe(src.loc)
-				new /obj/item/clothing/head/plebhood(src.loc)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/raggedrobe, slot_wear_suit)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/head/plebhood, slot_head)
 				new /obj/item/paper/administratum/weapon3(src.loc)
 				new /obj/item/pen(src.loc)
 				if(prob(25))
 					new /obj/item/device/radio/headset/headset_sci(src.loc)
 		if("Witch Hunter")
 			U.add_skills(rand(7,10),rand(8,10),rand(3,6),rand(2,4),rand(2,6)) //melee, ranged, med, eng, surgery
-			new /obj/item/storage/backpack/satchel/warfare(src.loc)
+			equip_to_slot_or_store_or_drop(new /obj/item/storage/backpack/satchel/warfare, slot_back)
 			equip_to_slot_or_store_or_drop(new /obj/item/clothing/under/rank/victorian, slot_w_uniform)
 			new /obj/item/device/flashlight/lantern(src.loc) 
-			new /obj/item/clothing/shoes/jackboots/pilgrim_boots(src.loc)
+			equip_to_slot_or_store_or_drop(new /obj/item/clothing/shoes/jackboots/pilgrim_boots, slot_shoes)
 			new /obj/item/clothing/accessory/holster/hip(src.loc)
 			new /obj/item/gun/energy/las/laspistol(src.loc)
 			equip_to_slot_or_store_or_drop(new /obj/item/card/id/key/grand/monastary, slot_wear_id)
@@ -311,19 +311,19 @@ Pilgrim Fate System
 			to_chat(U,"<span class='goodmood'>You are a Witch Hunter -- a unique subset of the Bounty Hunter Guild attached to the Chamber Militant, working both as Servant to the Ecclesiarchy and a 'bounty hunter' that the Ecclesiarchy can rely upon without tainting their own hands.</font></b></span>")
 			U.add_stats(rand(16,17), rand(14,16), rand(14,16), rand (10,12)) //veteran mercenary
 			new /obj/item/melee/sword/cane(src.loc)
-			new /obj/item/clothing/head/helmet/witch(src.loc)
-			new /obj/item/clothing/suit/armor/witch(src.loc)
+			equip_to_slot_or_store_or_drop(new /obj/item/clothing/head/helmet/witch, slot_head)
+			equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/armor/witch, slot_wear_suit)
 			new /obj/item/device/radio/headset/headset_sci(src.loc)
 			new /obj/item/paper/administratum/weapon4(src.loc)
 			new /obj/item/pen(src.loc)
 			new /obj/item/paper/administratum/theta(src.loc)
 		if("Mercenary")
 			U.add_skills(rand(7,10),rand(8,10),rand(3,6),rand(2,4),rand(2,6)) //melee, ranged, med, eng, surgery
-			new /obj/item/storage/backpack/satchel/warfare(src.loc)
+			equip_to_slot_or_store_or_drop(new /obj/item/storage/backpack/satchel/warfare, slot_back)
 			equip_to_slot_or_store_or_drop(new /obj/item/clothing/under/rank/victorian, slot_w_uniform)
 			new /obj/item/device/radio/headset/headset_service(src.loc)
 			new /obj/item/device/flashlight/lantern(src.loc) 
-			new /obj/item/clothing/shoes/jackboots/pilgrim_boots(src.loc)
+			equip_to_slot_or_store_or_drop(new /obj/item/clothing/shoes/jackboots/pilgrim_boots, slot_shoes)
 			equip_to_slot_or_store_or_drop(new /obj/item/card/id/pilgrim/penitent, slot_wear_id)
 			U.verbs -= list(/mob/living/carbon/human/proc/penitentclass,)
 			U.stat = CONSCIOUS
@@ -334,8 +334,8 @@ Pilgrim Fate System
 				to_chat(U,"<span class='goodmood'>A holy warrior of your chosen god, you work on behalf of the Ecclesiarchy(or the cult) as a slayer of the heretical and unfaithful. Face against the dark and protect your flock... for a price.</font></b></span>")
 				U.add_stats(rand(16,18), rand(14,16), rand(16,18), rand (10,12)) //veteran mercenary
 				new /obj/item/melee/trench_axe/glaive/adamantine(src.loc)
-				new /obj/item/clothing/suit/armor/brigandine(src.loc)
-				new /obj/item/clothing/head/helmet/hero(src.loc)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/armor/brigandine, slot_wear_suit)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/head/helmet/hero, slot_head)
 				new /obj/item/paper/administratum/weapon3(src.loc)
 				new /obj/item/paper/administratum/theta(src.loc)
 				new /obj/item/pen(src.loc)
@@ -356,7 +356,7 @@ Pilgrim Fate System
 				new /obj/item/paper/administratum/weapon4(src.loc)
 				new /obj/item/paper/administratum/theta(src.loc)
 				new /obj/item/pen(src.loc)
-				new /obj/item/clothing/suit/armor/armoredtrench(src.loc)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/armor/armoredtrench, slot_wear_suit)
 				if(prob(2))
 					new /obj/item/device/radio/headset/headset_eng(src.loc)
 				if(prob(2))
@@ -376,13 +376,13 @@ Pilgrim Fate System
 				new /obj/item/paper/administratum/theta(src.loc)
 				new /obj/item/pen(src.loc)
 				if(prob(60))
-					new /obj/item/clothing/suit/armor/bountyhunter2(src.loc)
-					new /obj/item/clothing/head/bountyhead(src.loc)
+					equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/armor/bountyhunter2, slot_wear_suit)
+					equip_to_slot_or_store_or_drop(new /obj/item/clothing/head/bountyhead, slot_head)
 				else if(prob(50))
-					new /obj/item/clothing/suit/armor/carapace3(src.loc)
-					new /obj/item/clothing/head/helmet/marinehelm(src.loc)
+					equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/armor/carapace3, slot_wear_suit)
+					equip_to_slot_or_store_or_drop(new /obj/item/clothing/head/helmet/marinehelm, slot_head)
 				else if(prob(30))
-					new /obj/item/clothing/suit/armor/vanpa(src.loc)
+					equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/armor/vanpa, slot_wear_suit)
 				else
 					new /obj/item/ammo_magazine/c50(src.loc)
 				if(prob(15))
@@ -417,9 +417,9 @@ Pilgrim Fate System
 
 		if("Mysterious Citizen")
 			U.add_skills(rand(7,10),rand(7,9),rand(2,4),rand(3,4),rand(2,3)) //melee, ranged, med, eng, surgery
-			new /obj/item/storage/backpack/satchel/warfare(src.loc)
+			equip_to_slot_or_store_or_drop(new /obj/item/storage/backpack/satchel/warfare, slot_back)
 			new /obj/item/device/radio/headset/headset_service(src.loc)
-			new /obj/item/clothing/shoes/jackboots/pilgrim_boots(src.loc)
+			equip_to_slot_or_store_or_drop(new /obj/item/clothing/shoes/jackboots/pilgrim_boots, slot_shoes)
 			equip_to_slot_or_store_or_drop(new /obj/item/card/id/pilgrim/penitent, slot_wear_id)
 			new /obj/item/device/flashlight/lantern(src.loc)
 			U.stat = CONSCIOUS
@@ -434,9 +434,9 @@ Pilgrim Fate System
 				new /obj/item/melee/sword/skinning_knife(src.loc)
 				new /obj/item/storage/firstaid/surgery(src.loc)
 				new /obj/item/clothing/mask/gas/prac_mask(src.loc)
-				new /obj/item/clothing/suit/prac_arpon(src.loc)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/prac_arpon, slot_wear_suit)
 				new /obj/item/clothing/gloves/prac_gloves(src.loc)
-				new /obj/item/clothing/shoes/prac_boots(src.loc)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/shoes/prac_boots, slot_shoes)
 				new /obj/item/toothpuller(src.loc)
 				equip_to_slot_or_store_or_drop(new /obj/item/card/id/ring/disgracedmedicae, slot_wear_id)
 				equip_to_slot_or_store_or_drop(new /obj/item/clothing/under/rank/victorian, slot_w_uniform)
@@ -458,10 +458,10 @@ Pilgrim Fate System
 				new /obj/item/gun/projectile/talon/renegade(src.loc)
 				if(prob(50))
 					new /obj/item/device/batterer(src.loc)
-				new /obj/item/clothing/suit/armor/slumcoat(src.loc)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/armor/slumcoat, slot_wear_suit)
 				new /obj/item/storage/box/syndie_kit/imp_freedom(src.loc)
-				new /obj/item/clothing/head/chameleon(src.loc)
-				new /obj/item/clothing/under/chameleon(src.loc)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/head/chameleon, slot_head)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/under/chameleon, slot_w_uniform)
 				var/datum/heretic_deity/deity = GOD(U.client.prefs.cult)
 					deity.add_cultist(U)
 				if(prob(1))
@@ -476,12 +476,12 @@ Pilgrim Fate System
 				new /obj/item/ammo_magazine/a357/ms(src.loc)
 				new /obj/item/ammo_magazine/a357/ms(src.loc)
 				new /obj/item/storage/briefcase/crimekit(src.loc)
-				new /obj/item/clothing/suit/armor/bountyhunter2(src.loc)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/armor/bountyhunter2, slot_wear_suit)
 				new /obj/item/clothing/suit/armor/tduster(src.loc)
-				new /obj/item/clothing/head/det(src.loc)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/head/det, slot_head)
 				new /obj/item/storage/fancy/cigarettes/dromedaryco(src.loc)
 				new /obj/item/flame/lighter(src.loc)
-				new /obj/item/clothing/under/det/black(src.loc)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/under/det/black, slot_w_uniform)
 				new /obj/item/paper/administratum/weapon3(src.loc)
 				new /obj/item/paper/administratum/theta(src.loc)
 				new /obj/item/pen(src.loc)
@@ -489,12 +489,12 @@ Pilgrim Fate System
 			U.add_stats(rand(16,18), rand(14,16), rand(14,18), rand (12,14)) //
 			U.add_skills(rand(6,8),rand(4,7),rand(3,6),rand(5,6),rand(2,6)) //melee, ranged, med, eng, surgery
 			new /obj/item/clothing/gloves/thick(src.loc)
-			new /obj/item/clothing/head/helmet/hard_had(src.loc)
+			equip_to_slot_or_store_or_drop(new /obj/item/clothing/head/helmet/hard_had, slot_head)
 			equip_to_slot_or_store_or_drop(new /obj/item/clothing/under/rank/victorian, slot_w_uniform)
 			new /obj/item/storage/backpack/satchel/satchel_eng(src.loc)
-			new /obj/item/pickaxe/newpick(src.loc)
-			new /obj/item/clothing/suit/miner(src.loc)
-			new /obj/item/clothing/shoes/prac_boots(src.loc)
+			new /obj/item/pickaxe/mechanicus(src.loc)
+			equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/miner, slot_wear_suit)
+			equip_to_slot_or_store_or_drop(new /obj/item/clothing/shoes/prac_boots, slot_shoes)
 			new /obj/item/device/flashlight/lantern(src.loc)
 			equip_to_slot_or_store_or_drop(new /obj/item/card/id/ring/disgracedmedicae, slot_wear_id)
 			new /obj/item/stack/thrones3/twenty(src.loc)
@@ -502,7 +502,7 @@ Pilgrim Fate System
 			new /obj/item/paper/administratum/weapon4(src.loc)
 			new /obj/item/pen(src.loc)
 			to_chat(U,"<span class='danger'><b><font size=4>THE BROKEBACK MINER</font></b></span>")
-			to_chat(U,"<span class='goodmood'><b><font size=3>A veteran of many digsites you travelled the galaxy looking for work.</font></b></span>")
+			to_chat(U,"<span class='goodmood'><b><font size=3>A veteran of many digsites you were press ganged into service to the mechanicus here on Messina.</font></b></span>")
 			U.stat = CONSCIOUS
 			U.verbs -= list(/mob/living/carbon/human/proc/citizenclass,)
 			U.sleeping = 0
@@ -511,15 +511,15 @@ Pilgrim Fate System
 			U.add_stats(rand(15,17), rand(14,17), rand(14,16), rand (13,15)) //
 			U.add_skills(rand(6,8),rand(6,8),rand(4,6),rand(5,6),rand(2,6)) //melee, ranged, med, eng, surgery
 			new /obj/item/clothing/gloves/thick(src.loc)
-			new /obj/item/storage/backpack/satchel/warfare(src.loc)
+			equip_to_slot_or_store_or_drop(new /obj/item/storage/backpack/satchel/warfare, slot_back)
 			equip_to_slot_or_store_or_drop(new /obj/item/clothing/under/rank/victorian, slot_w_uniform)
 			new /obj/item/device/radio/headset/red_team(src.loc)
 			new /obj/item/device/flashlight/lantern(src.loc) 
 			new /obj/item/clothing/shoes/jackboots/noble(src.loc)
 			equip_to_slot_or_store_or_drop(new /obj/item/card/id/key/grand/monastary, slot_wear_id)
 			new /obj/item/stack/thrones/five(src.loc)
-			new /obj/item/clothing/head/helmet/hevhelm/palace(src.loc)
-			new /obj/item/clothing/suit/armor/brigandine/palace(src.loc)
+			equip_to_slot_or_store_or_drop(new /obj/item/clothing/head/helmet/hevhelm/palace, slot_head)
+			equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/armor/brigandine/palace, slot_wear_suit)
 			new /obj/item/melee/trench_axe/glaive/adamantine(src.loc)
 			new /obj/item/paper/administratum/weapon3(src.loc)
 			new /obj/item/pen(src.loc)
@@ -536,18 +536,18 @@ Pilgrim Fate System
 			new /obj/item/clothing/gloves/thick(src.loc)
 			new /obj/item/clothing/mask/gas/half/cadianrespirator(src.loc)
 			equip_to_slot_or_store_or_drop(new /obj/item/clothing/under/cadian_uniform, slot_w_uniform)
-			new /obj/item/storage/backpack/satchel/warfare(src.loc)
-			if(prob(15))
-				new /obj/item/clothing/suit/armor/whiteshield/pdf(src.loc)
-				new /obj/item/clothing/head/helmet/whiteshield/pdf(src.loc)
+			equip_to_slot_or_store_or_drop(new /obj/item/storage/backpack/satchel/warfare, slot_back)
+			if(prob(25))
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/armor/whiteshield/pdf, slot_wear_suit)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/head/helmet/whiteshield/pdf, slot_head)
 				new /obj/item/gun/projectile/automatic/heavystubber(src.loc)
-			if(prob(45))
-				new /obj/item/clothing/suit/armor/whiteshield/pdf/medic(src.loc)
+			if(prob(35))
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/armor/whiteshield/pdf/medic, slot_wear_suit)
 				new /obj/item/storage/belt/medical/full(src.loc)
-				new /obj/item/clothing/head/helmet/whiteshield/pdf/medic(src.loc)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/head/helmet/whiteshield/pdf/medic, slot_head)
 			else
-				new /obj/item/clothing/suit/armor/whiteshield/pdf/spec(src.loc)
-				new /obj/item/clothing/head/helmet/whiteshield/pdf/spec(src.loc)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/armor/whiteshield/pdf/spec, slot_wear_suit)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/head/helmet/whiteshield/pdf/spec, slot_head)
 				new /obj/item/cell/plasma(src.loc)
 			new /obj/item/clothing/shoes/jackboots/cadian(src.loc)
 			new /obj/item/device/flashlight/lantern(src.loc)
@@ -568,10 +568,10 @@ Pilgrim Fate System
 			U.add_skills(rand(6,8),rand(4,8),rand(2,8),rand(2,8),rand(2,8)) //melee, ranged, med, eng, surgery
 			equip_to_slot_or_store_or_drop(new /obj/item/clothing/under/rank/victorian, slot_w_uniform)
 			new /obj/item/device/radio/headset/headset_service(src.loc)
-			new /obj/item/storage/backpack/satchel/warfare(src.loc)
+			equip_to_slot_or_store_or_drop(new /obj/item/storage/backpack/satchel/warfare, slot_back)
 			new /obj/item/device/flashlight/lantern(src.loc)
 			equip_to_slot_or_store_or_drop(new /obj/item/card/id/pilgrim/penitent, slot_wear_id)
-			new /obj/item/clothing/shoes/jackboots/pilgrim_boots(src.loc)
+			equip_to_slot_or_store_or_drop(new /obj/item/clothing/shoes/jackboots/pilgrim_boots, slot_shoes)
 			U.verbs -= list(/mob/living/carbon/human/proc/penitentclass,)
 			U.stat = CONSCIOUS
 			U.sleeping = 0
@@ -580,8 +580,8 @@ Pilgrim Fate System
 				to_chat(U,"<span class='danger'><b><font size=4>THE SORCERER</font></b></span>")
 				to_chat(U,"<span class='goodmood'>You're a foul sorcerer of chaos magics -- unless you aren't. In which case you're a crackpot. Or are you? Who knows. Best hide your robes unless you want to be shot to pieces though...</font></b></span>")
 				U.add_stats(rand(15,16), rand(14,16), rand(14,18), rand (12,16)) //
-				new /obj/item/clothing/head/culthood/magus(src.loc)
-				new /obj/item/clothing/suit/cultrobes/magusred(src.loc)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/head/culthood/magus, slot_head)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/cultrobes/magusred, slot_wear_suit)
 				if(prob(10))
 					new /obj/item/device/radio/headset/blue_team/all(src.loc)
 				new /obj/item/reagent_containers/food/snacks/warfare/rat(src.loc)
@@ -594,7 +594,7 @@ Pilgrim Fate System
 				to_chat(U,"<span class='danger'><b><font size=4>THE MERCHANT</font></b></span>")
 				to_chat(U,"<span class='goodmood'>Guided by your lust for thrones you smelled opportunity on this newly founded world. You have connectoins to the local gangs and trade guilds, find allies to further your interests in Messina.</font></b></span>")
 				U.add_stats(rand(14,15), rand(14,15), rand(15,17), rand (15,16))
-				new /obj/item/clothing/suit/armor/vest/leather/tailcoat(src.loc)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/armor/vest/leather/tailcoat, slot_wear_suit)
 				new /obj/item/stack/thrones/five(src.loc) 
 				new /obj/item/stack/thrones2/ten(src.loc) 
 				new /obj/item/stack/thrones3/twenty(src.loc) 
@@ -615,8 +615,8 @@ Pilgrim Fate System
 				new /obj/item/stack/thrones/five(src.loc) 
 				new /obj/item/stack/thrones2/ten(src.loc) 
 				new /obj/item/stack/thrones3/twenty(src.loc)
-				new /obj/item/clothing/suit/musician(src.loc)
-				new /obj/item/clothing/head/musichat(src.loc)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/musician, slot_wear_suit)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/head/musichat, slot_head)
 				new /obj/item/instrument/guitar(src.loc)
 				new /obj/item/device/violin(src.loc)
 				new /obj/item/paper/administratum/weapon3(src.loc)
@@ -625,13 +625,13 @@ Pilgrim Fate System
 		if("Fate Touched")
 			U.add_stats(rand(16,17), rand(15,17), rand(10,16), rand (12,16)) 
 			U.add_skills(rand(2,7),rand(5,7),rand(1,6),rand(1,6),rand(1,6)) //melee, ranged, med, eng, surgery
-			new /obj/item/clothing/under/rank/chaplain(src.loc)
-			new /obj/item/storage/backpack/satchel/warfare(src.loc)
+			equip_to_slot_or_store_or_drop(new /obj/item/clothing/under/rank/chaplain, slot_w_uniform)
+			equip_to_slot_or_store_or_drop(new /obj/item/storage/backpack/satchel/warfare, slot_back)
 			new /obj/item/device/radio/headset/headset_sci(src.loc)
 			new /obj/item/book/manual(src.loc)
 			equip_to_slot_or_store_or_drop(new /obj/item/card/id/pilgrim/penitent, slot_wear_id)
 			new /obj/item/device/flashlight/lantern(src.loc)
-			new /obj/item/clothing/shoes/jackboots/pilgrim_boots(src.loc)
+			equip_to_slot_or_store_or_drop(new /obj/item/clothing/shoes/jackboots/pilgrim_boots, slot_shoes)
 			U.verbs -= list(/mob/living/carbon/human/proc/citizenclass,)
 			U.stat = CONSCIOUS
 			U.sleeping = 0
@@ -640,11 +640,11 @@ Pilgrim Fate System
 				to_chat(U,"<span class='danger'><b><font size=4>THE SORCERER</font></b></span>")
 				to_chat(U,"<span class='goodmood'>You're a foul sorcerer of chaos magics -- unless you aren't. In which case you're a crackpot. Or are you? Who knows. Best hide your robes unless you want to be shot to pieces though...</font></b></span>")
 				U.add_stats(rand(15,16), rand(14,16), rand(14,18), rand (12,16)) //
-				new /obj/item/clothing/suit/armor/knighthosp(src.loc)
-				new /obj/item/clothing/head/helmet/hauberk(src.loc)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/armor/knighthosp, slot_wear_suit)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/head/helmet/hauberk, slot_head)
 				new /obj/item/reagent_containers/food/snacks/warfare/rat(src.loc)
 				new /obj/item/device/radio/headset/headset_sci(src.loc)
-				if(prob(25))
+				if(prob(30))
 					new /obj/item/device/radio/headset/blue_team/all(src.loc)
 				var/datum/heretic_deity/deity = GOD(U.client.prefs.cult)
 					deity.add_cultist(U)
@@ -652,9 +652,9 @@ Pilgrim Fate System
 				to_chat(U,"<span class='danger'><b><font size=4>THE CLERIC</font></b></span>")
 				to_chat(U,"<span class='goodmood'>Banish the heretic and redeem this world.</font></b></span>")
 				U.add_stats(rand(14,15), rand(14,15), rand(15,17), rand (15,16))
-				new /obj/item/clothing/suit/armor/knighthosp(src.loc)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/armor/knighthosp, slot_wear_suit)
 				new /obj/item/melee/chain/inqcs(src.loc) 
-				new /obj/item/clothing/head/helmet/hauberk(src.loc)
+				equip_to_slot_or_store_or_drop(new /obj/item/clothing/head/helmet/hauberk, slot_head)
 				new /obj/item/reagent_containers/food/snacks/warfare/rat(src.loc)
 				new /obj/item/device/radio/headset/headset_sci(src.loc)
 				new /obj/item/paper/administratum/weapon4(src.loc)
@@ -675,7 +675,6 @@ Pilgrim Fate System
 	latejoin_at_spawnpoints = TRUE
 	announced = FALSE
 	cultist_chance = 35
-	species_role = "Ogryn"
 
 	equip(var/mob/living/carbon/human/H)
 	//theres gonna be some redundencies here but I do not careeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
@@ -687,8 +686,7 @@ Pilgrim Fate System
 		H.verbs += list(
 			/mob/living/carbon/human/proc/ideology,
 		)
-		to_chat(H, "<span class='notice'><b><font size=3>You're an up-and-coming entrepreneur on Messina -- the wisest most big brain Ogryn bonehead that ever lived. You were sent here by House Goliath from Necromunda who supplies most of the sub-sector through the cold-trade, and the Militarum with cheap manufactured autoguns who give it by the freight-load to private armies in the frontier. Goliath expects big things from you, so you best get to grinding Oggy... </font></b></span>")
-		to_chat(H, "<span class='notice'><b><font size=3>You're an up-and-coming entrepreneur on Messina -- the wisest most big brain Ogryn bonehead that ever lived. You were sent here by House Goliath from Necromunda who supplies most of the sub-sector through the cold-trade, and the Militarum with cheap manufactured autoguns who give it by the freight-load to private armies in the frontier. Goliath expects big things from you, so you best get to grinding Oggy... </font></b></span>")
+		to_chat(H, "<span class='notice'><b><font size=3>You're an up-and-coming entrepreneur on Messina -- the wisest most big brain ganger that ever lived. Surviving the gangs of Necromunda which now supplies most of the sub-sector through the cold-trade, and the Militarum with cheap manufactured autoguns who give it by the freight-load to private armies in the frontier. Your gang expects big things from you, so you best get to grinding slummer... </font></b></span>")
 
 /*
 /datum/job/innkeeper
@@ -873,13 +871,13 @@ Pilgrim Fate System
 
 /decl/hierarchy/outfit/job/underboss
 	name = OUTFIT_JOB_NAME("Underboss")
-	uniform = /obj/item/clothing/under/ogryn/jumpsuit
-	head = /obj/item/clothing/head/ogryn
-	shoes = /obj/item/clothing/shoes/jackboots/ogryn
-	gloves = null
-	back = /obj/item/storage/backpack/satchel/warfare/ogryn
+	uniform = /obj/item/clothing/under/waiter
+	back = /obj/item/storage/backpack/satchel/warfare
 	neck = /obj/item/reagent_containers/food/drinks/canteen
-	suit = /obj/item/clothing/suit/armor/ogryn/bouncer
+	r_ear = null
+	shoes = /obj/item/clothing/shoes/dress
+	gloves = /obj/item/clothing/gloves/latex
+	r_pocket = /obj/item/storage/box/coin
 	l_ear = /obj/item/device/radio/headset/ert2
 	r_ear = null
 	l_pocket = /obj/item/device/flashlight/lantern
@@ -888,9 +886,10 @@ Pilgrim Fate System
 	r_pocket = /obj/item/storage/box/coin
 	suit_store = null
 	l_hand = /obj/item/melee/sword/machete/chopper/heavy/adamantine
-	r_hand = /obj/item/gun/projectile/ork/automatic/shoota/big
+	r_hand = /obj/item/gun/projectile/shotgun/pump/shitty/magrave
 	backpack_contents = list(
 	/obj/item/card/id/pilgrim/penitent/keeper = 1,
+	/obj/item/ammo_box/shotgun/msslug = 1,
 	/obj/item/stack/thrones2/five = 1,
 	/obj/item/stack/thrones3/twenty = 1,
 	/obj/item/pen = 1,
@@ -1125,11 +1124,11 @@ Pilgrim Fate System
 			U.add_stats(rand(14,18), rand(14,17), rand(17,19), rand (12,16))
 			U.add_skills(rand(8,10),rand(5,6),rand(1,3),rand(2,6),rand(1,2)) //melee, ranged, med, eng, surgery
 			equip_to_slot_or_store_or_drop(new /obj/item/clothing/under/rank/victorian, slot_w_uniform)
-			new /obj/item/clothing/shoes/jackboots/pilgrim_boots(src.loc) 
+			equip_to_slot_or_store_or_drop(new /obj/item/clothing/shoes/jackboots/pilgrim_boots, slot_shoes)
 			new /obj/item/clothing/suit/armor/goliathplate(src.loc) 
 			new /obj/item/clothing/head/helmet/gangerhelm(src.loc) 
 			new /obj/item/device/radio/headset/ert(src.loc) 
-			new /obj/item/storage/backpack/satchel/warfare(src.loc) 
+			equip_to_slot_or_store_or_drop(new /obj/item/storage/backpack/satchel/warfare, slot_back) 
 			new /obj/item/melee/classic_baton/trench_club(src.loc)
 			equip_to_slot_or_store_or_drop(new /obj/item/card/id/pilgrim/penitent/keeper, slot_wear_id)  
 			new /obj/item/stack/thrones3/twenty(src.loc) 
@@ -1142,7 +1141,7 @@ Pilgrim Fate System
 			U.add_stats(rand(14,17), rand(15,17), rand(14,16), rand (14,16)) //ex criminal, not fed very well, but random stats
 			U.add_skills(rand(5,6),rand(9,11),rand(2,4),rand(5,10),rand(2,4)) //melee, ranged, med, eng, surgery
 			equip_to_slot_or_store_or_drop(new /obj/item/clothing/under/rank/penitent, slot_w_uniform)
-			new /obj/item/clothing/shoes/jackboots/pilgrim_boots(src.loc) 
+			equip_to_slot_or_store_or_drop(new /obj/item/clothing/shoes/jackboots/pilgrim_boots, slot_shoes)
 			new /obj/item/clothing/suit/storage/vest/tactical(src.loc) 
 			new /obj/item/device/radio/headset/ert(src.loc) 
 			equip_to_slot_or_store_or_drop(new /obj/item/card/id/pilgrim/penitent/keeper, slot_wear_id) 
@@ -1157,10 +1156,10 @@ Pilgrim Fate System
 		if("Rogue Doc")
 			U.add_stats(rand(15,17), rand(12,15), rand(12,15), rand (15,15))
 			U.add_skills(rand(4,6),rand(4,6),rand(10,10),rand(9,10),rand(10,10)) //melee, ranged, med, eng, surgery
-			new /obj/item/storage/backpack/satchel/warfare(src.loc) 
+			equip_to_slot_or_store_or_drop(new /obj/item/storage/backpack/satchel/warfare, slot_back) 
 			equip_to_slot_or_store_or_drop(new /obj/item/clothing/under/rank/victorian, slot_w_uniform)
 			new /obj/item/storage/belt/medical/full(src.loc)  
-			new /obj/item/clothing/shoes/jackboots/pilgrim_boots(src.loc) 
+			equip_to_slot_or_store_or_drop(new /obj/item/clothing/shoes/jackboots/pilgrim_boots, slot_shoes)
 			new /obj/item/device/radio/headset/ert(src.loc) 
 			equip_to_slot_or_store_or_drop(new /obj/item/card/id/pilgrim/penitent/keeper, slot_wear_id) 
 			new /obj/item/stack/thrones3/twenty(src.loc) 

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -1,6 +1,6 @@
 /obj/item/plastique
-	name = "plastic explosives"
-	desc = "Used to put holes in specific areas without too much extra hole."
+	name = "det pack(breacher)"
+	desc = "A simple explosive charge designed for breaching large fortifications."
 	gender = PLURAL
 	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "plastic-explosive0"

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -74,6 +74,7 @@
 	name = "silver pickaxe"
 	icon_state = "spickaxe"
 	item_state = "spickaxe"
+	armor_penetration = 1
 	digspeed = 45
 	origin_tech = list(TECH_MATERIAL = 2)
 	desc = "This makes no metallurgic sense."
@@ -82,6 +83,8 @@
 	name = "mechanicus pickaxe"
 	icon_state = "spickaxe"
 	item_state = "spickaxe"
+	force = 27
+	armor_penetration = 5
 	digspeed = 35
 	origin_tech = list(TECH_MATERIAL = 2)
 	desc = "This makes no metallurgic sense."
@@ -91,6 +94,7 @@
 	icon_state = "handdrill"
 	item_state = "jackhammer"
 	digspeed = 25
+	armor_penetration = 6
 	origin_tech = list(TECH_MATERIAL = 2, TECH_POWER = 2, TECH_ENGINEERING = 2)
 	desc = "Yours is the drill that will pierce through the rock walls."
 	drill_verb = "drilling"
@@ -99,6 +103,7 @@
 	name = "sonic jackhammer"
 	icon_state = "jackhammer"
 	item_state = "jackhammer"
+	armor_penetration = 5
 	digspeed = 25 //faster than drill, but cannot dig
 	origin_tech = list(TECH_MATERIAL = 2, TECH_POWER = 2, TECH_ENGINEERING = 2)
 	desc = "Cracks rocks with sonic blasts, perfect for killing cave lizards."
@@ -109,6 +114,7 @@
 	icon_state = "gpickaxe"
 	item_state = "gpickaxe"
 	digspeed = 47
+	armor_penetration = 0
 	origin_tech = list(TECH_MATERIAL = 2)
 	desc = "This makes no metallurgic sense."
 	drill_verb = "picking"
@@ -118,6 +124,7 @@
 	icon_state = "dpickaxe"
 	item_state = "dpickaxe"
 	digspeed = 31
+	armor_penetration = 6
 	origin_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
 	desc = "A pickaxe with a diamond pick head."
 	drill_verb = "picking"
@@ -126,6 +133,7 @@
 	name = "diamond mining drill"
 	icon_state = "diamonddrill"
 	item_state = "jackhammer"
+	armor_penetration = 7
 	digspeed = 22 //Digs through walls, girders, and can dig up sand
 	origin_tech = list(TECH_MATERIAL = 2, TECH_POWER = 2, TECH_ENGINEERING = 2)
 	desc = "Yours is the drill that will pierce the heavens!"

--- a/maps/delta/warhammer-1.dmm
+++ b/maps/delta/warhammer-1.dmm
@@ -457,6 +457,13 @@
 	icon_state = "dark1"
 	},
 /area/cadiaoutpost/oa/wilds/dungeonlower)
+"ml" = (
+/obj/structure/torchwall/service{
+	dir = 4;
+	icon_state = "torchwall0"
+	},
+/turf/simulated/floor/stone,
+/area/cadiaoutpost/oa/wilds/dungeonlower)
 "mB" = (
 /obj/structure/closet/hive/iron_c{
 	anchored = 1
@@ -1126,6 +1133,8 @@
 /obj/effect/floor_decal/newcorner/blue{
 	dir = 4
 	},
+/obj/item/storage/firstaid/o2,
+/obj/item/storage/firstaid/toxin,
 /turf/simulated/floor/tiled{
 	color = "grey"
 	},
@@ -1188,9 +1197,14 @@
 /turf/simulated/floor/ceramic,
 /area/cadiaoutpost/oa/wilds/dungeonlower)
 "Cq" = (
-/mob/living/simple_animal/hostile/syndicate/ranged,
-/mob/living/simple_animal/hostile/syndicate/ranged,
-/turf/simulated/wall/ancient,
+/obj/structure/torchwall/service{
+	dir = 4;
+	icon_state = "torchwall0"
+	},
+/turf/simulated/floor/tiled{
+	color = "grey";
+	icon_state = "dark1"
+	},
 /area/cadiaoutpost/oa/wilds/dungeonlower)
 "Cu" = (
 /obj/machinery/door/unpowered/simple/iron{
@@ -1231,6 +1245,13 @@
 /obj/random/loot/randomlasammo,
 /obj/random/loot/randomlasammo,
 /obj/effect/floor_decal/newcorner/yellow/quarter,
+/turf/simulated/floor/tiled{
+	color = "grey"
+	},
+/area/cadiaoutpost/oa/wilds/dungeonlower)
+"CW" = (
+/obj/structure/table/rack/dark,
+/obj/item/grenade/frag/plasma,
 /turf/simulated/floor/tiled{
 	color = "grey"
 	},
@@ -1451,6 +1472,12 @@
 	dir = 4
 	},
 /turf/simulated/floor/ceramic,
+/area/cadiaoutpost/oa/wilds/dungeonlower)
+"IE" = (
+/obj/item/grenade/frag/high_yield/krak2,
+/turf/simulated/floor/tiled{
+	color = "grey"
+	},
 /area/cadiaoutpost/oa/wilds/dungeonlower)
 "IF" = (
 /obj/structure/table/graf/big_wood_table{
@@ -1768,6 +1795,7 @@
 /obj/effect/floor_decal/newcorner/yellow/quarter{
 	dir = 8
 	},
+/obj/item/grenade/frag/plasma,
 /turf/simulated/floor/tiled{
 	color = "grey"
 	},
@@ -1777,6 +1805,7 @@
 	anchored = 1
 	},
 /obj/random/loot/badweaponlas,
+/obj/item/grenade/frag/high_yield/krak2,
 /turf/simulated/floor/tiled{
 	color = "grey"
 	},
@@ -1820,6 +1849,7 @@
 /obj/effect/floor_decal/newcorner/yellow{
 	dir = 1
 	},
+/obj/item/plastique,
 /turf/simulated/floor/tiled{
 	color = "grey"
 	},
@@ -2019,6 +2049,10 @@
 "Ub" = (
 /obj/structure/stairs/south,
 /turf/simulated/floor/stone/seabed,
+/area/cadiaoutpost/oa/wilds/dungeonlower)
+"Uo" = (
+/obj/item/grenade/frag/high_yield/homemade,
+/turf/simulated/floor/stone,
 /area/cadiaoutpost/oa/wilds/dungeonlower)
 "Ur" = (
 /obj/effect/floor_decal/turf/armory{
@@ -26330,7 +26364,7 @@ bQ
 xv
 vb
 bQ
-tl
+CW
 bQ
 me
 Jh
@@ -27100,7 +27134,7 @@ OA
 wl
 OA
 IC
-Cq
+xv
 iA
 bu
 vX
@@ -31118,7 +31152,7 @@ LM
 xv
 HL
 tf
-tf
+Uo
 WY
 vk
 tf
@@ -31371,7 +31405,7 @@ xv
 HL
 pC
 vk
-tf
+Uo
 xv
 HL
 HL
@@ -32159,7 +32193,7 @@ xv
 xv
 xv
 bQ
-iT
+bQ
 xv
 xv
 tf
@@ -32412,7 +32446,7 @@ xv
 GF
 bQ
 bQ
-Jh
+Cq
 xv
 vo
 tf
@@ -32925,7 +32959,7 @@ tf
 tf
 tf
 tf
-pC
+xv
 pC
 pC
 pC
@@ -33177,7 +33211,7 @@ tf
 tf
 tf
 tf
-tf
+ml
 pC
 pC
 pC
@@ -33420,7 +33454,7 @@ xv
 GF
 bQ
 Jh
-bQ
+FU
 xv
 GF
 tf
@@ -33671,7 +33705,7 @@ xv
 xv
 xv
 bQ
-FU
+bQ
 xv
 xv
 op
@@ -34178,7 +34212,7 @@ HL
 HL
 HL
 HL
-tf
+cv
 Tm
 pC
 pC
@@ -34430,7 +34464,7 @@ HL
 HL
 pC
 pC
-pC
+xv
 pC
 pC
 pC
@@ -35171,7 +35205,7 @@ HL
 HL
 xv
 Cy
-bQ
+IE
 Wb
 Jh
 bQ
@@ -35447,7 +35481,7 @@ pC
 pC
 pC
 pC
-tf
+cv
 tf
 tf
 tf
@@ -35699,7 +35733,7 @@ pC
 pC
 pC
 pC
-pC
+xv
 tf
 tf
 tf
@@ -35949,8 +35983,8 @@ pC
 pC
 pC
 pC
-Tm
-tf
+pC
+pC
 pC
 pC
 tf
@@ -36165,7 +36199,7 @@ tf
 tf
 tf
 tf
-tf
+cv
 tf
 tf
 tf
@@ -36417,7 +36451,7 @@ pC
 pC
 pC
 pC
-pC
+xv
 pC
 tf
 tf
@@ -36909,7 +36943,7 @@ pC
 pC
 pC
 tf
-tf
+cv
 tf
 tf
 tf
@@ -37161,7 +37195,7 @@ pC
 pC
 pC
 pC
-pC
+xv
 tf
 tf
 tf
@@ -37690,7 +37724,7 @@ pC
 pC
 pC
 pC
-tf
+cv
 tf
 tf
 tf
@@ -37925,7 +37959,7 @@ pC
 pC
 tf
 tf
-tf
+cv
 fh
 fh
 Ow
@@ -37942,7 +37976,7 @@ pC
 pC
 pC
 pC
-pC
+xv
 pC
 pC
 tf
@@ -38463,7 +38497,7 @@ tf
 tf
 tf
 tf
-tf
+cv
 pC
 pC
 pC
@@ -38715,7 +38749,7 @@ pC
 pC
 pC
 pC
-pC
+xv
 pC
 pC
 pC

--- a/maps/delta/warhammer-2.dmm
+++ b/maps/delta/warhammer-2.dmm
@@ -753,9 +753,11 @@
 /turf/simulated/floor/stone,
 /area/cadiaoutpost/oa/caves/undercity)
 "cm" = (
-/turf/simulated/floor/plating{
-	icon_state = "evil"
+/obj/machinery/light/small/red{
+	dir = 1;
+	icon_state = "bulb1"
 	},
+/turf/simulated/floor/stone/seabed,
 /area/cadiaoutpost/oa/wilds/dungeonlower)
 "cn" = (
 /obj/effect/floor_decal/newcorner/mine_walls{
@@ -4151,12 +4153,6 @@
 	icon = 'icons/map_project/ship/tilesnovos.dmi'
 	},
 /area/cadiaoutpost/oa/engineering/engine/enginewaste)
-"mv" = (
-/mob/living/simple_animal/hostile/flesh/advanced,
-/turf/simulated/floor/plating{
-	icon_state = "evil"
-	},
-/area/cadiaoutpost/oa/wilds/dungeonlower)
 "mw" = (
 /obj/structure/table/graf/pagan,
 /obj/item/melee/sword/slaanesh,
@@ -7994,14 +7990,12 @@
 	},
 /area/cadiaoutpost/oa/caves/undercity)
 "yJ" = (
-/obj/machinery/door/unpowered/inn{
-	color = "grey";
-	name = "ancient door"
+/obj/machinery/light/small/red{
+	dir = 8;
+	icon_state = "bulb1"
 	},
-/turf/simulated/floor/tiled/dark{
-	color = "grey"
-	},
-/area/cadiaoutpost/new_hive/caves)
+/turf/simulated/open,
+/area/cadiaoutpost/oa/wilds/dungeonlower)
 "yK" = (
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/ship_floor/steel{
@@ -12498,12 +12492,6 @@
 	icon = 'icons/map_project/ship/tilesnovos.dmi'
 	},
 /area/cadiaoutpost/oa/engineering/engine/enginewaste)
-"LI" = (
-/obj/item/remains/human,
-/turf/simulated/floor/plating{
-	icon_state = "evil"
-	},
-/area/cadiaoutpost/oa/wilds/dungeonlower)
 "LJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 6
@@ -13036,12 +13024,6 @@
 	icon_state = "rwall1"
 	},
 /area/cadiaoutpost/oa/engineering/engine/enginewaste)
-"NE" = (
-/obj/effect/gibspawner/human,
-/turf/simulated/floor/plating{
-	icon_state = "evil"
-	},
-/area/cadiaoutpost/oa/wilds/dungeonlower)
 "NG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -13736,15 +13718,6 @@
 /obj/structure/catwalkrust/blocked,
 /turf/simulated/floor/stone,
 /area/cadiaoutpost/oa/wilds/dungeonlower)
-"PQ" = (
-/obj/structure/torchwall{
-	dir = 8;
-	icon_state = "torchwall0"
-	},
-/turf/simulated/floor/tiled/dark{
-	color = "grey"
-	},
-/area/cadiaoutpost/new_hive/caves)
 "PR" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -14353,11 +14326,6 @@
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/seolite,
 /area/cadiaoutpost/oa/wilds/dungeonlower)
-"RM" = (
-/turf/simulated/wall/concrete{
-	integrity = 1500
-	},
-/area/cadiaoutpost/new_hive/caves)
 "RN" = (
 /obj/effect/floor_decal/newcorner/plating,
 /turf/simulated/floor/fancyfloor/oldcobble,
@@ -49141,10 +49109,10 @@ gQ
 gQ
 gQ
 gQ
-QV
-QV
-QV
-QV
+gQ
+gQ
+gQ
+gQ
 gQ
 gQ
 gQ
@@ -49392,11 +49360,11 @@ gQ
 gQ
 gQ
 gQ
-QV
-tB
-WZ
-jW
-pR
+gQ
+gQ
+gQ
+gQ
+gQ
 gQ
 gQ
 gQ
@@ -49644,11 +49612,11 @@ gQ
 gQ
 gQ
 gQ
-QV
-vR
-Sm
-zM
-Nq
+gQ
+gQ
+gQ
+gQ
+gQ
 gQ
 gQ
 gQ
@@ -49896,11 +49864,11 @@ gQ
 gQ
 gQ
 gQ
-QV
-nR
-oQ
-nR
-QV
+gQ
+gQ
+gQ
+gQ
+gQ
 gQ
 gQ
 gQ
@@ -50148,11 +50116,11 @@ gQ
 gQ
 gQ
 gQ
-QV
-pV
-Dc
-pV
-TS
+gQ
+gQ
+gQ
+gQ
+gQ
 gQ
 gQ
 gQ
@@ -50400,11 +50368,11 @@ gQ
 gQ
 gQ
 gQ
-QV
-QV
-QV
-QV
-QV
+gQ
+gQ
+gQ
+gQ
+gQ
 gQ
 gQ
 gQ
@@ -51900,7 +51868,7 @@ gQ
 gQ
 gQ
 ep
-uA
+yJ
 uA
 Xt
 Xt
@@ -52915,7 +52883,7 @@ ep
 ep
 ep
 ep
-Xt
+cm
 Xt
 Xt
 Xt
@@ -53685,10 +53653,10 @@ gQ
 gQ
 gQ
 gQ
-QV
-QV
-QV
-QV
+gQ
+gQ
+gQ
+gQ
 gQ
 gQ
 gQ
@@ -53936,11 +53904,6 @@ gQ
 gQ
 gQ
 gQ
-QV
-tB
-WZ
-jW
-pR
 gQ
 gQ
 gQ
@@ -53955,11 +53918,16 @@ gQ
 gQ
 gQ
 gQ
-QV
-QV
-QV
-QV
-QV
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
 gQ
 gQ
 gQ
@@ -54188,11 +54156,6 @@ gQ
 gQ
 gQ
 gQ
-QV
-vR
-Sm
-zM
-Nq
 gQ
 gQ
 gQ
@@ -54207,11 +54170,16 @@ gQ
 gQ
 gQ
 gQ
-QV
-tB
-WZ
-jW
-pR
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
 gQ
 gQ
 gQ
@@ -54440,11 +54408,6 @@ gQ
 gQ
 gQ
 gQ
-QV
-nR
-oQ
-nR
-QV
 gQ
 gQ
 gQ
@@ -54459,11 +54422,16 @@ gQ
 gQ
 gQ
 gQ
-QV
-vR
-Sm
-zM
-Nq
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
 gQ
 gQ
 gQ
@@ -54692,11 +54660,6 @@ gQ
 gQ
 gQ
 gQ
-QV
-pV
-Dc
-pV
-TS
 gQ
 gQ
 gQ
@@ -54711,11 +54674,16 @@ gQ
 gQ
 gQ
 gQ
-QV
-nR
-oQ
-nR
-QV
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
 gQ
 gQ
 gQ
@@ -54944,11 +54912,6 @@ gQ
 gQ
 gQ
 gQ
-QV
-QV
-QV
-QV
-QV
 gQ
 gQ
 gQ
@@ -54963,11 +54926,16 @@ gQ
 gQ
 gQ
 gQ
-QV
-pV
-Dc
-pV
-TS
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
 gQ
 gQ
 gQ
@@ -55215,11 +55183,11 @@ gQ
 gQ
 gQ
 gQ
-QV
-QV
-QV
-QV
-QV
+gQ
+gQ
+gQ
+gQ
+gQ
 gQ
 gQ
 gQ
@@ -55708,13 +55676,13 @@ gQ
 gQ
 gQ
 gQ
-cm
-cm
-cm
-cm
-cm
-cm
-cm
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
 gQ
 gQ
 gQ
@@ -55960,13 +55928,6 @@ gQ
 gQ
 gQ
 gQ
-LI
-cm
-cm
-cm
-cm
-cm
-LI
 gQ
 gQ
 gQ
@@ -55979,11 +55940,18 @@ gQ
 gQ
 gQ
 gQ
-QV
-QV
-QV
-QV
-QV
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
 gQ
 gQ
 QV
@@ -56212,13 +56180,6 @@ gQ
 gQ
 gQ
 gQ
-cm
-cm
-cm
-cm
-LI
-cm
-cm
 gQ
 gQ
 gQ
@@ -56231,11 +56192,18 @@ gQ
 gQ
 gQ
 gQ
-QV
-tB
-WZ
-jW
-pR
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
 gQ
 gQ
 QV
@@ -56464,13 +56432,6 @@ gQ
 gQ
 gQ
 gQ
-LI
-cm
-LI
-mv
-cm
-cm
-cm
 gQ
 gQ
 gQ
@@ -56483,11 +56444,18 @@ gQ
 gQ
 gQ
 gQ
-QV
-vR
-Sm
-zM
-Nq
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
 gQ
 gQ
 QV
@@ -56716,13 +56684,6 @@ gQ
 gQ
 gQ
 gQ
-cm
-cm
-cm
-cm
-cm
-cm
-cm
 gQ
 gQ
 gQ
@@ -56735,11 +56696,18 @@ gQ
 gQ
 gQ
 gQ
-QV
-nR
-oQ
-nR
-QV
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
 gQ
 gQ
 QV
@@ -56968,13 +56936,6 @@ gQ
 gQ
 gQ
 gQ
-LI
-cm
-LI
-cm
-cm
-LI
-cm
 gQ
 gQ
 gQ
@@ -56987,11 +56948,18 @@ gQ
 gQ
 gQ
 gQ
-QV
-pV
-Dc
-pV
-TS
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
 gQ
 gQ
 QV
@@ -57220,13 +57188,6 @@ gQ
 gQ
 gQ
 gQ
-LI
-cm
-cm
-LI
-cm
-cm
-NE
 gQ
 gQ
 gQ
@@ -57239,11 +57200,18 @@ gQ
 gQ
 gQ
 gQ
-QV
-QV
-QV
-QV
-QV
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
 gQ
 gQ
 QV
@@ -57987,11 +57955,11 @@ gQ
 gQ
 gQ
 gQ
-QV
-QV
-QV
-QV
-QV
+gQ
+gQ
+gQ
+gQ
+gQ
 gQ
 gQ
 gQ
@@ -58239,11 +58207,11 @@ gQ
 gQ
 gQ
 gQ
-QV
-tB
-WZ
-jW
-pR
+gQ
+gQ
+gQ
+gQ
+gQ
 gQ
 gQ
 gQ
@@ -58491,11 +58459,11 @@ gQ
 gQ
 gQ
 gQ
-QV
-vR
-Sm
-zM
-Nq
+gQ
+gQ
+gQ
+gQ
+gQ
 gQ
 gQ
 gQ
@@ -58743,11 +58711,11 @@ gQ
 gQ
 gQ
 gQ
-QV
-nR
-oQ
-nR
-QV
+gQ
+gQ
+gQ
+gQ
+gQ
 gQ
 gQ
 gQ
@@ -58995,11 +58963,11 @@ hI
 hI
 hI
 hI
-RM
-Wq
-PQ
-Wq
-yJ
+hI
+hI
+hI
+hI
+hI
 hI
 hI
 gQ
@@ -59247,11 +59215,11 @@ hI
 hI
 hI
 hI
-RM
-RM
-RM
-RM
-RM
+hI
+hI
+hI
+hI
+hI
 hI
 hI
 gQ

--- a/maps/delta/warhammer-4.dmm
+++ b/maps/delta/warhammer-4.dmm
@@ -20376,6 +20376,10 @@
 	dir = 1
 	},
 /area/cadiaoutpost/oa/security/barracks)
+"pKd" = (
+/obj/effect/landmark/start/imperialguard/specialist,
+/turf/simulated/floor/tiled/dark,
+/area/cadiaoutpost/oa/security/armory)
 "pKr" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/light/small/red{
@@ -29518,6 +29522,10 @@
 	},
 /turf/simulated/floor/fancyfloor/coralg,
 /area/cadiaoutpost/oa/security/barracks)
+"wrt" = (
+/obj/effect/landmark/start/imperialguard/guard,
+/turf/simulated/floor/tiled/dark,
+/area/cadiaoutpost/oa/security/armory)
 "wrw" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 4
@@ -59397,7 +59405,7 @@ iFj
 bQR
 aYo
 btQ
-vqP
+btQ
 btQ
 btQ
 sCi
@@ -71421,7 +71429,7 @@ gsa
 kpF
 hxJ
 cTr
-hxJ
+wrt
 hxJ
 mYs
 gsa
@@ -71925,7 +71933,7 @@ gsa
 kpF
 hxJ
 ptc
-hxJ
+pKd
 hxJ
 pjV
 pjV

--- a/maps/delta/warhammer-5.dmm
+++ b/maps/delta/warhammer-5.dmm
@@ -908,6 +908,20 @@
 /obj/item/clothing/head/hairflower/blue,
 /turf/simulated/floor/darkwood,
 /area/cadiaoutpost/oa/supply/offices/roguetrader)
+"df" = (
+/obj/item/paper_bin{
+	pixel_y = 8
+	},
+/obj/item/pen/multi{
+	pixel_y = 4
+	},
+/obj/structure/table/graf/reinf_table{
+	icon_state = "reinf_table3";
+	dir = 8
+	},
+/obj/item/book/manual/law,
+/turf/simulated/floor/darkwood,
+/area/cadiaoutpost/oa/security/brig)
 "di" = (
 /obj/effect/floor_decal/newcorner/reinforced{
 	dir = 1
@@ -1490,6 +1504,22 @@
 /obj/effect/floor_decal/newcorner/polar/quarter,
 /turf/simulated/floor/wood,
 /area/cadiaoutpost/oa/service/inn)
+"fA" = (
+/obj/item/newspaper{
+	pixel_y = 10;
+	pixel_x = 7
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	icon_state = "bulb1";
+	light_color = "#234F1E"
+	},
+/obj/structure/table/graf/reinf_table{
+	icon_state = "reinf_table3";
+	dir = 4
+	},
+/turf/simulated/floor/darkwood,
+/area/cadiaoutpost/oa/security/brig)
 "fB" = (
 /obj/effect/floor_decal/newcorner/reinforced/corner{
 	dir = 8
@@ -1931,6 +1961,30 @@
 	},
 /turf/simulated/floor/ceramic/surgery2,
 /area/cadiaoutpost/oa/service/hab/inside)
+"hd" = (
+/obj/item/clothing/head/servicesgt{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/storage/fancy/cigarettes/cigarello/mint{
+	pixel_y = 8;
+	pixel_x = 8
+	},
+/obj/item/flame/lighter/zippo,
+/obj/item/reagent_containers/food/drinks/bottle/small/beer{
+	pixel_y = -8;
+	pixel_x = -10
+	},
+/obj/item/reagent_containers/food/drinks/bottle/small/beer{
+	pixel_y = -6;
+	pixel_x = -4
+	},
+/obj/structure/table/graf/reinf_table{
+	icon_state = "reinf_table3";
+	dir = 1
+	},
+/turf/simulated/floor/darkwood,
+/area/cadiaoutpost/oa/security/brig)
 "he" = (
 /obj/structure/railing{
 	dir = 8;
@@ -2236,6 +2290,8 @@
 "il" = (
 /obj/structure/table/rack,
 /obj/random/loot/goodweapon,
+/obj/item/cell/plasma,
+/obj/item/cell/melta,
 /turf/simulated/floor/tiled{
 	color = "grey"
 	},
@@ -2487,6 +2543,17 @@
 	color = "purple"
 	},
 /area/cadiaoutpost/oa/service/inn)
+"iT" = (
+/obj/structure/table/rack/dark,
+/obj/item/clothing/accessory/storage/webbing_large{
+	pixel_y = -5
+	},
+/obj/item/clothing/accessory/holster/armpit{
+	pixel_y = -2
+	},
+/obj/item/cell/lasgun/hotshot,
+/turf/simulated/floor/darkwood,
+/area/cadiaoutpost/oa/security/brig)
 "iX" = (
 /obj/structure/lattice,
 /obj/effect/floor_decal/turf/piping{
@@ -3458,6 +3525,15 @@
 	},
 /turf/simulated/floor/fancyfloor/coralg,
 /area/cadiaoutpost/oa/hallway/northern)
+"mA" = (
+/obj/structure/curtain/open/shower/security{
+	name = "privacy curtain";
+	pixel_x = -32
+	},
+/mob/living/simple_animal/corgi/cpl_buddy,
+/obj/structure/dogbed,
+/turf/simulated/floor/darkwood,
+/area/cadiaoutpost/oa/security/brig)
 "mB" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/ceramic/old,
@@ -3622,6 +3698,20 @@
 	dir = 4
 	},
 /area/cadiaoutpost/oa/service/inn)
+"nq" = (
+/obj/structure/table/rack,
+/obj/item/gun/energy/las/lasgun{
+	pixel_y = 8
+	},
+/obj/item/gun/energy/las/lasgun,
+/obj/effect/floor_decal/industrial/mark,
+/obj/item/gun/energy/las/lasgun{
+	pixel_y = -6
+	},
+/turf/simulated/floor/tiled{
+	color = "grey"
+	},
+/area/cadiaoutpost/oa/security/brig)
 "nr" = (
 /obj/machinery/door/airlock/multi_tile/glass,
 /turf/simulated/floor/tiled/dark{
@@ -3693,6 +3783,14 @@
 	},
 /area/cadiaoutpost/oa/service/chapel)
 "nD" = (
+/obj/item/clothing/accessory/medal/iron/Administratum{
+	pixel_y = 15;
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/food/drinks/bottle/amasecexpensive{
+	pixel_y = 11;
+	pixel_x = -8
+	},
 /obj/item/reagent_containers/food/drinks/glass2/shot{
 	pixel_y = -5;
 	pixel_x = 9
@@ -3705,10 +3803,7 @@
 	icon_state = "wood_1tilethick";
 	dir = 4
 	},
-/obj/item/reagent_containers/food/drinks/bottle/premiumwine{
-	pixel_y = 9;
-	pixel_x = 3
-	},
+/obj/item/reagent_containers/glass/bottle/spice,
 /turf/simulated/floor/darkwood,
 /area/cadiaoutpost/oa/security/brig)
 "nE" = (
@@ -4014,6 +4109,14 @@
 /obj/structure/hivedecor/vehicle/tau,
 /turf/simulated/floor/fancyfloor/coralg,
 /area/cadiaoutpost/oa/supply/offices/roguetrader)
+"oN" = (
+/obj/structure/bed/padded,
+/obj/item/bedsheet/green{
+	color = "grey"
+	},
+/obj/effect/landmark/start/imperialguard,
+/turf/simulated/floor/darkwood,
+/area/cadiaoutpost/oa/security/brig)
 "oP" = (
 /obj/item/fluff_items/bfg,
 /obj/structure/table/graf/wood_office_table{
@@ -4038,8 +4141,11 @@
 /area/cadiaoutpost/oa/hallway/northern)
 "oS" = (
 /obj/structure/table/rack,
+/obj/item/gun/energy/las/lasgun/lucius{
+	pixel_y = 6
+	},
 /obj/effect/floor_decal/industrial/mark,
-/obj/item/gun/energy/las/lasgun/lucius,
+/obj/item/gun/energy/las/lasgun,
 /turf/simulated/floor/tiled{
 	color = "grey"
 	},
@@ -4163,11 +4269,16 @@
 	},
 /area/cadiaoutpost/oa/security/brig)
 "pq" = (
+/obj/item/clothing/mask/gas/commissar{
+	pixel_y = -1
+	},
+/obj/item/clothing/head/commissar/adept{
+	pixel_y = 14
+	},
 /obj/structure/table/graf/wood_office_table{
 	icon_state = "wood_1tileendtable";
 	dir = 4
 	},
-/obj/item/device/boombox,
 /turf/simulated/floor/darkwood,
 /area/cadiaoutpost/oa/security/brig)
 "pr" = (
@@ -4779,14 +4890,10 @@
 /area/cadiaoutpost/oa/security/brig)
 "rG" = (
 /obj/structure/table/rack,
-/obj/item/gun/energy/las/lasgun{
-	pixel_y = 8
-	},
-/obj/item/gun/energy/las/lasgun,
-/obj/item/gun/energy/las/lasgun{
-	pixel_y = -6
-	},
 /obj/effect/floor_decal/industrial/mark,
+/obj/item/gun/projectile/automatic/m22/warmonger/m14/battlerifle,
+/obj/item/gun/projectile/automatic/m22/combatrifle,
+/obj/item/gun/projectile/automatic/autogrim/krieg,
 /turf/simulated/floor/tiled{
 	color = "grey"
 	},
@@ -5233,7 +5340,10 @@
 	dir = 1;
 	icon_state = "tube1"
 	},
-/obj/item/gun/energy/las/lasgun,
+/obj/item/gun/energy/las/lasgun/catachan{
+	pixel_y = 8
+	},
+/obj/item/gun/energy/las/lasgun/accatran,
 /turf/simulated/floor/tiled{
 	color = "grey"
 	},
@@ -5602,6 +5712,10 @@
 	},
 /turf/simulated/wall/concrete/strong,
 /area/cadiaoutpost/oa/security/armory)
+"vf" = (
+/obj/machinery/light,
+/turf/simulated/floor/darkwood,
+/area/cadiaoutpost/oa/security/brig)
 "vh" = (
 /obj/structure/bed/barrack,
 /obj/structure/bed/barrack1,
@@ -9003,6 +9117,7 @@
 	dir = 1;
 	icon_state = "spline_plain"
 	},
+/obj/effect/landmark/start/imperialguard/commissar,
 /turf/simulated/floor/fancyfloor/coralg,
 /area/cadiaoutpost/oa/security/brig)
 "Hk" = (
@@ -9272,6 +9387,14 @@
 	dir = 8
 	},
 /area/cadiaoutpost/oa/village/pathfinder)
+"Ib" = (
+/obj/machinery/door/airlock/cone{
+	maxhealth = 3000;
+	name = "Guard Sergeant Quarters";
+	req_one_access = list(67,331)
+	},
+/turf/simulated/floor/factory_floor,
+/area/cadiaoutpost/oa/security/brig)
 "Ie" = (
 /obj/structure/bed/royal/bottom,
 /obj/structure/curtain/open/bed,
@@ -10373,6 +10496,9 @@
 	pixel_x = -6
 	},
 /obj/effect/floor_decal/industrial/mark,
+/obj/item/cell/lasgun/hotshot{
+	pixel_x = 6
+	},
 /turf/simulated/floor/tiled/dark{
 	icon_state = "steel"
 	},
@@ -11402,6 +11528,10 @@
 /turf/simulated/floor/wood,
 /area/cadiaoutpost/oa/service/inn)
 "PU" = (
+/obj/item/card/id/commissar/spare{
+	pixel_x = -8;
+	pixel_y = -5
+	},
 /obj/structure/table/graf/wood_office_table{
 	icon_state = "wood_1tilethick";
 	dir = 4
@@ -11409,6 +11539,7 @@
 /obj/item/device/cassette/starcraft_1,
 /obj/item/device/cassette/grimdark,
 /obj/item/device/cassette/church1,
+/obj/item/device/boombox,
 /turf/simulated/floor/darkwood,
 /area/cadiaoutpost/oa/security/brig)
 "PV" = (
@@ -11584,12 +11715,14 @@
 /turf/simulated/floor/darkwood,
 /area/cadiaoutpost/oa/service/inn)
 "QC" = (
-/obj/item/device/radio/headset/red_team/all,
-/obj/item/device/radio/headset/red_team/all,
-/obj/item/device/radio/headset/red_team/all,
-/obj/structure/closet/secure_closet/personal{
-	color = "grey"
+/obj/structure/closet/secure_closet/hos{
+	color = "grey";
+	req_one_access = list(67)
 	},
+/obj/item/device/megaphone,
+/obj/item/device/radio/headset/red_team/all,
+/obj/item/device/radio/headset/red_team/all,
+/obj/item/device/radio/headset/red_team/all,
 /turf/simulated/floor/darkwood,
 /area/cadiaoutpost/oa/security/brig)
 "QD" = (
@@ -11750,6 +11883,7 @@
 /obj/structure/table/rack/shelf{
 	color = "grey"
 	},
+/obj/item/melee/sword/commissword,
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "tube1"
@@ -12550,6 +12684,12 @@
 	icon_state = "wood_1tileendtable";
 	dir = 8
 	},
+/obj/item/reagent_containers/food/snacks/enchiladas{
+	name = "Fried Traitor"
+	},
+/obj/item/reagent_containers/food/snacks/dionaroast{
+	name = "roasted gretchin"
+	},
 /obj/item/reagent_containers/food/snacks/meatpie{
 	name = "deserter pie"
 	},
@@ -12956,6 +13096,11 @@
 "UP" = (
 /turf/simulated/wall/concrete,
 /area/cadiaoutpost/oa/service/hab/inside)
+"UQ" = (
+/obj/random/loot/goodweapon,
+/obj/structure/table/rack/dark,
+/turf/simulated/floor/darkwood,
+/area/cadiaoutpost/oa/security/brig)
 "UR" = (
 /obj/machinery/door/unpowered/inn{
 	req_one_access = list(331)
@@ -13349,6 +13494,13 @@
 /obj/effect/landmark/costume/butler,
 /turf/simulated/floor/darkwood,
 /area/cadiaoutpost/oa/supply/offices/roguetrader)
+"Wj" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/darkwood,
+/area/cadiaoutpost/oa/security/brig)
 "Wk" = (
 /turf/simulated/open,
 /area/cadiaoutpost/oa/shuttle/station2)
@@ -13828,6 +13980,10 @@
 	dir = 4
 	},
 /area/cadiaoutpost/oa/hallway/northern)
+"XV" = (
+/obj/structure/closet/secure_closet/warden,
+/turf/simulated/floor/darkwood,
+/area/cadiaoutpost/oa/security/brig)
 "XW" = (
 /obj/effect/decal/cleanable/flour{
 	name = "snow";
@@ -54140,7 +54296,7 @@ IH
 IH
 IH
 IH
-YE
+Hl
 ml
 HE
 QX
@@ -54392,7 +54548,7 @@ wO
 lC
 IH
 IH
-ya
+Ex
 IH
 IH
 IH
@@ -55877,7 +56033,7 @@ Pq
 Yh
 UO
 Ms
-rG
+nq
 rG
 GC
 ma
@@ -57633,8 +57789,8 @@ fi
 cJ
 fi
 UO
-UO
-UO
+Lw
+Lw
 UO
 UO
 gP
@@ -57885,8 +58041,8 @@ UO
 UO
 UO
 UO
-UO
-UO
+Ib
+FZ
 UO
 Vc
 Bf
@@ -58134,11 +58290,11 @@ UO
 UO
 UO
 UO
-UO
-UO
-UO
-UO
-UO
+hd
+fA
+df
+fu
+mA
 UO
 MP
 Bf
@@ -58386,11 +58542,11 @@ UO
 UO
 UO
 UO
-UO
-UO
-UO
-UO
-UO
+iT
+gv
+fu
+fu
+vf
 UO
 dj
 Bf
@@ -58638,11 +58794,11 @@ gS
 gS
 gS
 UO
-UO
-UO
-UO
-UO
-UO
+UQ
+oN
+Wj
+fu
+XV
 UO
 AG
 ip

--- a/maps/delta/warhammer-7.dmm
+++ b/maps/delta/warhammer-7.dmm
@@ -307,11 +307,6 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/wood,
 /area/centcom)
-"be" = (
-/obj/random/loot/goodweapon,
-/obj/structure/table/rack/dark,
-/turf/simulated/floor/darkwood,
-/area/cadiaoutpost/gma/inquisitoracolyte)
 "bf" = (
 /obj/structure/railing{
 	dir = 1
@@ -586,30 +581,6 @@
 /obj/item/modular_computer/console/preset/command,
 /turf/simulated/floor/carpet/red,
 /area/centcom)
-"cg" = (
-/obj/item/clothing/head/servicesgt{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/storage/fancy/cigarettes/cigarello/mint{
-	pixel_y = 8;
-	pixel_x = 8
-	},
-/obj/item/flame/lighter/zippo,
-/obj/item/reagent_containers/food/drinks/bottle/small/beer{
-	pixel_y = -8;
-	pixel_x = -10
-	},
-/obj/item/reagent_containers/food/drinks/bottle/small/beer{
-	pixel_y = -6;
-	pixel_x = -4
-	},
-/obj/structure/table/graf/reinf_table{
-	icon_state = "reinf_table3";
-	dir = 1
-	},
-/turf/simulated/floor/darkwood,
-/area/cadiaoutpost/gma/inquisitoracolyte)
 "cj" = (
 /obj/machinery/recharger{
 	pixel_y = 32
@@ -1023,13 +994,6 @@
 	dir = 8
 	},
 /area/space)
-"eC" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/darkwood,
-/area/cadiaoutpost/gma/inquisitoracolyte)
 "eF" = (
 /obj/machinery/light/spot{
 	dir = 8;
@@ -2560,10 +2524,6 @@
 /obj/machinery/telecomms/allinone,
 /turf/unsimulated/miningtime,
 /area/space)
-"le" = (
-/obj/machinery/light,
-/turf/simulated/floor/darkwood,
-/area/cadiaoutpost/gma/inquisitoracolyte)
 "lf" = (
 /obj/structure/table/rack/dark,
 /obj/item/clothing/glasses/hud/health,
@@ -4105,14 +4065,6 @@
 /obj/item/storage/backpack/holding,
 /turf/simulated/floor/shuttle/darkred,
 /area/cadiaoutpost/oa/tauship)
-"sM" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet/green{
-	color = "grey"
-	},
-/obj/effect/landmark/start/imperialguard,
-/turf/simulated/floor/darkwood,
-/area/cadiaoutpost/gma/inquisitoracolyte)
 "sO" = (
 /obj/structure/catwalkrust/water,
 /turf/simulated/floor/plating,
@@ -6014,22 +5966,6 @@
 	},
 /turf/simulated/floor/shuttle/darkred,
 /area/cadiaoutpost/oa/tauship)
-"CJ" = (
-/obj/item/newspaper{
-	pixel_y = 10;
-	pixel_x = 7
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	icon_state = "bulb1";
-	light_color = "#234F1E"
-	},
-/obj/structure/table/graf/reinf_table{
-	icon_state = "reinf_table3";
-	dir = 4
-	},
-/turf/simulated/floor/darkwood,
-/area/cadiaoutpost/gma/inquisitoracolyte)
 "CK" = (
 /obj/structure/table/woodentable,
 /obj/machinery/light,
@@ -6812,14 +6748,6 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/centcom)
-"Gt" = (
-/obj/machinery/door/airlock/cone{
-	maxhealth = 3000;
-	name = "Guard Sergeant Quarters";
-	req_one_access = list(67,331)
-	},
-/turf/simulated/floor/factory_floor,
-/area/cadiaoutpost/gma/inquisitoracolyte)
 "Gw" = (
 /obj/structure/shipdecor{
 	icon_state = "tncB"
@@ -7099,20 +7027,6 @@
 	color = "grey"
 	},
 /area/centcom)
-"HM" = (
-/obj/item/paper_bin{
-	pixel_y = 8
-	},
-/obj/item/pen/multi{
-	pixel_y = 4
-	},
-/obj/structure/table/graf/reinf_table{
-	icon_state = "reinf_table3";
-	dir = 8
-	},
-/obj/item/book/manual/law,
-/turf/simulated/floor/darkwood,
-/area/cadiaoutpost/gma/inquisitoracolyte)
 "HP" = (
 /obj/structure/table/rack,
 /obj/item/extinguisher/mini{
@@ -7139,10 +7053,6 @@
 	color = "grey"
 	},
 /area/centcom)
-"HR" = (
-/obj/structure/closet/secure_closet/warden,
-/turf/simulated/floor/darkwood,
-/area/cadiaoutpost/gma/inquisitoracolyte)
 "HU" = (
 /obj/structure/table/rack,
 /obj/item/device/personal_shield,
@@ -7325,17 +7235,6 @@
 "IM" = (
 /turf/space,
 /area/cadiaoutpost/rtship2)
-"IN" = (
-/obj/structure/table/rack/dark,
-/obj/item/clothing/accessory/storage/webbing_large{
-	pixel_y = -5
-	},
-/obj/item/clothing/accessory/holster/armpit{
-	pixel_y = -2
-	},
-/obj/item/cell/lasgun/hotshot,
-/turf/simulated/floor/darkwood,
-/area/cadiaoutpost/gma/inquisitoracolyte)
 "IP" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -8017,10 +7916,6 @@
 	icon_state = "wall3"
 	},
 /area/cadiaoutpost/oa/shuttle/inquisition)
-"Mv" = (
-/obj/effect/landmark/start/imperialguard/guard,
-/turf/simulated/floor/fancyfloor/coralg,
-/area/cadiaoutpost/gma/inquisitoracolyte)
 "Mz" = (
 /obj/structure/table/woodentable,
 /obj/machinery/chemical_dispenser/bar_coffee/full,
@@ -8354,15 +8249,6 @@
 /obj/effect/floor_decal/turf/metal/five,
 /turf/simulated/floor/tiled/dark,
 /area/cadiaoutpost/oa/shuttle/inquisition)
-"Oq" = (
-/obj/structure/curtain/open/shower/security{
-	name = "privacy curtain";
-	pixel_x = -32
-	},
-/mob/living/simple_animal/corgi/cpl_buddy,
-/obj/structure/dogbed,
-/turf/simulated/floor/darkwood,
-/area/cadiaoutpost/gma/inquisitoracolyte)
 "Or" = (
 /obj/machinery/door/blast/grates,
 /turf/simulated/floor/tiled/dark,
@@ -10583,10 +10469,6 @@
 /obj/effect/floor_decal/turf/metal/five,
 /turf/simulated/floor/tiled/dark,
 /area/cadiaoutpost/oa/shuttle/inquisition)
-"ZX" = (
-/obj/effect/landmark/start/imperialguard/specialist,
-/turf/simulated/floor/fancyfloor/coralg,
-/area/cadiaoutpost/gma/inquisitoracolyte)
 "ZY" = (
 /turf/simulated/floor/fancyfloor/coralg,
 /area/cadiaoutpost/oa/shuttle/station1)
@@ -26437,9 +26319,9 @@ Bq
 Bq
 KO
 bI
-Mv
 bI
-ZX
+bI
+bI
 bI
 bI
 bI
@@ -29201,8 +29083,8 @@ An
 bC
 An
 fD
-Gt
-rZ
+fD
+fD
 fD
 fD
 Sc
@@ -29453,8 +29335,8 @@ fD
 fD
 fD
 fD
-iI
-Oq
+fD
+fD
 fD
 ZV
 AY
@@ -29702,11 +29584,11 @@ fD
 fD
 fD
 fD
-cg
-CJ
-HM
-iI
-le
+fD
+fD
+fD
+fD
+fD
 fD
 dr
 AY
@@ -29954,11 +29836,11 @@ fD
 fD
 fD
 fD
-IN
-Ws
-iI
-iI
-iI
+fD
+fD
+fD
+fD
+fD
 fD
 nD
 AY
@@ -30206,11 +30088,11 @@ FQ
 FQ
 FQ
 fD
-be
-sM
-eC
-iI
-HR
+fD
+fD
+fD
+fD
+fD
 fD
 Qx
 ti


### PR DESCRIPTION
Minor Mapping QOL -- major changes is just the spawners for guard and armory edits.

Guard returned to game but reduced slots.

Plastique explosives renamed to canon name Det Packs. Will be also making a grenade version of the det pack in future. This one is called det pack - breacher

Mining Items have added Armor_Penetration, Pilgrim Miners now start with upgraded pickaxes that double as decent weapons.

Fixed up Pilgrim Equip code slightly so their outfits attached to their bodies instead of dropping on the floor.

Made Tavern Keeper human.

Guard Command structure is now basically - everyone answers to PDF Captain or Commissar, but Captain first.