### PR TITLE
Kroot biology lore additions

### DIFF
--- a/code/modules/mob/living/carbon/human/species/races/krootboys.dm
+++ b/code/modules/mob/living/carbon/human/species/races/krootboys.dm
@@ -25,11 +25,16 @@
 		/datum/unarmed_attack/punch,
 		/datum/unarmed_attack/bite
 		)
+
+	has_organ = list(
+		BP_EYES =     /obj/item/organ/internal/eyes/kroot
+	)
+
 /datum/species/kroot/handle_post_spawn(var/mob/living/carbon/human/H)
 	H.age = rand(min_age,max_age)//Random age for kiddos.
 	if(H.f_style)//kroot don't get beards.
 		H.f_style = "Shaved"
-	to_chat(H, "<big><span class='warning'>Your a mercenary hired by the Tau. Obey whatever instructions they have, if you cannot communicate with any Tau immediately, then prepare a frontal base..</span></big>")
+	to_chat(H, "<big><span class='warning'>You're a mercenary hired by the Tau. Obey whatever instructions they have, if you cannot communicate with any Tau immediately, then prepare a frontal base..</span></big>")
 	H.update_eyes()	//hacky fix, i don't care and i'll never ever care
 	return ..()
 /mob/living/carbon/human
@@ -72,6 +77,7 @@
 	visible_message("[name] stretches their muscles after a long flight, feeling their strength and skill return to them.")
 	src.add_stats(rand(14,16),rand(14,18),rand(12,15),10)
 	src.add_skills(10,10,rand(0,3),0,0) //skills such as melee, ranged, med, eng and surg
+	src.set_quirk(new/datum/quirk/no_bathroom())//Kroot dont shit or piss. Their sweat is their excrement
 	src.adjustStaminaLoss(-INFINITY)
 	src.update_eyes() //should fix grey vision
 	src.warfare_language_shit(TAU) //secondary language

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -229,4 +229,14 @@
 	max_damage = 65
 	var/vision_flags = SEE_TURFS|SEE_MOBS|SEE_OBJS|SEE_SELF
 
-
+/obj/item/organ/internal/eyes/kroot
+	name = "kroot eyeballs"
+	icon_state = "eyes"
+	gender = PLURAL
+	organ_tag = BP_EYES
+	parent_organ = BP_HEAD
+	surface_accessible = TRUE
+	relative_size = 10
+	max_damage = 55
+	sales_price = 25
+	vision_flags = SEE_TURFS|SEE_MOBS|SEE_SELF//Kroot infrared vision funky stuff. Don't get to see objects because it's not an organic that makes its own heat yada yada

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -239,4 +239,4 @@
 	relative_size = 10
 	max_damage = 55
 	sales_price = 25
-	vision_flags = SEE_TURFS|SEE_MOBS|SEE_SELF//Kroot infrared vision funky stuff. Don't get to see objects because it's not an organic that makes its own heat yada yada
+	var/vision_flags = SEE_TURFS|SEE_MOBS|SEE_SELF//Kroot infrared vision funky stuff. Don't get to see objects because it's not an organic that makes its own heat yada yada


### PR DESCRIPTION
- Gives Kroot species specific eyes which grant IR sight (essentially mesons. Cannot see objects)
Kroot in lore have eyes which can see into the IR spectrum and visualize the body heat of prey. This reflects that mechanically
- Gives Kroot the bladderless trait by default
Kroot in lore do not defecate/urinate. They instead sweat out their waste/excrement. This reflects that mechanically